### PR TITLE
chore: CFD-365 Make all logs JSON and only alert on errors

### DIFF
--- a/fdbt-aws/cloudformation/service/eu-west-2/fargate.yml
+++ b/fdbt-aws/cloudformation/service/eu-west-2/fargate.yml
@@ -668,7 +668,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref SiteLogGroup
-      FilterPattern: "?ERROR ?Error ?error"
+      FilterPattern: "{ $.level = error }"
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: "FDBT/Site"
@@ -741,7 +741,7 @@ Resources:
         - Fn::ImportValue: !Sub ${Stage}:SlackAlertsTopicArn
       OKActions:
         - Fn::ImportValue: !Sub ${Stage}:SlackAlertsTopicArn
-  
+
   SiteErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:

--- a/repos/fdbt-site/src/pages/api/csvZoneUpload.ts
+++ b/repos/fdbt-site/src/pages/api/csvZoneUpload.ts
@@ -201,6 +201,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
 
                 if (ticketType.name === 'hybrid') {
                     redirectTo(res, '/serviceList?selectAll=false');
+                    return;
                 }
             }
 

--- a/repos/fdbt-site/src/utils/internalLogger.ts
+++ b/repos/fdbt-site/src/utils/internalLogger.ts
@@ -1,0 +1,12 @@
+import winston, { format } from 'winston';
+
+export default winston.createLogger({
+    level: 'info',
+    format: format.combine(
+        format.errors({ stack: true }),
+        format.prettyPrint(),
+        process.env.NODE_ENV === 'production' ? format.json() : format.simple(),
+        format.colorize(),
+    ),
+    transports: [new winston.transports.Console()],
+});

--- a/repos/fdbt-site/src/utils/logger.ts
+++ b/repos/fdbt-site/src/utils/logger.ts
@@ -1,14 +1,4 @@
-import winston, { format } from 'winston';
-
-const logger = winston.createLogger({
-    level: 'info',
-    format: format.combine(
-        format.errors({ stack: true }),
-        format.prettyPrint(),
-        process.env.NODE_ENV === 'production' ? format.json() : format.simple(),
-        format.colorize(),
-    ),
-    transports: [new winston.transports.Console()],
-});
+import logger from './internalLogger';
+import './nextLogger';
 
 export default logger;

--- a/repos/fdbt-site/src/utils/nextLogger.ts
+++ b/repos/fdbt-site/src/utils/nextLogger.ts
@@ -1,0 +1,49 @@
+import logger from './internalLogger';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const nextLogger = require('../../node_modules/next/dist/build/output/log');
+
+const passLogger = (level: string): ((obj: AnyError) => void) => {
+    const logMethod = getLogMethod(level);
+
+    return (obj) => {
+        const message = getMessage(obj);
+
+        return logMethod(message, obj);
+    };
+};
+
+const getLogMethod = (level: string) => {
+    switch (level) {
+        case 'error':
+            return logger.error.bind(logger);
+        case 'warn':
+            return logger.warn.bind(logger);
+        default:
+            return logger.info.bind(logger);
+    }
+};
+
+const getMessage = (obj: AnyError): string => {
+    if (obj instanceof Error) {
+        return obj.stack ?? obj.message;
+    }
+    if (obj.length === 1) {
+        return obj[0];
+    }
+    return obj.toString();
+};
+
+type AnyError = (Error & { [key: string]: unknown }) | string[] | string;
+
+Object.entries(nextLogger).forEach(([key, value]) => {
+    if (typeof value === 'function') {
+        nextLogger[key] = passLogger(key);
+    }
+});
+const consoleMethods: (keyof Console)[] = ['log', 'debug', 'info', 'warn', 'error'];
+
+consoleMethods.forEach((method) => {
+    // eslint-disable-next-line no-console
+    console[method] = passLogger(method);
+});


### PR DESCRIPTION
# Description

-   Make all logs JSON and only alert on errors

# Testing instructions

-   Trigger an error on site - should be alerted
-   All logs in cloudwatch for site should be JSON format with a "level" property

# Type of change

-   [ ] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [X] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
