### PR TITLE
chore: cfd-412 increase lambda throttle alarm threshold

### DIFF
--- a/repos/fdbt-reference-data-service/src/uploaders/serverless.yml
+++ b/repos/fdbt-reference-data-service/src/uploaders/serverless.yml
@@ -140,7 +140,7 @@ functions:
               threshold: 50000
               treatMissingData: notBreaching
             - name: functionThrottles
-              threshold: 1000
+              threshold: 1500
               treatMissingData: notBreaching
             - name: functionErrors
               treatMissingData: notBreaching


### PR DESCRIPTION
# Description

-   Increases the throttle threshold for TxcUploader lambda to prevent alarms

# Testing instructions

-   Trigger the TxcRetriever lambda and ensure a throttle alarm is not triggered

# Type of change

-   [ ] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [x] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
