### PR TITLE
fix: CFD-361 Fix issue with reloading passenger types with errors in global settings

### DIFF
--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -664,7 +664,7 @@ export const upsertSinglePassengerType = async (
         const updateQuery = `UPDATE passengerType
                              SET contents = ?
                              WHERE name = ? 
-                             AND isGroup  = ?
+                             AND isGroup = ?
                              AND nocCode = ?`;
         const meta = await executeQuery<ResultSetHeader>(updateQuery, [contents, name, false, nocCode]);
         if (meta.affectedRows > 1) {
@@ -690,13 +690,14 @@ export const updateSinglePassengerType = async (noc: string, passengerType: Sing
     try {
         const updateQuery = `UPDATE passengerType
                              SET name = ?, contents = ?
-                             WHERE id = ? AND nocCode = ?`;
+                             WHERE id = ? AND nocCode = ? AND isGroup = ?`;
 
         const meta = await executeQuery<ResultSetHeader>(updateQuery, [
             passengerType.name,
             contents,
             passengerType.id,
             noc,
+            false,
         ]);
 
         if (meta.affectedRows !== 1) {

--- a/repos/fdbt-site/src/pages/api/managePassengerGroup.ts
+++ b/repos/fdbt-site/src/pages/api/managePassengerGroup.ts
@@ -1,4 +1,4 @@
-import { updateGroupPassengerType } from './../../data/auroradb';
+import { updateGroupPassengerType } from '../../data/auroradb';
 import { isArray } from 'lodash';
 import { NextApiResponse } from 'next';
 import { GS_PASSENGER_GROUP_ATTRIBUTE } from '../../constants/attributes';
@@ -9,7 +9,11 @@ import { getAndValidateNoc, redirectTo, redirectToError } from './apiUtils';
 import { checkIntegerIsValid, removeExcessWhiteSpace } from './apiUtils/validator';
 
 export const formatRequestBody = (req: NextApiRequestWithSession): GroupPassengerTypeDb => {
-    const id = req.body.groupId;
+    const id = req.body.groupId && Number(req.body.groupId);
+    if (id && !Number.isInteger(id)) {
+        throw Error(`Received invalid id for passenger group [${req.body.groupId}]`);
+    }
+
     const maxGroupSize = removeExcessWhiteSpace(req.body.maxGroupSize);
     const groupName = removeExcessWhiteSpace(req.body.passengerGroupName);
     const passengerTypeIds: string[] = !req.body.passengerTypes
@@ -35,7 +39,7 @@ export const formatRequestBody = (req: NextApiRequestWithSession): GroupPassenge
     });
 
     return {
-        id,
+        id: id,
         name: groupName,
         groupPassengerType: { name: groupName, maxGroupSize, companions },
     };
@@ -116,7 +120,7 @@ export const collectErrors = async (userInput: GroupPassengerTypeDb, nocCode: st
     // checks to see if the duplicate name exists
     // OR
     // editMode is on and there is only one group with the same name, and it is the one being edited
-    if ((groupNameCheck && !editMode) || (editMode && groupNameCheck && groupNameCheck.id !== Number(userInput.id))) {
+    if ((groupNameCheck && !editMode) || (editMode && groupNameCheck && groupNameCheck.id !== userInput.id)) {
         errors.push({
             errorMessage: 'There is already a group with this name. Choose another',
             id: 'passenger-group-name',

--- a/repos/fdbt-site/src/pages/api/managePassengerGroup.ts
+++ b/repos/fdbt-site/src/pages/api/managePassengerGroup.ts
@@ -39,7 +39,7 @@ export const formatRequestBody = (req: NextApiRequestWithSession): GroupPassenge
     });
 
     return {
-        id: id,
+        id,
         name: groupName,
         groupPassengerType: { name: groupName, maxGroupSize, companions },
     };

--- a/repos/fdbt-site/src/pages/api/managePassengerTypes.ts
+++ b/repos/fdbt-site/src/pages/api/managePassengerTypes.ts
@@ -89,7 +89,7 @@ const formatRequestBody = async (
     const trimmedName = removeExcessWhiteSpace(name);
 
     const passengerType: SinglePassengerType = {
-        id: id,
+        id,
         name: trimmedName,
         passengerType: {
             passengerType: type,

--- a/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
+++ b/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
@@ -1,10 +1,12 @@
 import React, { ReactElement, useState } from 'react';
+import { GS_PASSENGER_GROUP_ATTRIBUTE, MANAGE_PASSENGER_TYPE_ERRORS_ATTRIBUTE } from '../constants/attributes';
 import { BaseLayout } from '../layout/Layout';
 import { SinglePassengerType, NextPageContextWithSession, FullGroupPassengerType } from '../interfaces';
 import { getCsrfToken, getAndValidateNoc, sentenceCaseString } from '../utils';
 import { getGroupPassengerTypesFromGlobalSettings, getPassengerTypesByNocCode } from '../data/auroradb';
 import SubNavigation from '../layout/SubNavigation';
 import DeleteConfirmationPopup from '../components/DeleteConfirmationPopup';
+import { updateSessionAttribute } from '../utils/sessions';
 
 const title = 'Passenger Types - Create Fares Data Service';
 const description = 'View and edit your passenger types.';
@@ -284,6 +286,9 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     const nationalOperatorCode = getAndValidateNoc(ctx);
     const singlePassengerTypes = await getPassengerTypesByNocCode(nationalOperatorCode, 'single');
     const groupPassengerTypes = await getGroupPassengerTypesFromGlobalSettings(nationalOperatorCode);
+
+    updateSessionAttribute(ctx.req, GS_PASSENGER_GROUP_ATTRIBUTE, undefined);
+    updateSessionAttribute(ctx.req, MANAGE_PASSENGER_TYPE_ERRORS_ATTRIBUTE, undefined);
 
     return { props: { csrfToken, singlePassengerTypes: singlePassengerTypes, groupPassengerTypes } };
 };

--- a/repos/fdbt-site/tests/pages/__snapshots__/managePassengerGroup.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/managePassengerGroup.test.tsx.snap
@@ -204,6 +204,7 @@ exports[`pages managePassengerGroup should render correctly after errors are mad
                 </label>
                 <input
                   className="govuk-input govuk-!-width-one-third"
+                  defaultValue=""
                   id="minimum-passengers-1"
                   name="minimumPassengers1"
                 />
@@ -219,36 +220,12 @@ exports[`pages managePassengerGroup should render correctly after errors are mad
                 </label>
                 <input
                   className="govuk-input govuk-!-width-one-third"
+                  defaultValue=""
                   id="maximum-passengers-1"
                   name="maximumPassengers1"
                 />
               </div>
             </div>
-            <input
-              name="Regular Senior-type"
-              type="hidden"
-              value="senior"
-            />
-            <input
-              name="Regular Senior-age-range-min"
-              type="hidden"
-              value=""
-            />
-            <input
-              name="Regular Senior-age-range-max"
-              type="hidden"
-              value=""
-            />
-            <input
-              name="Regular Senior-proof-docs"
-              type="hidden"
-              value="[]"
-            />
-            <input
-              name="Regular Senior-id"
-              type="hidden"
-              value="1"
-            />
             <div
               className="govuk-checkboxes__item"
               key="2"
@@ -294,6 +271,7 @@ exports[`pages managePassengerGroup should render correctly after errors are mad
                 </label>
                 <input
                   className="govuk-input govuk-!-width-one-third"
+                  defaultValue=""
                   id="minimum-passengers-2"
                   name="minimumPassengers2"
                 />
@@ -309,36 +287,12 @@ exports[`pages managePassengerGroup should render correctly after errors are mad
                 </label>
                 <input
                   className="govuk-input govuk-!-width-one-third"
+                  defaultValue=""
                   id="maximum-passengers-2"
                   name="maximumPassengers2"
                 />
               </div>
             </div>
-            <input
-              name="Regular infant-type"
-              type="hidden"
-              value="infant"
-            />
-            <input
-              name="Regular infant-age-range-min"
-              type="hidden"
-              value="1"
-            />
-            <input
-              name="Regular infant-age-range-max"
-              type="hidden"
-              value="3"
-            />
-            <input
-              name="Regular infant-proof-docs"
-              type="hidden"
-              value="[]"
-            />
-            <input
-              name="Regular infant-id"
-              type="hidden"
-              value="2"
-            />
           </div>
         </FormElementWrapper>
       </fieldset>
@@ -541,6 +495,7 @@ exports[`pages managePassengerGroup should render correctly in edit mode 1`] = `
                 </label>
                 <input
                   className="govuk-input govuk-!-width-one-third"
+                  defaultValue=""
                   id="minimum-passengers-1"
                   name="minimumPassengers1"
                 />
@@ -556,36 +511,12 @@ exports[`pages managePassengerGroup should render correctly in edit mode 1`] = `
                 </label>
                 <input
                   className="govuk-input govuk-!-width-one-third"
+                  defaultValue=""
                   id="maximum-passengers-1"
                   name="maximumPassengers1"
                 />
               </div>
             </div>
-            <input
-              name="Regular Senior-type"
-              type="hidden"
-              value="senior"
-            />
-            <input
-              name="Regular Senior-age-range-min"
-              type="hidden"
-              value=""
-            />
-            <input
-              name="Regular Senior-age-range-max"
-              type="hidden"
-              value=""
-            />
-            <input
-              name="Regular Senior-proof-docs"
-              type="hidden"
-              value="[]"
-            />
-            <input
-              name="Regular Senior-id"
-              type="hidden"
-              value="1"
-            />
             <div
               className="govuk-checkboxes__item"
               key="2"
@@ -631,6 +562,7 @@ exports[`pages managePassengerGroup should render correctly in edit mode 1`] = `
                 </label>
                 <input
                   className="govuk-input govuk-!-width-one-third"
+                  defaultValue=""
                   id="minimum-passengers-2"
                   name="minimumPassengers2"
                 />
@@ -646,36 +578,12 @@ exports[`pages managePassengerGroup should render correctly in edit mode 1`] = `
                 </label>
                 <input
                   className="govuk-input govuk-!-width-one-third"
+                  defaultValue=""
                   id="maximum-passengers-2"
                   name="maximumPassengers2"
                 />
               </div>
             </div>
-            <input
-              name="Regular infant-type"
-              type="hidden"
-              value="infant"
-            />
-            <input
-              name="Regular infant-age-range-min"
-              type="hidden"
-              value="1"
-            />
-            <input
-              name="Regular infant-age-range-max"
-              type="hidden"
-              value="3"
-            />
-            <input
-              name="Regular infant-proof-docs"
-              type="hidden"
-              value="[]"
-            />
-            <input
-              name="Regular infant-id"
-              type="hidden"
-              value="2"
-            />
           </div>
         </FormElementWrapper>
       </fieldset>
@@ -929,6 +837,7 @@ exports[`pages managePassengerGroup should render correctly in edit mode with er
                 </label>
                 <input
                   className="govuk-input govuk-!-width-one-third"
+                  defaultValue=""
                   id="minimum-passengers-1"
                   name="minimumPassengers1"
                 />
@@ -944,36 +853,12 @@ exports[`pages managePassengerGroup should render correctly in edit mode with er
                 </label>
                 <input
                   className="govuk-input govuk-!-width-one-third"
+                  defaultValue=""
                   id="maximum-passengers-1"
                   name="maximumPassengers1"
                 />
               </div>
             </div>
-            <input
-              name="Regular Senior-type"
-              type="hidden"
-              value="senior"
-            />
-            <input
-              name="Regular Senior-age-range-min"
-              type="hidden"
-              value=""
-            />
-            <input
-              name="Regular Senior-age-range-max"
-              type="hidden"
-              value=""
-            />
-            <input
-              name="Regular Senior-proof-docs"
-              type="hidden"
-              value="[]"
-            />
-            <input
-              name="Regular Senior-id"
-              type="hidden"
-              value="1"
-            />
             <div
               className="govuk-checkboxes__item"
               key="2"
@@ -1019,6 +904,7 @@ exports[`pages managePassengerGroup should render correctly in edit mode with er
                 </label>
                 <input
                   className="govuk-input govuk-!-width-one-third"
+                  defaultValue=""
                   id="minimum-passengers-2"
                   name="minimumPassengers2"
                 />
@@ -1034,36 +920,12 @@ exports[`pages managePassengerGroup should render correctly in edit mode with er
                 </label>
                 <input
                   className="govuk-input govuk-!-width-one-third"
+                  defaultValue=""
                   id="maximum-passengers-2"
                   name="maximumPassengers2"
                 />
               </div>
             </div>
-            <input
-              name="Regular infant-type"
-              type="hidden"
-              value="infant"
-            />
-            <input
-              name="Regular infant-age-range-min"
-              type="hidden"
-              value="1"
-            />
-            <input
-              name="Regular infant-age-range-max"
-              type="hidden"
-              value="3"
-            />
-            <input
-              name="Regular infant-proof-docs"
-              type="hidden"
-              value="[]"
-            />
-            <input
-              name="Regular infant-id"
-              type="hidden"
-              value="2"
-            />
           </div>
         </FormElementWrapper>
       </fieldset>
@@ -1287,31 +1149,6 @@ exports[`pages managePassengerGroup should render correctly on first opening of 
                 />
               </div>
             </div>
-            <input
-              name="Normal adult-type"
-              type="hidden"
-              value="adult"
-            />
-            <input
-              name="Normal adult-age-range-min"
-              type="hidden"
-              value="18"
-            />
-            <input
-              name="Normal adult-age-range-max"
-              type="hidden"
-              value="75"
-            />
-            <input
-              name="Normal adult-proof-docs"
-              type="hidden"
-              value="[]"
-            />
-            <input
-              name="Normal adult-id"
-              type="hidden"
-              value="1"
-            />
             <div
               className="govuk-checkboxes__item"
               key="2"
@@ -1379,31 +1216,6 @@ exports[`pages managePassengerGroup should render correctly on first opening of 
                 />
               </div>
             </div>
-            <input
-              name="Normal child-type"
-              type="hidden"
-              value="child"
-            />
-            <input
-              name="Normal child-age-range-min"
-              type="hidden"
-              value="5"
-            />
-            <input
-              name="Normal child-age-range-max"
-              type="hidden"
-              value="13"
-            />
-            <input
-              name="Normal child-proof-docs"
-              type="hidden"
-              value="[]"
-            />
-            <input
-              name="Normal child-id"
-              type="hidden"
-              value="2"
-            />
           </div>
         </FormElementWrapper>
       </fieldset>

--- a/repos/fdbt-site/tests/pages/api/managePassengerGroup.test.ts
+++ b/repos/fdbt-site/tests/pages/api/managePassengerGroup.test.ts
@@ -285,7 +285,7 @@ describe('managePassengerGroup', () => {
                 maxGroupSize: '7',
                 name: 'group',
             },
-            id: '2',
+            id: 2,
             name: 'group',
         });
     });
@@ -349,7 +349,7 @@ describe('managePassengerGroup', () => {
                     maxGroupSize: '7',
                     name: 'group',
                 },
-                id: '2',
+                id: 2,
                 name: 'group',
             },
         });

--- a/repos/fdbt-site/tests/pages/managePassengerTypes.test.tsx
+++ b/repos/fdbt-site/tests/pages/managePassengerTypes.test.tsx
@@ -13,9 +13,7 @@ describe('pages', () => {
                 },
             };
 
-            const tree = shallow(
-                <ManagePassengerTypes isInEditMode={false} csrfToken={''} errors={[]} inputs={inputs} />,
-            );
+            const tree = shallow(<ManagePassengerTypes editMode={false} csrfToken={''} errors={[]} inputs={inputs} />);
 
             expect(tree).toMatchSnapshot();
         });
@@ -34,7 +32,7 @@ describe('pages', () => {
             };
 
             const tree = shallow(
-                <ManagePassengerTypes isInEditMode={false} csrfToken={''} errors={errors} inputs={inputs} />,
+                <ManagePassengerTypes editMode={false} csrfToken={''} errors={errors} inputs={inputs} />,
             );
 
             expect(tree).toMatchSnapshot();
@@ -55,7 +53,7 @@ describe('pages', () => {
             };
 
             const tree = shallow(
-                <ManagePassengerTypes isInEditMode={false} csrfToken={''} errors={errors} inputs={inputs} />,
+                <ManagePassengerTypes editMode={false} csrfToken={''} errors={errors} inputs={inputs} />,
             );
 
             expect(tree).toMatchSnapshot();
@@ -73,9 +71,7 @@ describe('pages', () => {
                 },
             };
 
-            const tree = shallow(
-                <ManagePassengerTypes isInEditMode={false} csrfToken={''} errors={[]} inputs={inputs} />,
-            );
+            const tree = shallow(<ManagePassengerTypes editMode={false} csrfToken={''} errors={[]} inputs={inputs} />);
 
             expect(tree).toMatchSnapshot();
         });


### PR DESCRIPTION
# Description

-   Fix issue with reloading passenger types with errors in global settings

# Testing instructions

-   Make sure that when editing / creating passenger types, the errors from previously editing / creating don't come through
-   Repeat for Groups

# Type of change

-   [ ] feat - A new feature
-   [X] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
