### PR TITLE
chore: Removed code which outputs to slack on successful validation

### DIFF
--- a/repos/fdbt-netex-output/src/netex-validator/main.py
+++ b/repos/fdbt-netex-output/src/netex-validator/main.py
@@ -104,17 +104,6 @@ def lambda_handler(event, context):
             logger.info('NeTEx valid, uploading to S3...')
             s3_client.upload_file(download_path, os.getenv('VALIDATED_NETEX_BUCKET'), key)
 
-            sns_client.publish(
-                TopicArn=SNS_ALERTS_ARN,
-                Subject="NeTEx Validator",
-                Message=f'NeTEx file: {key} has been successfully validated and uploaded',
-                MessageAttributes={
-                    'NewStateValue': {
-                        'DataType': 'String',
-                        'StringValue': 'OK'
-                    }
-                }
-            )
         except Exception as e:
             logger.error(f'There was an error when validating NeTEx file: {key}, error: {e}')
 


### PR DESCRIPTION
# Description

-   We want the slack channel to alert us when files are not validated, not when they are. This change removes the code which outputs to our slack on success.

# Testing instructions

-   None required, will be able to test when merged in by creating a netex file.

# Type of change

-   [ ] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [ ] Able to run pr locally
-   [ ] Followed acceptance criteria
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
