### PR TITLE
feat: Added distinction for carnets in created files page and enabled carnet in prod

### DIFF
--- a/repos/fdbt-site/src/interfaces/index.ts
+++ b/repos/fdbt-site/src/interfaces/index.ts
@@ -281,6 +281,7 @@ export interface S3NetexFile {
     date: string;
     signedUrl: string;
     fileSize: number;
+    carnet: boolean;
 }
 
 /* eslint-disable camelcase */

--- a/repos/fdbt-site/src/pages/createdFiles.tsx
+++ b/repos/fdbt-site/src/pages/createdFiles.tsx
@@ -24,10 +24,10 @@ interface CreateFilesProps {
     numberPerPage: number;
 }
 
-export const buildName = (file: PointToPointTicket | PeriodTicket): string => {
-    let name = `${file.nocCode ? `${file.nocCode} - ` : ''}${sentenceCaseString(file.type)} - ${sentenceCaseString(
-        file.passengerType,
-    )}`;
+export const buildName = (file: PointToPointTicket | PeriodTicket, isCarnet: boolean): string => {
+    let name = `${file.nocCode ? `${file.nocCode} - ` : ''}${sentenceCaseString(file.type)}${
+        isCarnet ? ' (carnet)' : ''
+    } - ${sentenceCaseString(file.passengerType)}`;
 
     if (isPointToPointTicket(file)) {
         name += ` - Line ${file.lineName}`;
@@ -76,9 +76,10 @@ const enrichNetexFileData = async (
             }
 
             const matchingData: PointToPointTicket | PeriodTicket = JSON.parse(item.matchingData.Body.toString());
+            const carnet = 'carnetDetails' in matchingData.products[0];
 
             return {
-                name: buildName(matchingData),
+                name: buildName(matchingData, carnet),
                 noc: matchingData.nocCode,
                 reference: matchingData.uuid,
                 fareType: matchingData.type,
@@ -99,6 +100,7 @@ const enrichNetexFileData = async (
                     : '',
                 signedUrl: item.signedUrl,
                 fileSize: item.fileSize || 0,
+                carnet,
             };
         })
         .filter(isNotEmpty);
@@ -170,6 +172,7 @@ const CreatedFiles = ({ files, numberOfResults, currentPage, numberPerPage }: Cr
                                 )}
                                 <span className="govuk-body govuk-!-font-weight-bold">Fare Type: </span>{' '}
                                 {sentenceCaseString(file.fareType)}
+                                {file.carnet ? ' (carnet)' : ''}
                                 <br />
                                 <span className="govuk-body govuk-!-font-weight-bold">Passenger Type: </span>{' '}
                                 {sentenceCaseString(file.passengerType)}

--- a/repos/fdbt-site/src/pages/fareType.tsx
+++ b/repos/fdbt-site/src/pages/fareType.tsx
@@ -191,7 +191,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     const errors: ErrorInfo[] =
         fareTypeAttribute && isFareTypeAttributeWithErrors(fareTypeAttribute) ? fareTypeAttribute.errors : [];
 
-    const displayCarnet = process.env.STAGE !== 'prod';
+    const displayCarnet = !schemeOp;
 
     return { props: { operatorName, schemeOp, displayCarnet, errors, csrfToken } };
 };

