### PR TITLE
fix: scheme operator netex not generating

### DIFF
--- a/fdbt-dev/data/matchingData/schemeOperatorGeoZone.json
+++ b/fdbt-dev/data/matchingData/schemeOperatorGeoZone.json
@@ -2,7 +2,7 @@
   "schemeOperatorName": "IW Buses",
   "schemeOperatorRegionCode": "Y",
   "additionalNocs": ["WBTR", "DCCL", "HCTY"],
-  "type": "multiOperator",
+  "type": "period",
   "email": "test@example.com",
   "uuid": "BLACc1363964",
   "timeRestriction": [

--- a/repos/fdbt-netex-output/.eslintrc.js
+++ b/repos/fdbt-netex-output/.eslintrc.js
@@ -22,7 +22,7 @@ module.exports = {
         sourceType: 'module',
         project: './tsconfig.json',
     },
-    plugins: ['@typescript-eslint'],
+    plugins: ['@typescript-eslint', 'jest'],
     rules: {
         'jest/no-disabled-tests': 'error',
         'jest/no-identical-title': 'error',

--- a/repos/fdbt-netex-output/.eslintrc.js
+++ b/repos/fdbt-netex-output/.eslintrc.js
@@ -24,6 +24,9 @@ module.exports = {
     },
     plugins: ['@typescript-eslint'],
     rules: {
+        'jest/no-disabled-tests': 'error',
+        'jest/no-identical-title': 'error',
+        'jest/valid-expect': 'error',
         'no-unused-vars': 'off',
         '@typescript-eslint/no-unused-vars': [
             'error',

--- a/repos/fdbt-netex-output/package-lock.json
+++ b/repos/fdbt-netex-output/package-lock.json
@@ -1756,11 +1756,39 @@
                 }
             }
         },
+        "@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "dependencies": {
+                "@nodelib/fs.stat": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+                    "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+                    "dev": true
+                }
+            }
+        },
         "@nodelib/fs.stat": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
             "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
             "dev": true
+        },
+        "@nodelib/fs.walk": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.7.tgz",
+            "integrity": "sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            }
         },
         "@sindresorhus/is": {
             "version": "0.14.0",
@@ -2091,6 +2119,22 @@
                 "eslint-visitor-keys": "^1.1.0"
             }
         },
+        "@typescript-eslint/scope-manager": {
+            "version": "4.26.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.26.1.tgz",
+            "integrity": "sha512-TW1X2p62FQ8Rlne+WEShyd7ac2LA6o27S9i131W4NwDSfyeVlQWhw8ylldNNS8JG6oJB9Ha9Xyc+IUcqipvheQ==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "4.26.1",
+                "@typescript-eslint/visitor-keys": "4.26.1"
+            }
+        },
+        "@typescript-eslint/types": {
+            "version": "4.26.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.26.1.tgz",
+            "integrity": "sha512-STyMPxR3cS+LaNvS8yK15rb8Y0iL0tFXq0uyl6gY45glyI7w0CsyqyEXl/Fa0JlQy+pVANeK3sbwPneCbWE7yg==",
+            "dev": true
+        },
         "@typescript-eslint/typescript-estree": {
             "version": "2.34.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
@@ -2129,6 +2173,24 @@
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
+                }
+            }
+        },
+        "@typescript-eslint/visitor-keys": {
+            "version": "4.26.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.26.1.tgz",
+            "integrity": "sha512-IGouNSSd+6x/fHtYRyLOM6/C+QxMDzWlDtN41ea+flWuSF9g02iqcIlX8wM53JkfljoIjP0U+yp7SiTS1onEkw==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "4.26.1",
+                "eslint-visitor-keys": "^2.0.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+                    "dev": true
                 }
             }
         },
@@ -4167,6 +4229,140 @@
                 }
             }
         },
