### PR TITLE
fix: Fixed bug around carnet no expiry

### DIFF
--- a/repos/fdbt-site/src/pages/api/multipleProducts.ts
+++ b/repos/fdbt-site/src/pages/api/multipleProducts.ts
@@ -200,7 +200,7 @@ export const checkCarnetExpiriesAreValid = (products: MultiProduct[]): MultiProd
         const trimmedQuantity = removeExcessWhiteSpace(expiryTime);
         const expiryError = checkIntegerIsValid(trimmedQuantity, 'Carnet expiry amount', 1, 999);
 
-        if (expiryError) {
+        if (expiryError && product.carnetDetails?.expiryUnit !== 'no expiry') {
             return {
                 ...product,
                 productCarnetExpiryDurationError: expiryError,
@@ -283,7 +283,7 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
                 productPriceId,
                 carnetDetails: quantity && {
                     quantity,
-                    expiryTime,
+                    expiryTime: expiryUnit === 'no expiry' ? '' : expiryTime,
                     expiryUnit,
                 },
                 productCarnetQuantityId,

--- a/repos/fdbt-site/tests/pages/api/multipleProducts.test.ts
+++ b/repos/fdbt-site/tests/pages/api/multipleProducts.test.ts
@@ -1,4 +1,3 @@
-import { MULTIPLE_PRODUCT_ATTRIBUTE } from './../../../src/constants/attributes';
 import multipleProduct, {
     checkProductPricesAreValid,
     checkProductDurationsAreValid,
@@ -22,6 +21,7 @@ import {
     NUMBER_OF_PRODUCTS_ATTRIBUTE,
     FARE_TYPE_ATTRIBUTE,
     CARNET_FARE_TYPE_ATTRIBUTE,
+    MULTIPLE_PRODUCT_ATTRIBUTE,
 } from '../../../src/constants/attributes';
 import * as sessions from '../../../src/utils/sessions';
 
@@ -130,7 +130,7 @@ describe('multipleProducts', () => {
         expect(writeHeadMock).toBeCalledWith(302, expectedLocation);
     });
 
-    const carnetCases: any[] = [
+    const carnetCases = [
         [
             {
                 multipleProductNameInput0: 'Best Product',


### PR DESCRIPTION
# Description

-   No expiry option for carnet's were forcing users to enter a number, when they shouldnt have been.

# Testing instructions

-   Use locally and test the situation.
- 
# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [ ] Able to run pr locally
-   [ ] Followed acceptance criteria
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