--- a/repos/fdbt-site/tests/pages/__snapshots__/createdFiles.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/createdFiles.test.tsx.snap
@@ -1,5 +1,248 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`pages createdFiles should render correctly for a classic carnet operator 1`] = `
+<TwoThirdsLayout
+  description="Created Files page for the Create Fares Data Service"
+  title="Created Files - Create Fares Data Service"
+>
+  <div
+    className="govuk-breadcrumbs "
+  >
+    <ol
+      className="govuk-breadcrumbs__list"
+    >
+      <li
+        className="govuk-breadcrumbs__list-item"
+      >
+        <a
+          className="govuk-breadcrumbs__link"
+          href="/home"
+        >
+          Home
+        </a>
+      </li>
+    </ol>
+  </div>
+  <h1
+    className="govuk-heading-l"
+  >
+    Previously created files
+  </h1>
+  <span
+    className="govuk-hint"
+    id="fare-type-operator-hint"
+  >
+    This page will show any NeTEx files created in the last 60 days
+  </span>
+  <div
+    className="govuk-accordion"
+    data-module="govuk-accordion"
+    id="accordion-default"
+  >
+    <div
+      className="govuk-accordion__section"
+      key="TEST12345Test Name"
+    >
+      <div
+        className="govuk-accordion__section-header"
+      >
+        <h2
+          className="govuk-accordion__section-heading"
+        >
+          <span
+            className="govuk-accordion__section-button"
+            id="accordion-default-heading-0"
+          >
+            Test Name
+          </span>
+        </h2>
+      </div>
+      <div
+        aria-labelledby="accordion-default-heading-0"
+        className="govuk-accordion__section-content"
+        id="accordion-default-content-0"
+      >
+        <div
+          className="govuk-body"
+        >
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Reference: 
+          </span>
+           
+          TEST12345
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            National Operator Code:
+             
+          </span>
+          TEST
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Fare Type: 
+          </span>
+           
+          Single
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Passenger Type: 
+          </span>
+           
+          Adult
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Sales Offer Package(s): 
+          </span>
+          Test SOP Name, Test SOP Name 2
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Line Name: 
+          </span>
+           
+          X01
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Date of Creation: 
+          </span>
+           
+          Tue, 01 Sep 2020 14:46:58 GMT
+          <br />
+          <br />
+          <a
+            className="govuk-button"
+            download={true}
+            href="https://test.example.com/dscsdcd"
+          >
+            Download - File Type XML - File Size 
+            123B
+          </a>
+        </div>
+      </div>
+    </div>
+    <div
+      className="govuk-accordion__section"
+      key="TEST54321Test Name 2"
+    >
+      <div
+        className="govuk-accordion__section-header"
+      >
+        <h2
+          className="govuk-accordion__section-heading"
+        >
+          <span
+            className="govuk-accordion__section-button"
+            id="accordion-default-heading-1"
+          >
+            Test Name 2
+          </span>
+        </h2>
+      </div>
+      <div
+        aria-labelledby="accordion-default-heading-1"
+        className="govuk-accordion__section-content"
+        id="accordion-default-content-1"
+      >
+        <div
+          className="govuk-body"
+        >
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Reference: 
+          </span>
+           
+          TEST54321
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            National Operator Code:
+             
+          </span>
+          TEST2
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Fare Type: 
+          </span>
+           
+          Flat fare
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Passenger Type: 
+          </span>
+           
+          Child
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Sales Offer Package(s): 
+          </span>
+          Test SOP Name 2
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Service(s): 
+          </span>
+           
+          1, 56, X02
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Product(s): 
+          </span>
+           
+          Product 1, Product 2
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Date of Creation: 
+          </span>
+           
+          Wed, 02 Sep 2020 14:46:58 GMT
+          <br />
+          <br />
+          <a
+            className="govuk-button"
+            download={true}
+            href="https://test.example.com/gfnhgddd"
+          >
+            Download - File Type XML - File Size 
+            456B
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <Pagination
+    currentPage={1}
+    link="/createdFiles"
+    numberOfResults={10}
+    numberPerPage={5}
+  />
+</TwoThirdsLayout>
+`;
+
 exports[`pages createdFiles should render correctly for a classic operator 1`] = `
 <TwoThirdsLayout
   description="Created Files page for the Create Fares Data Service"

--- a/repos/fdbt-site/tests/pages/createdFiles.test.tsx
+++ b/repos/fdbt-site/tests/pages/createdFiles.test.tsx
@@ -19,6 +19,7 @@ const classicOperatorNetexFiles: S3NetexFile[] = [
         sopNames: 'Test SOP Name, Test SOP Name 2',
         lineName: 'X01',
         fileSize: 123,
+        carnet: false,
     },
     {
         name: 'Test Name 2',
@@ -32,6 +33,37 @@ const classicOperatorNetexFiles: S3NetexFile[] = [
         serviceNames: '1, 56, X02',
         productNames: 'Product 1, Product 2',
         fileSize: 456,
+        carnet: false,
+    },
+];
+
+const classicCarnetOperatorNetexFiles: S3NetexFile[] = [
+    {
+        name: 'Test Name',
+        fareType: 'single',
+        noc: 'TEST',
+        passengerType: 'adult',
+        reference: 'TEST12345',
+        date: 'Tue, 01 Sep 2020 14:46:58 GMT',
+        signedUrl: 'https://test.example.com/dscsdcd',
+        sopNames: 'Test SOP Name, Test SOP Name 2',
+        lineName: 'X01',
+        fileSize: 123,
+        carnet: false,
+    },
+    {
+        name: 'Test Name 2',
+        fareType: 'flatFare',
+        noc: 'TEST2',
+        passengerType: 'child',
+        reference: 'TEST54321',
+        date: 'Wed, 02 Sep 2020 14:46:58 GMT',
+        signedUrl: 'https://test.example.com/gfnhgddd',
+        sopNames: 'Test SOP Name 2',
+        serviceNames: '1, 56, X02',
+        productNames: 'Product 1, Product 2',
+        fileSize: 456,
+        carnet: false,
     },
 ];
 
@@ -47,6 +79,7 @@ const schemeOperatorNetexFiles: S3NetexFile[] = [
         sopNames: 'Test SOP Name, Test SOP Name 2',
         lineName: 'X01',
         fileSize: 123,
+        carnet: false,
     },
     {
         name: 'Test Name 2',
@@ -60,6 +93,7 @@ const schemeOperatorNetexFiles: S3NetexFile[] = [
         serviceNames: '1, 56, X02',
         productNames: 'Product 1, Product 2',
         fileSize: 456,
+        carnet: false,
     },
 ];
 
@@ -107,6 +141,18 @@ describe('pages', () => {
             const tree = shallow(
                 <CreatedFiles
                     files={classicOperatorNetexFiles}
+                    numberOfResults={10}
+                    currentPage={1}
+                    numberPerPage={5}
+                />,
+            );
+            expect(tree).toMatchSnapshot();
+        });
+
+        it('should render correctly for a classic carnet operator', () => {
+            const tree = shallow(
+                <CreatedFiles
+                    files={classicCarnetOperatorNetexFiles}
                     numberOfResults={10}
                     currentPage={1}
                     numberPerPage={5}
@@ -177,7 +223,7 @@ describe('pages', () => {
                     zoneName: 'The Test Zone',
                     stops: [],
                 };
-                expect(buildName(file)).toBe('NOC - Single - Child - The Test Zone');
+                expect(buildName(file, false)).toBe('NOC - Single - Child - The Test Zone');
             });
             it('does not include the NOC if its not there', () => {
                 const file = {
@@ -204,7 +250,7 @@ describe('pages', () => {
                     zoneName: 'The Test Zone',
                     stops: [],
                 };
-                expect(buildName(file)).toBe('Single - Child - The Test Zone');
+                expect(buildName(file, false)).toBe('Single - Child - The Test Zone');
             });
         });
 
@@ -259,6 +305,7 @@ describe('pages', () => {
                                 sopNames: 'Onboard (cash),Onboard (contactless)',
                                 zoneName: '',
                                 fileSize: 1234,
+                                carnet: false,
                             },
                             {
                                 date: '',
@@ -274,6 +321,7 @@ describe('pages', () => {
                                 sopNames: 'Onboard (cash),Onboard (contactless)',
                                 zoneName: '',
                                 fileSize: 1234032,
+                                carnet: false,
                             },
                         ],
                         numberOfResults: 2,


### PR DESCRIPTION
# Description

-   To allow the user to see a distinction between their normal fares and carnet fares in the created files page. Also, to turn on carnet in prod for all fares apart from scheme operators.

# Testing instructions

-   Add a carnetDetails : {} to the first product in some matching JSON, and make sure the created files page sees this locally. 

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [ ] Able to run pr locally
-   [ ] Followed acceptance criteria
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
