### PR TITLE
fix: cfd 355 passenger page design issues

### DIFF
--- a/repos/fdbt-site/src/design/modules/_cards.scss
+++ b/repos/fdbt-site/src/design/modules/_cards.scss
@@ -1,5 +1,6 @@
 .card {
     &__body {
+        height: 160px;
         background-color: govuk-colour('light-grey');
         padding: govuk-spacing(5) govuk-spacing(5) 10px govuk-spacing(5);
 

--- a/repos/fdbt-site/src/design/modules/_cards.scss
+++ b/repos/fdbt-site/src/design/modules/_cards.scss
@@ -1,6 +1,7 @@
 .card {
     &__body {
-        height: 160px;
+        box-sizing: border-box;
+        height: 225px;
         background-color: govuk-colour('light-grey');
         padding: govuk-spacing(5) govuk-spacing(5) 10px govuk-spacing(5);
 

--- a/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
+++ b/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
@@ -4,8 +4,6 @@ import { PassengerType, NextPageContextWithSession, GroupPassengerType } from '.
 import { getAndValidateNoc, sentenceCaseString } from '../utils';
 import { getPassengerTypesByNocCode } from '../data/auroradb';
 import SubNavigation from '../layout/SubNavigation';
-import { stringify } from 'querystring';
-import { profile } from 'winston';
 
 const title = 'Passenger types';
 const description = 'View and edit your passenger types.';
@@ -221,7 +219,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     return { props: { passengerTypes, passengerTypeGroups } };
 };
 
-const getProofOfDocumentsString = (documents) => {
+const getProofOfDocumentsString = (documents: string[]) => {
     let proofOfDocumentsString = documents.map((document) => sentenceCaseString(document)).join(', ');
 
     proofOfDocumentsString =

--- a/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
+++ b/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
@@ -98,6 +98,11 @@ const IndividualPassengerTypes = ({ passengerTypes }: { passengerTypes: Passenge
                                 </h4>
 
                                 <p className="govuk-body-s govuk-!-margin-bottom-2">
+                                    <span className="govuk-!-font-weight-bold">Passenger type:</span>{' '}
+                                    {sentenceCaseString(passengerType.passengerType)}
+                                </p>
+
+                                <p className="govuk-body-s govuk-!-margin-bottom-2">
                                     <span className="govuk-!-font-weight-bold">Minimum age:</span>{' '}
                                     {passengerType.ageRangeMin ? passengerType.ageRangeMin : 'N/A'}
                                 </p>

--- a/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
+++ b/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
@@ -4,6 +4,8 @@ import { PassengerType, NextPageContextWithSession, GroupPassengerType } from '.
 import { getAndValidateNoc, sentenceCaseString } from '../utils';
 import { getPassengerTypesByNocCode } from '../data/auroradb';
 import SubNavigation from '../layout/SubNavigation';
+import { stringify } from 'querystring';
+import { profile } from 'winston';
 
 const title = 'Passenger types';
 const description = 'View and edit your passenger types.';
@@ -110,7 +112,7 @@ const IndividualPassengerTypes = ({ passengerTypes }: { passengerTypes: Passenge
                                 <p className="govuk-body-s govuk-!-margin-bottom-2">
                                     <span className="govuk-!-font-weight-bold">Proof document(s):</span>{' '}
                                     {passengerType.proofDocuments
-                                        ? passengerType.proofDocuments.map((pd) => sentenceCaseString(pd)).join(', ')
+                                        ? getProofOfDocumentsString(passengerType.proofDocuments)
                                         : 'N/A'}
                                 </p>
                             </div>
@@ -217,6 +219,17 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     const passengerTypeGroups = await getPassengerTypesByNocCode(nationalOperatorCode, 'group');
 
     return { props: { passengerTypes, passengerTypeGroups } };
+};
+
+const getProofOfDocumentsString = (documents) => {
+    let proofOfDocumentsString = documents.map((document) => sentenceCaseString(document)).join(', ');
+
+    proofOfDocumentsString =
+        proofOfDocumentsString.length > 44
+            ? proofOfDocumentsString.substring(0, 44).concat('…')
+            : proofOfDocumentsString;
+
+    return proofOfDocumentsString;
 };
 
 export default ViewPassengerTypes;


### PR DESCRIPTION
# Description
In order to tidy up the passenger page design this ticket has:
- Included underlying passenger type on each card
- Allowed max 2 lines (44 Characters) for proof documents, any more than this and it's truncated with '...' at end of second line
- Every box matches the size of the ones with 2 lines for proof documents

# Testing instructions

-  Define some passenger types (preferably some with all verification documents)
-  Go to http://localhost:5555/viewPassengerTypes and check that all three objectives in the description still hold true

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
