### PR TITLE
feat: CFD-337 filter ended services

### DIFF
--- a/fdbt-aws/sql/l.addEndDateColumnTotxcOperatorLine.sql
+++ b/fdbt-aws/sql/l.addEndDateColumnTotxcOperatorLine.sql
@@ -1,0 +1,2 @@
+-- add an 'endDate' column to the txcOperatorLine as part of CFD-337
+alter table txcOperatorLine add column endDate date default null;

--- a/fdbt-aws/sql/l.addEndDateColumnTotxcOperatorLine.sql
+++ b/fdbt-aws/sql/l.addEndDateColumnTotxcOperatorLine.sql
@@ -1,2 +1,2 @@
 -- add an 'endDate' column to the txcOperatorLine as part of CFD-337
-alter table txcOperatorLine add column endDate date default null;
+ALTER TABLE txcOperatorLine ADD COLUMN endDate DATE DEFAULT NULL;

--- a/fdbt-dev/sql/txcOperatorLine.sql
+++ b/fdbt-dev/sql/txcOperatorLine.sql
@@ -302,13 +302,13 @@ INSERT INTO `txcOperatorLine` (id,nocCode,lineName,lineId,startDate,serviceCode,
 -- update a few rows to test end date logic for services
 
 -- a future date
-update txcOperatorLine set endDate = DATE_ADD(CURDATE(), INTERVAL 10 DAY) where lineId = 'I3vs2Q';
+UPDATE txcOperatorLine SET endDate = DATE_ADD(CURDATE(), INTERVAL 10 DAY) WHERE lineId = 'I3vs2Q';
 
 -- today's date
-update txcOperatorLine set endDate = CURDATE() where lineId = 'QdeLAv';
+UPDATE txcOperatorLine SET endDate = CURDATE() WHERE lineId = 'QdeLAv';
 
 -- a date in the past
-update txcOperatorLine set endDate = DATE_SUB(CURDATE(), INTERVAL 10 DAY) where lineId = 'SeszrT';
+UPDATE txcOperatorLine SET endDate = DATE_SUB(CURDATE(), INTERVAL 10 DAY) WHERE lineId = 'SeszrT';
 
 UNLOCK TABLES;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;

--- a/fdbt-dev/sql/txcOperatorLine.sql
+++ b/fdbt-dev/sql/txcOperatorLine.sql
@@ -299,6 +299,16 @@ INSERT INTO `txcOperatorLine` (id,nocCode,lineName,lineId,startDate,serviceCode,
 (11766,"WBTR","H20","zMR1aZ","2020-04-13","NW_07_NW_H20_2","Warrington''s Own Buses","Murdishaw - Murdishaw","NW","tnds","Aschau im Zillertal","Genaro Estrada"),
 (11871,"WBTR","H20A","U5oPWj","2020-04-13","NW_07_NW_H20A_2","Warrington''s Own Buses","Murdishaw - Murdishaw","NW","tnds","Dukinfield","Trzebnica");
 
+-- update a few rows to test end date logic for services
+
+-- a future date
+update txcOperatorLine set endDate = DATE_ADD(CURDATE(), INTERVAL 10 DAY) where lineId = 'I3vs2Q';
+
+-- today's date
+update txcOperatorLine set endDate = CURDATE() where lineId = 'QdeLAv';
+
+-- a date in the past
+update txcOperatorLine set endDate = DATE_SUB(CURDATE(), INTERVAL 10 DAY) where lineId = 'SeszrT';
 
 UNLOCK TABLES;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;

--- a/repos/fdbt-reference-data-service/src/uploaders/tests/test_xml_uploader.py
+++ b/repos/fdbt-reference-data-service/src/uploaders/tests/test_xml_uploader.py
@@ -31,7 +31,7 @@ class TestDatabaseInsertQuerying:
 class TestDataCollectionFunctionality:
     def test_extract_data_for_txc_operator_service_table(self):
         expected_operator_and_service_info = (
-            'ANWE', '2018-01-28', 'ANW', 'Macclesfield - Upton Priory Circular', 'NW_01_ANW_4_1', 'Macclesfield', 'Macclesfield')
+            'ANWE', '2018-01-28', '2099-12-31', 'ANW', 'Macclesfield - Upton Priory Circular', 'NW_01_ANW_4_1', 'Macclesfield', 'Macclesfield')
         operator = mock_data_dict['TransXChange']['Operators']['Operator']
         service = mock_data_dict['TransXChange']['Services']['Service']
 

--- a/repos/fdbt-reference-data-service/src/uploaders/txc_uploader/txc_processor.py
+++ b/repos/fdbt-reference-data-service/src/uploaders/txc_uploader/txc_processor.py
@@ -58,6 +58,7 @@ def get_lines_for_service(service):
 def extract_data_for_txc_operator_service_table(operator, service):
     noc_code = operator['NationalOperatorCode']
     start_date = service['OperatingPeriod']['StartDate']
+    end_date = service['OperatingPeriod']['EndDate']
     operator_short_name = operator['OperatorShortName']
     service_description = service['Description'] if 'Description' in service else ''
     service_code = service['ServiceCode'] if 'ServiceCode' in service else None

--- a/repos/fdbt-reference-data-service/src/uploaders/txc_uploader/txc_processor.py
+++ b/repos/fdbt-reference-data-service/src/uploaders/txc_uploader/txc_processor.py
@@ -58,7 +58,7 @@ def get_lines_for_service(service):
 def extract_data_for_txc_operator_service_table(operator, service):
     noc_code = operator['NationalOperatorCode']
     start_date = service['OperatingPeriod']['StartDate']
-    end_date = service['OperatingPeriod']['EndDate']
+    end_date = service['OperatingPeriod']['EndDate'] if 'EndDate' in service['OperatingPeriod'] else None
     operator_short_name = operator['OperatorShortName']
     service_description = service['Description'] if 'Description' in service else ''
     service_code = service['ServiceCode'] if 'ServiceCode' in service else None
@@ -66,7 +66,7 @@ def extract_data_for_txc_operator_service_table(operator, service):
     origin = standard_service['Origin'] if standard_service and 'Origin' in standard_service else None
     destination = standard_service['Destination'] if standard_service and 'Destination' in standard_service else None
 
-    return noc_code, start_date, operator_short_name, service_description, service_code, origin, destination
+    return noc_code, start_date, end_date, operator_short_name, service_description, service_code, origin, destination
 
 
 def collect_journey_pattern_section_refs_and_info(raw_journey_patterns):
@@ -209,6 +209,7 @@ def insert_into_txc_operator_service_table(cursor, operator, service, line, regi
     (
         noc_code,
         start_date,
+        end_date,
         operator_short_name,
         service_description,
         service_code,
@@ -216,8 +217,8 @@ def insert_into_txc_operator_service_table(cursor, operator, service, line, regi
         destination
     ) = extract_data_for_txc_operator_service_table(operator, service)
 
-    query = f"""INSERT INTO txcOperatorLine (nocCode, lineName, lineId, startDate, operatorShortName, serviceDescription, serviceCode, regionCode, dataSource, origin, destination)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"""
+    query = f"""INSERT INTO txcOperatorLine (nocCode, lineName, lineId, startDate, endDate, operatorShortName, serviceDescription, serviceCode, regionCode, dataSource, origin, destination)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"""
 
     line_id = line.get('@id', '')
     line_name = line.get('LineName', '')
@@ -230,6 +231,7 @@ def insert_into_txc_operator_service_table(cursor, operator, service, line, regi
                 line_name,
                 line_id,
                 start_date,
+                end_date,
                 operator_short_name,
                 service_description,
                 service_code,
@@ -257,6 +259,7 @@ def check_txc_line_exists(cursor, operator, service, line, data_source, cloudwat
     (
         noc_code,
         start_date,
+        end_date,
         operator_short_name,
         service_description,
         service_code,
@@ -266,7 +269,7 @@ def check_txc_line_exists(cursor, operator, service, line, data_source, cloudwat
 
     query = f"""
         SELECT id FROM txcOperatorLine
-        WHERE nocCode = %s AND lineName = %s AND serviceCode = %s AND startDate = %s AND dataSource = %s
+        WHERE nocCode = %s AND lineName = %s AND serviceCode = %s AND startDate = %s AND endDate = %s AND dataSource = %s
         LIMIT 1
     """
 
@@ -279,6 +282,7 @@ def check_txc_line_exists(cursor, operator, service, line, data_source, cloudwat
             line_name,
             service_code,
             start_date,
+            end_date,
             data_source
         ]
     )

--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -129,7 +129,7 @@ export const getServicesByNocCodeAndDataSource = async (nocCode: string, source:
         const queryInput = `
             SELECT lineName, lineId, startDate, serviceDescription AS description, origin, destination, serviceCode
             FROM txcOperatorLine
-            WHERE nocCode = ? AND dataSource = ?
+            WHERE nocCode = ? AND dataSource = ? AND (endDate IS NULL OR CURDATE() < endDate)
             ORDER BY CAST(lineName AS UNSIGNED) = 0, CAST(lineName AS UNSIGNED), LEFT(lineName, 1), MID(lineName, 2), startDate;
         `;
 

--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -129,7 +129,7 @@ export const getServicesByNocCodeAndDataSource = async (nocCode: string, source:
         const queryInput = `
             SELECT lineName, lineId, startDate, serviceDescription AS description, origin, destination, serviceCode
             FROM txcOperatorLine
-            WHERE nocCode = ? AND dataSource = ? AND (endDate IS NULL OR CURDATE() < endDate)
+            WHERE nocCode = ? AND dataSource = ? AND (endDate IS NULL OR CURDATE() <= endDate)
             ORDER BY CAST(lineName AS UNSIGNED) = 0, CAST(lineName AS UNSIGNED), LEFT(lineName, 1), MID(lineName, 2), startDate;
         `;
 


### PR DESCRIPTION
# Description

-   Filter ended services.

# Testing instructions

-   Deploy to test environment, then trigger the txcRetriever, once that path is complete.
-   Connect to the MySQL database on test.
-   Add an endDate for a few services that belong to the national operator code 'BLAC'
-   Navigate to to the site and get to the Service List page using the `BLAC` national operator code.
-   You should only see services whose endDate is less than or equal to today's date.

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [ ] Able to run pr locally
-   [ ] Followed acceptance criteria
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