+        "eslint-plugin-jest": {
+            "version": "24.3.6",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.3.6.tgz",
+            "integrity": "sha512-WOVH4TIaBLIeCX576rLcOgjNXqP+jNlCiEmRgFTfQtJ52DpwnIQKAVGlGPAN7CZ33bW6eNfHD6s8ZbEUTQubJg==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/experimental-utils": "^4.0.1"
+            },
+            "dependencies": {
+                "@nodelib/fs.stat": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+                    "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+                    "dev": true
+                },
+                "@typescript-eslint/experimental-utils": {
+                    "version": "4.26.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.26.1.tgz",
+                    "integrity": "sha512-sQHBugRhrXzRCs9PaGg6rowie4i8s/iD/DpTB+EXte8OMDfdCG5TvO73XlO9Wc/zi0uyN4qOmX9hIjQEyhnbmQ==",
+                    "dev": true,
+                    "requires": {
+                        "@types/json-schema": "^7.0.7",
+                        "@typescript-eslint/scope-manager": "4.26.1",
+                        "@typescript-eslint/types": "4.26.1",
+                        "@typescript-eslint/typescript-estree": "4.26.1",
+                        "eslint-scope": "^5.1.1",
+                        "eslint-utils": "^3.0.0"
+                    }
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "4.26.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.26.1.tgz",
+                    "integrity": "sha512-l3ZXob+h0NQzz80lBGaykdScYaiEbFqznEs99uwzm8fPHhDjwaBFfQkjUC/slw6Sm7npFL8qrGEAMxcfBsBJUg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "4.26.1",
+                        "@typescript-eslint/visitor-keys": "4.26.1",
+                        "debug": "^4.3.1",
+                        "globby": "^11.0.3",
+                        "is-glob": "^4.0.1",
+                        "semver": "^7.3.5",
+                        "tsutils": "^3.21.0"
+                    }
+                },
+                "debug": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "dir-glob": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+                    "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+                    "dev": true,
+                    "requires": {
+                        "path-type": "^4.0.0"
+                    }
+                },
+                "eslint-utils": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+                    "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+                    "dev": true,
+                    "requires": {
+                        "eslint-visitor-keys": "^2.0.0"
+                    }
+                },
+                "eslint-visitor-keys": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+                    "dev": true
+                },
+                "fast-glob": {
+                    "version": "3.2.5",
+                    "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+                    "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+                    "dev": true,
+                    "requires": {
+                        "@nodelib/fs.stat": "^2.0.2",
+                        "@nodelib/fs.walk": "^1.2.3",
+                        "glob-parent": "^5.1.0",
+                        "merge2": "^1.3.0",
+                        "micromatch": "^4.0.2",
+                        "picomatch": "^2.2.1"
+                    }
+                },
+                "globby": {
+                    "version": "11.0.3",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+                    "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+                    "dev": true,
+                    "requires": {
+                        "array-union": "^2.1.0",
+                        "dir-glob": "^3.0.1",
+                        "fast-glob": "^3.1.1",
+                        "ignore": "^5.1.4",
+                        "merge2": "^1.3.0",
+                        "slash": "^3.0.0"
+                    }
+                },
+                "ignore": {
+                    "version": "5.1.8",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+                    "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "path-type": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+                    "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "7.3.5",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                }
+            }
+        },
         "eslint-plugin-prettier": {
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz",
@@ -4725,6 +4921,15 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
+        },
+        "fastq": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
+            "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
+            "dev": true,
+            "requires": {
+                "reusify": "^1.0.4"
+            }
         },
         "fb-watchman": {
             "version": "2.0.1",
@@ -11002,6 +11207,12 @@
             "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
             "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
         },
+        "queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "dev": true
+        },
         "rc": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -11272,6 +11483,12 @@
             "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
             "dev": true
         },
+        "reusify": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "dev": true
+        },
         "rimraf": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -11291,6 +11508,15 @@
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
             "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
             "dev": true
