### PR TITLE
feat: CFD-167 remove the bucket lifecycle policy and make linter happy again

### DIFF
--- a/fdbt-aws/cloudformation/service/eu-west-2/s3.yml
+++ b/fdbt-aws/cloudformation/service/eu-west-2/s3.yml
@@ -33,10 +33,6 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
-      LifecycleConfiguration:
-        Rules:
-          - ExpirationInDays: 30
-            Status: Enabled
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:

--- a/repos/fdbt-site/tests/pages/selectSalesOfferPackage.test.tsx
+++ b/repos/fdbt-site/tests/pages/selectSalesOfferPackage.test.tsx
@@ -26,7 +26,6 @@ describe('pages', () => {
         errors: [],
         products: [],
         csrfToken: '',
-        customPriceEnabled: true,
     };
 
     const selectSalesOfferPackagePropsInfoWithError: SelectSalesOfferPackageProps = {
@@ -39,7 +38,6 @@ describe('pages', () => {
         ],
         errors: [{ errorMessage: 'Choose at least one service from the options', id: 'sales-offer-package-error' }],
         csrfToken: '',
-        customPriceEnabled: true,
     };
 
     describe('selectSalesOfferPackage', () => {
@@ -50,7 +48,6 @@ describe('pages', () => {
                     products={[]}
                     errors={selectSalesOfferPackagePropsInfoNoError.errors}
                     csrfToken=""
-                    customPriceEnabled
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -63,7 +60,6 @@ describe('pages', () => {
                     products={[]}
                     errors={selectSalesOfferPackagePropsInfoWithError.errors}
                     csrfToken=""
-                    customPriceEnabled={false}
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -76,7 +72,6 @@ describe('pages', () => {
                     products={[]}
                     errors={selectSalesOfferPackagePropsInfoNoError.errors}
                     csrfToken=""
-                    customPriceEnabled
                 />,
             );
             expect(tree).toMatchSnapshot();


### PR DESCRIPTION
# Description

-   Removed the lifecycle policy on the `fdbt-raw-user-data` S3 bucket.

# Testing instructions

-   In 30 days time, check the bucket to see if files from 30 days ago remain.

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
