### PR TITLE
feat: CFD-295 add the global settings page

### DIFF
--- a/repos/fdbt-site/src/design/Layout.scss
+++ b/repos/fdbt-site/src/design/Layout.scss
@@ -5,6 +5,94 @@ main {
     outline: none;
 }
 
+.govuk-header.app-header {
+    border-bottom: 10px solid #1d70b8;
+    min-height: 60px;
+}
+
+.govuk-header > .govuk-header__container {
+    border-bottom: 0;
+}
+
+.app-navigation {
+    font-family: 'GDS Transport', arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-weight: 700;
+    /* font-size: 16px; */
+    font-size: 1.1875rem;
+    line-height: 1.25;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    width: 100%;
+    background-color: #f8f8f8;
+}
+
+.app-navigation__list {
+    position: relative;
+    left: -15px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.app-navigation__list-item {
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    display: block;
+    position: relative;
+    height: 50px;
+    padding: 0 15px;
+    float: left;
+    line-height: 50px;
+}
+
+.app-navigation__list-item--current {
+    border-bottom: 5px solid #1d70b8;
+}
+
+.app-width-container {
+    max-width: 960px;
+    margin-right: auto;
+    margin-left: auto;
+}
+
+.app-subnav__section-item {
+	margin-bottom: 5px;
+	padding-top: 5px;
+	padding-bottom: 5px;
+}
+
+.app-subnav__section-item .app-subnav__link {
+	font-weight: normal;
+
+  &:hover {
+    text-underline-offset: .3em;
+    text-decoration-thickness: 3px;
+  }
+}
+
+.app-subnav__section-item--current {
+	margin-left: -14px;
+	padding-left: 10px;
+	border-left: 4px solid #1d70b8;
+	background-color: #fff;
+
+  .app-subnav__link {
+    font-weight: bold;
+  }
+}
+
+.app-subnav__section {
+    margin: 0 0 20px;
+    padding: 0;
+    list-style-type: none;
+}
+
+.govuk-link--no-underline:not(:hover):not(:active) {
+    text-decoration: none;
+}
+
 .skip {
     position: absolute;
     overflow: hidden;

--- a/repos/fdbt-site/src/design/main.scss
+++ b/repos/fdbt-site/src/design/main.scss
@@ -1,0 +1,10 @@
+@import '../../node_modules/govuk-frontend/govuk/all';
+@import './modules/_layout.scss';
+@import './modules/_components.scss';
+@import './modules/_pages.scss';
+
+// import header styles
+@import './modules/_header.scss';
+
+// import phase banner styles
+@import './modules/_phase-banner.scss';

--- a/repos/fdbt-site/src/design/modules/_components.scss
+++ b/repos/fdbt-site/src/design/modules/_components.scss
@@ -1,5 +1,3 @@
-@import '../../node_modules/govuk-frontend/govuk/all';
-
 .file-attachment {
     display: flex;
     margin-top: 40px;

--- a/repos/fdbt-site/src/design/modules/_header.scss
+++ b/repos/fdbt-site/src/design/modules/_header.scss
@@ -1,0 +1,8 @@
+.app-header {
+    border-bottom: 10px solid #1d70b8;
+
+    .app-header__container {
+        margin-bottom: 0;
+        border-bottom: 0;
+    }
+}

--- a/repos/fdbt-site/src/design/modules/_layout.scss
+++ b/repos/fdbt-site/src/design/modules/_layout.scss
@@ -1,17 +1,6 @@
-@import '../../node_modules/govuk-frontend/govuk/all';
-
 main {
     border: none;
     outline: none;
-}
-
-.govuk-header.app-header {
-    border-bottom: 10px solid #1d70b8;
-    min-height: 60px;
-}
-
-.govuk-header > .govuk-header__container {
-    border-bottom: 0;
 }
 
 .app-navigation {
@@ -93,6 +82,10 @@ main {
     text-decoration: none;
 }
 
+.app-phase-banner {
+  border: none;
+}
+
 .skip {
     position: absolute;
     overflow: hidden;
@@ -121,19 +114,6 @@ main {
 .govuk-grid-row {
     margin-right: -15px;
     margin-left: -15px;
-}
-
-.govuk-grid-column-two-thirds {
-    box-sizing: border-box;
-    width: 100%;
-    padding: 0 15px;
-}
-
-@media (min-width: 40.0625em) {
-    .govuk-grid-column-two-thirds {
-        width: 16%;
-        float: left;
-    }
 }
 
 .gem-c-organisation-logo {

--- a/repos/fdbt-site/src/design/modules/_pages.scss
+++ b/repos/fdbt-site/src/design/modules/_pages.scss
@@ -1,5 +1,3 @@
-@import '../../node_modules/govuk-frontend/govuk/all';
-
 .index-page-list {
     list-style-type: disc;
     line-height: 35px;

--- a/repos/fdbt-site/src/design/modules/_phase-banner.scss
+++ b/repos/fdbt-site/src/design/modules/_phase-banner.scss
@@ -1,0 +1,3 @@
+.app-phase-banner {
+    border: 0;
+}

--- a/repos/fdbt-site/src/layout/Header.tsx
+++ b/repos/fdbt-site/src/layout/Header.tsx
@@ -8,7 +8,7 @@ interface HeaderProps {
 
 const Header = ({ isAuthed, csrfToken }: HeaderProps): ReactElement => (
     <header className="govuk-header app-header" role="banner" data-module="govuk-header">
-        <div className="govuk-header__container govuk-width-container">
+        <div className="govuk-header__container app-header__container govuk-width-container">
             <div className="govuk-header__logo">
                 <a href="https://www.gov.uk/" className="govuk-header__link govuk-header__link--homepage">
                     <span className="govuk-header__logotype">

--- a/repos/fdbt-site/src/layout/Header.tsx
+++ b/repos/fdbt-site/src/layout/Header.tsx
@@ -7,7 +7,7 @@ interface HeaderProps {
 }
 
 const Header = ({ isAuthed, csrfToken }: HeaderProps): ReactElement => (
-    <header className="govuk-header " role="banner" data-module="govuk-header">
+    <header className="govuk-header app-header" role="banner" data-module="govuk-header">
         <div className="govuk-header__container govuk-width-container">
             <div className="govuk-header__logo">
                 <a href="https://www.gov.uk/" className="govuk-header__link govuk-header__link--homepage">

--- a/repos/fdbt-site/src/layout/Layout.tsx
+++ b/repos/fdbt-site/src/layout/Layout.tsx
@@ -6,6 +6,7 @@ import favicon from '../assets/images/favicon.ico';
 import { buildTitle } from '../utils';
 import { ErrorInfo } from '../interfaces';
 import PhaseBanner from './PhaseBanner';
+import Navigation from './Navigation';
 import Footer from './Footer';
 import Help from '../components/Help';
 import CookieBanner from './CookieBanner';
@@ -15,6 +16,7 @@ interface LayoutProps {
     description: string;
     errors?: ErrorInfo[];
     hideCookieBanner?: boolean;
+    showNavigation?: boolean;
     hideHelp?: boolean;
 }
 
@@ -24,6 +26,7 @@ export const BaseLayout = ({
     errors = [],
     children,
     hideCookieBanner = false,
+    showNavigation = false,
     hideHelp = false,
 }: PropsWithChildren<LayoutProps>): ReactElement => {
     const [showBanner, setShowBanner] = useState(false);
@@ -48,8 +51,11 @@ export const BaseLayout = ({
                 </Portal>
             )}
 
+            <PhaseBanner />
+
+            {showNavigation && <Navigation />}
+
             <div className="govuk-width-container app-width-container--wide">
-                <PhaseBanner />
                 <main id="main-content" role="main" tabIndex={-1}>
                     <div className="govuk-main-wrapper app-main-class">{children}</div>
                 </main>

--- a/repos/fdbt-site/src/layout/Layout.tsx
+++ b/repos/fdbt-site/src/layout/Layout.tsx
@@ -55,10 +55,8 @@ export const BaseLayout = ({
 
             {showNavigation && <Navigation />}
 
-            <div className="govuk-width-container app-width-container--wide">
-                <main id="main-content" role="main" tabIndex={-1}>
-                    <div className="govuk-main-wrapper app-main-class">{children}</div>
-                </main>
+            <div className="govuk-width-container">
+                <main className="govuk-main-wrapper">{children}</main>
                 {!hideHelp && <Help />}
             </div>
             <Footer />

--- a/repos/fdbt-site/src/layout/Navigation.tsx
+++ b/repos/fdbt-site/src/layout/Navigation.tsx
@@ -1,0 +1,19 @@
+import React, { ReactElement } from 'react';
+
+const Navigation = (): ReactElement => (
+    <nav className="app-navigation govuk-clearfix">
+        <ul className="app-navigation__list app-width-container">
+            <li className="app-navigation__list-item app-navigation__list-item--current">
+                <a
+                    className="govuk-link govuk-link--no-visited-state govuk-link--no-underline app-navigation__link"
+                    href="/get-started/"
+                    data-topnav="Get started"
+                >
+                    My settings
+                </a>
+            </li>
+        </ul>
+    </nav>
+);
+
+export default Navigation;

--- a/repos/fdbt-site/src/layout/PhaseBanner.tsx
+++ b/repos/fdbt-site/src/layout/PhaseBanner.tsx
@@ -2,17 +2,19 @@ import React, { ReactElement } from 'react';
 import { FEEDBACK_LINK } from '../constants';
 
 const PhaseBanner = (): ReactElement => (
-    <div className="govuk-phase-banner">
-        <p className="govuk-phase-banner__content">
-            <strong className="govuk-tag govuk-phase-banner__content__tag">beta</strong>
-            <span className="govuk-phase-banner__text">
-                This is a new service – your{' '}
-                <a className="govuk-link" id="feedback-link" href={FEEDBACK_LINK}>
-                    feedback
-                </a>{' '}
-                will help us to improve it.
-            </span>
-        </p>
+    <div className="app-phase-banner__wrapper">
+        <div className="govuk-phase-banner app-phase-banner app-width-container">
+            <p className="govuk-phase-banner__content">
+                <strong className="govuk-tag govuk-phase-banner__content__tag">beta</strong>
+                <span className="govuk-phase-banner__text">
+                    This is a new service – your{' '}
+                    <a className="govuk-link" id="feedback-link" href={FEEDBACK_LINK}>
+                        feedback
+                    </a>{' '}
+                    will help us to improve it.
+                </span>
+            </p>
+        </div>
     </div>
 );
 

--- a/repos/fdbt-site/src/pages/_app.tsx
+++ b/repos/fdbt-site/src/pages/_app.tsx
@@ -1,6 +1,4 @@
-import '../design/Pages.scss';
-import '../design/Layout.scss';
-import '../design/Components.scss';
+import '../design/main.scss';
 import { AppProps } from 'next/app';
 import React, { ReactElement, useEffect } from 'react';
 

--- a/repos/fdbt-site/src/pages/globalSettings.tsx
+++ b/repos/fdbt-site/src/pages/globalSettings.tsx
@@ -22,7 +22,7 @@ const GlobalSettings = (): ReactElement => (
                                     <li className="app-subnav__section-item app-subnav__section-item--current">
                                         <a
                                             className="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline"
-                                            href="/components/accordion/"
+                                            href="/globalSettings"
                                         >
                                             Settings overview
                                         </a>
@@ -31,7 +31,7 @@ const GlobalSettings = (): ReactElement => (
                                     <li className="app-subnav__section-item">
                                         <a
                                             className="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline"
-                                            href="/components/back-link/"
+                                            href="/globalSettings"
                                         >
                                             Passenger types
                                         </a>
@@ -40,7 +40,7 @@ const GlobalSettings = (): ReactElement => (
                                     <li className="app-subnav__section-item">
                                         <a
                                             className="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline"
-                                            href="/components/breadcrumbs/"
+                                            href="/globalSettings"
                                         >
                                             Service day end
                                         </a>
@@ -49,7 +49,7 @@ const GlobalSettings = (): ReactElement => (
                                     <li className="app-subnav__section-item">
                                         <a
                                             className="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline"
-                                            href="/components/button/"
+                                            href="/globalSettings"
                                         >
                                             Purchase methods
                                         </a>
@@ -58,7 +58,7 @@ const GlobalSettings = (): ReactElement => (
                                     <li className="app-subnav__section-item">
                                         <a
                                             className="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline"
-                                            href="/components/character-count/"
+                                            href="/globalSettings"
                                         >
                                             Time restrictions
                                         </a>
@@ -67,7 +67,7 @@ const GlobalSettings = (): ReactElement => (
                                     <li className="app-subnav__section-item">
                                         <a
                                             className="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline"
-                                            href="/components/checkboxes/"
+                                            href="/globalSettings"
                                         >
                                             Multi-operator groups
                                         </a>
@@ -76,7 +76,7 @@ const GlobalSettings = (): ReactElement => (
                                     <li className="app-subnav__section-item">
                                         <a
                                             className="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline"
-                                            href="/components/cookie-banner/"
+                                            href="/globalSettings"
                                         >
                                             Travel Zones
                                         </a>

--- a/repos/fdbt-site/src/pages/globalSettings.tsx
+++ b/repos/fdbt-site/src/pages/globalSettings.tsx
@@ -1,0 +1,106 @@
+import React, { ReactElement } from 'react';
+import { NextPageContextWithSession } from '../interfaces';
+import { BaseLayout } from '../layout/Layout';
+import { redirectTo } from './api/apiUtils';
+
+const title = 'Operator Settings';
+const description = 'View and access your settings in one place.';
+
+const GlobalSettings = (): ReactElement => (
+    <BaseLayout title={title} description={description} showNavigation={true}>
+        <div className="govuk-width-container">
+            <main className="govuk-main-wrapper">
+                <div className="govuk-grid-row">
+                    <div className="govuk-grid-column-one-third">
+                        <div className="app-pane__subnav">
+                            <nav className="app-subnav" aria-labelledby="app-subnav-heading">
+                                <h2 className="govuk-visually-hidden" id="app-subnav-heading">
+                                    Pages in this section
+                                </h2>
+
+                                <ul className="app-subnav__section">
+                                    <li className="app-subnav__section-item app-subnav__section-item--current">
+                                        <a
+                                            className="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline"
+                                            href="/components/accordion/"
+                                        >
+                                            Settings overview
+                                        </a>
+                                    </li>
+
+                                    <li className="app-subnav__section-item">
+                                        <a
+                                            className="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline"
+                                            href="/components/back-link/"
+                                        >
+                                            Passenger types
+                                        </a>
+                                    </li>
+
+                                    <li className="app-subnav__section-item">
+                                        <a
+                                            className="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline"
+                                            href="/components/breadcrumbs/"
+                                        >
+                                            Service day end
+                                        </a>
+                                    </li>
+
+                                    <li className="app-subnav__section-item">
+                                        <a
+                                            className="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline"
+                                            href="/components/button/"
+                                        >
+                                            Purchase methods
+                                        </a>
+                                    </li>
+
+                                    <li className="app-subnav__section-item">
+                                        <a
+                                            className="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline"
+                                            href="/components/character-count/"
+                                        >
+                                            Time restrictions
+                                        </a>
+                                    </li>
+
+                                    <li className="app-subnav__section-item">
+                                        <a
+                                            className="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline"
+                                            href="/components/checkboxes/"
+                                        >
+                                            Multi-operator groups
+                                        </a>
+                                    </li>
+
+                                    <li className="app-subnav__section-item">
+                                        <a
+                                            className="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline"
+                                            href="/components/cookie-banner/"
+                                        >
+                                            Travel Zones
+                                        </a>
+                                    </li>
+                                </ul>
+                            </nav>
+                        </div>
+                    </div>
+                    <div className="govuk-grid-column-two-thirds">
+                        <h1 className="govuk-heading-xl">Operator Settings</h1>
+                        <p className="govuk-body">This is a paragraph inside a two-thirds wide column</p>
+                    </div>
+                </div>
+            </main>
+        </div>
+    </BaseLayout>
+);
+
+export const getServerSideProps = (ctx: NextPageContextWithSession): { props: {} } => {
+    if (process.env.STAGE === 'prod' && ctx.res) {
+        redirectTo(ctx.res, '/home');
+    }
+
+    return { props: {} };
+};
+
+export default GlobalSettings;

--- a/repos/fdbt-site/src/pages/home.tsx
+++ b/repos/fdbt-site/src/pages/home.tsx
@@ -60,6 +60,7 @@ const Home = ({ multipleOperators, isOnTestEnvironment }: HomeProps): ReactEleme
                     </p>
                 </div>
             </div>
+
             <div className="govuk-grid-column-one-third">
                 <h2 className="govuk-heading-s">Public information</h2>
                 <a href="/contact" className="govuk-link govuk-!-font-size-19" id="contact-link">

--- a/repos/fdbt-site/src/pages/home.tsx
+++ b/repos/fdbt-site/src/pages/home.tsx
@@ -8,9 +8,10 @@ const description = 'Create Fares Data is a service that allows you to generate 
 
 interface HomeProps {
     multipleOperators: boolean;
+    isOnTestEnvironment: boolean;
 }
 
-const Home = ({ multipleOperators }: HomeProps): ReactElement => (
+const Home = ({ multipleOperators, isOnTestEnvironment }: HomeProps): ReactElement => (
     <BaseLayout title={title} description={description}>
         <h1 className="govuk-heading-xl">Create fares data</h1>
         <div className="govuk-grid-row">
@@ -40,8 +41,12 @@ const Home = ({ multipleOperators }: HomeProps): ReactElement => (
                         For updating the information we use about your services when creating NeTEx data.
                     </p>
 
-                    <a href="/account" className="govuk-link govuk-!-font-size-19" id="account-link">
-                        My account settings
+                    <a
+                        href={isOnTestEnvironment ? '/globalSettings' : '/account'}
+                        className="govuk-link govuk-!-font-size-19"
+                        id="account-link"
+                    >
+                        {isOnTestEnvironment ? 'Open operator settings' : 'My account settings'}
                     </a>
                 </div>
                 <div className="govuk-!-margin-top-7 govuk-!-padding-bottom-7">
@@ -66,7 +71,7 @@ const Home = ({ multipleOperators }: HomeProps): ReactElement => (
 );
 
 export const getServerSideProps = (ctx: NextPageContextWithSession): { props: HomeProps } => ({
-    props: { multipleOperators: checkIfMultipleOperators(ctx) },
+    props: { multipleOperators: checkIfMultipleOperators(ctx), isOnTestEnvironment: process.env.STAGE !== 'prod' },
 });
 
 export default Home;

--- a/repos/fdbt-site/src/pages/index.tsx
+++ b/repos/fdbt-site/src/pages/index.tsx
@@ -18,6 +18,7 @@ const Start = ({ multipleOperators }: StartProps): ReactElement => (
             This service is for creating or accessing NeTEx data for public transport services, excluding rail, in
             England. The service can be used by:
         </p>
+
         <ul className="govuk-list govuk-list--bullet">
             <li>Bus operators running commercial services in England</li>
             <li>Local transport authorities acting on behalf of bus operators</li>
@@ -25,6 +26,7 @@ const Start = ({ multipleOperators }: StartProps): ReactElement => (
         </ul>
 
         <p className="govuk-body">Use this service to:</p>
+
         <ul className="govuk-list govuk-list--bullet">
             <li>Generate fares data in NeTEx format for a new or existing service</li>
             <li>Download your own fares data</li>

--- a/repos/fdbt-site/tests/layout/__snapshots__/AlphaBanner.test.tsx.snap
+++ b/repos/fdbt-site/tests/layout/__snapshots__/AlphaBanner.test.tsx.snap
@@ -2,31 +2,36 @@
 
 exports[`PhaseBanner should render correctly 1`] = `
 <div
-  className="govuk-phase-banner"
+  className="app-phase-banner__wrapper"
 >
-  <p
-    className="govuk-phase-banner__content"
+  <div
+    className="govuk-phase-banner app-phase-banner app-width-container"
   >
-    <strong
-      className="govuk-tag govuk-phase-banner__content__tag"
+    <p
+      className="govuk-phase-banner__content"
     >
-      beta
-    </strong>
-    <span
-      className="govuk-phase-banner__text"
-    >
-      This is a new service – your
-       
-      <a
-        className="govuk-link"
-        href="/feedback"
-        id="feedback-link"
+      <strong
+        className="govuk-tag govuk-phase-banner__content__tag"
       >
-        feedback
-      </a>
-       
-      will help us to improve it.
-    </span>
-  </p>
+        beta
+      </strong>
+      <span
+        className="govuk-phase-banner__text"
+      >
+        This is a new service – your
+         
+        <a
+          className="govuk-link"
+          href="/feedback"
+          id="feedback-link"
+        >
+          feedback
+        </a>
+         
+        will help us to improve it.
+      </span>
+    </p>
+  </div>
 </div>
 `;
+

--- a/repos/fdbt-site/tests/layout/__snapshots__/Header.test.tsx.snap
+++ b/repos/fdbt-site/tests/layout/__snapshots__/Header.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Header should render correctly 1`] = `
   role="banner"
 >
   <div
-    className="govuk-header__container govuk-width-container"
+    className="govuk-header__container app-header__container govuk-width-container"
   >
     <div
       className="govuk-header__logo"

--- a/repos/fdbt-site/tests/layout/__snapshots__/Header.test.tsx.snap
+++ b/repos/fdbt-site/tests/layout/__snapshots__/Header.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Header should render correctly 1`] = `
 <header
-  className="govuk-header "
+  className="govuk-header app-header"
   data-module="govuk-header"
   role="banner"
 >

--- a/repos/fdbt-site/tests/pages/__snapshots__/home.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/home.test.tsx.snap
@@ -59,10 +59,10 @@ exports[`pages home page should render correctly 1`] = `
         </p>
         <a
           className="govuk-link govuk-!-font-size-19"
-          href="/account"
+          href="/globalSettings"
           id="account-link"
         >
-          My account settings
+          Open operator settings
         </a>
       </div>
       <div
@@ -166,10 +166,10 @@ exports[`pages home page should render correctly with no multiple operators 1`] 
         </p>
         <a
           className="govuk-link govuk-!-font-size-19"
-          href="/account"
+          href="/globalSettings"
           id="account-link"
         >
-          My account settings
+          Open operator settings
         </a>
       </div>
       <div

--- a/repos/fdbt-site/tests/pages/home.test.tsx
+++ b/repos/fdbt-site/tests/pages/home.test.tsx
@@ -5,11 +5,11 @@ import Home from '../../src/pages/home';
 describe('pages', () => {
     describe('home page', () => {
         it('should render correctly', () => {
-            const tree = shallow(<Home multipleOperators />);
+            const tree = shallow(<Home multipleOperators isOnTestEnvironment />);
             expect(tree).toMatchSnapshot();
         });
         it('should render correctly with no multiple operators', () => {
-            const tree = shallow(<Home multipleOperators={false} />);
+            const tree = shallow(<Home multipleOperators={false} isOnTestEnvironment={true} />);
             expect(tree).toMatchSnapshot();
         });
     });


### PR DESCRIPTION
# Description

This ticket creates the user interface for the global settings page and also displays a link to "operator settings" on the home page provided it's not hosted on the production environment.

# Testing instructions

Spin the site up and head to http://localhost:5555/globalSettings and check it looks like the ticket says it should

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