+        },
+        "run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "dev": true,
+            "requires": {
+                "queue-microtask": "^1.2.2"
+            }
         },
         "rxjs": {
             "version": "6.6.7",

--- a/repos/fdbt-netex-output/package.json
+++ b/repos/fdbt-netex-output/package.json
@@ -53,6 +53,7 @@
         "eslint-config-airbnb-base": "^14.1.0",
         "eslint-config-prettier": "^6.11.0",
         "eslint-plugin-import": "^2.20.0",
+        "eslint-plugin-jest": "^24.3.6",
         "eslint-plugin-prettier": "^3.1.2",
         "husky": "^4.2.1",
         "jest": "^26.6.3",

--- a/repos/fdbt-netex-output/src/types/index.ts
+++ b/repos/fdbt-netex-output/src/types/index.ts
@@ -278,7 +278,7 @@ export const isMultiServiceTicket = (ticket: Ticket): ticket is PeriodMultipleSe
     (ticket as PeriodMultipleServicesTicket).selectedServices !== undefined;
 
 export const isPeriodGeoZoneTicket = (ticket: Ticket): ticket is PeriodGeoZoneTicket =>
-    ticket.type === 'period' && (ticket as PeriodGeoZoneTicket).zoneName !== undefined;
+    !isSchemeOperatorTicket(ticket) && ticket.type === 'period' && (ticket as PeriodGeoZoneTicket).zoneName !== undefined;
 
 export const isPeriodMultipleServicesTicket = (ticket: Ticket): ticket is PeriodMultipleServicesTicket =>
     ticket.type === 'period' && (ticket as PeriodMultipleServicesTicket).selectedServices !== undefined;

--- a/repos/fdbt-netex-output/src/types/index.ts
+++ b/repos/fdbt-netex-output/src/types/index.ts
@@ -277,9 +277,6 @@ export const isGeoZoneTicket = (ticket: Ticket): ticket is GeoZoneTicket =>
 export const isMultiServiceTicket = (ticket: Ticket): ticket is PeriodMultipleServicesTicket =>
     (ticket as PeriodMultipleServicesTicket).selectedServices !== undefined;
 
-export const isPeriodGeoZoneTicket = (ticket: Ticket): ticket is PeriodGeoZoneTicket =>
-    !isSchemeOperatorTicket(ticket) && ticket.type === 'period' && 'zoneName' in ticket;
-
 export const isPeriodMultipleServicesTicket = (ticket: Ticket): ticket is PeriodMultipleServicesTicket =>
     ticket.type === 'period' && (ticket as PeriodMultipleServicesTicket).selectedServices !== undefined;
 
@@ -303,6 +300,9 @@ export const isMultiOperatorMultipleServicesTicket = (
 export const isSchemeOperatorTicket = (data: Ticket): data is SchemeOperatorTicket =>
     (data as SchemeOperatorTicket).schemeOperatorName !== undefined &&
     (data as SchemeOperatorTicket).schemeOperatorRegionCode !== undefined;
+
+export const isPeriodGeoZoneTicket = (ticket: Ticket): ticket is PeriodGeoZoneTicket =>
+    !isSchemeOperatorTicket(ticket) && ticket.type === 'period' && 'zoneName' in ticket;
 
 export const isSchemeOperatorGeoZoneTicket = (data: Ticket): data is SchemeOperatorGeoZoneTicket =>
     isSchemeOperatorTicket(data) && (data as SchemeOperatorGeoZoneTicket).zoneName !== undefined;

--- a/repos/fdbt-netex-output/src/types/index.ts
+++ b/repos/fdbt-netex-output/src/types/index.ts
@@ -278,7 +278,7 @@ export const isMultiServiceTicket = (ticket: Ticket): ticket is PeriodMultipleSe
     (ticket as PeriodMultipleServicesTicket).selectedServices !== undefined;
 
 export const isPeriodGeoZoneTicket = (ticket: Ticket): ticket is PeriodGeoZoneTicket =>
-    !isSchemeOperatorTicket(ticket) && ticket.type === 'period' && (ticket as PeriodGeoZoneTicket).zoneName !== undefined;
+    !isSchemeOperatorTicket(ticket) && ticket.type === 'period' && 'zoneName' in ticket;
 
 export const isPeriodMultipleServicesTicket = (ticket: Ticket): ticket is PeriodMultipleServicesTicket =>
     ticket.type === 'period' && (ticket as PeriodMultipleServicesTicket).selectedServices !== undefined;

--- a/repos/fdbt-site/src/pages/carnetProductDetails.tsx
+++ b/repos/fdbt-site/src/pages/carnetProductDetails.tsx
@@ -128,6 +128,7 @@ const CarnetProductDetails = ({ product, hintText, csrfToken, errors }: CarnetPr
                                         unitName="productDetailsExpiryUnitInput"
                                         unitId="product-details-carnet-expiry-unit"
                                         errors={errors}
+                                        carnet
                                     />
                                 </>
                             </FormGroupWrapper>

--- a/repos/fdbt-site/tests/pages/__snapshots__/carnetProductDetails.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/carnetProductDetails.test.tsx.snap
@@ -139,6 +139,7 @@ exports[`pages carnetProductDetails should render correctly 1`] = `
             errors={Array []}
           />
           <ExpirySelector
+            carnet={true}
             defaultDuration="2"
             defaultUnit="day"
             errors={Array []}

--- a/repos/fdbt-site/tests/pages/api/multipleProducts.test.ts
+++ b/repos/fdbt-site/tests/pages/api/multipleProducts.test.ts
@@ -190,27 +190,24 @@ describe('multipleProducts', () => {
         ],
     ];
 
-    it.only.each(carnetCases)(
-        'given %p as request, redirects to %p for carnet products',
-        (testData, expectedLocation) => {
-            const { req, res } = getMockRequestAndResponse({
-                cookieValues: {},
-                body: testData,
-                uuid: {},
-                mockWriteHeadFn: writeHeadMock,
-                session: {
-                    [NUMBER_OF_PRODUCTS_ATTRIBUTE]: {
-                        numberOfProductsInput: '2',
-                    },
-                    [CARNET_FARE_TYPE_ATTRIBUTE]: true,
+    it.each(carnetCases)('given %p as request, redirects to %p for carnet products', (testData, expectedLocation) => {
+        const { req, res } = getMockRequestAndResponse({
+            cookieValues: {},
+            body: testData,
+            uuid: {},
+            mockWriteHeadFn: writeHeadMock,
+            session: {
+                [NUMBER_OF_PRODUCTS_ATTRIBUTE]: {
+                    numberOfProductsInput: '2',
                 },
-            });
+                [CARNET_FARE_TYPE_ATTRIBUTE]: true,
+            },
+        });
 
-            (setCookieOnResponseObject as {}) = jest.fn();
-            multipleProduct(req, res);
-            expect(writeHeadMock).toBeCalledWith(302, expectedLocation);
-        },
-    );
+        (setCookieOnResponseObject as {}) = jest.fn();
+        multipleProduct(req, res);
+        expect(writeHeadMock).toBeCalledWith(302, expectedLocation);
+    });
 
     it('redirects to ticket confirmation for a flat fare ticket', () => {
         const { req, res } = getMockRequestAndResponse({


### PR DESCRIPTION
# Description

-   To allow scheme operators to correctly generate netex.

# Testing instructions

-   Run make command to generate scheme operator netex.

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [ ] Able to run pr locally
-   [ ] Followed acceptance criteria
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
