### PR TITLE
fix: Allow same passenger types in group

### DIFF
--- a/fdbt-dev/data/netexData/flatFareGroup.xml
+++ b/fdbt-dev/data/netexData/flatFareGroup.xml
@@ -224,12 +224,12 @@
                       <GroupTicket id="op:group" version="1.0">
                         <MaximumNumberOfPersons>5</MaximumNumberOfPersons>
                         <companionProfiles>
-                          <CompanionProfile version="1.0" id="op:companion@adult">
+                          <CompanionProfile version="1.0" id="op:companion@adult-0">
                             <UserProfileRef version="1.0" ref="op:adult"/>
                             <MinimumNumberOfPersons>1</MinimumNumberOfPersons>
                             <MaximumNumberOfPersons>2</MaximumNumberOfPersons>
                           </CompanionProfile>
-                          <CompanionProfile version="1.0" id="op:companion@child">
+                          <CompanionProfile version="1.0" id="op:companion@child-1">
                             <UserProfileRef version="1.0" ref="op:child"/>
                             <MinimumNumberOfPersons>1</MinimumNumberOfPersons>
                             <MaximumNumberOfPersons>3</MaximumNumberOfPersons>

--- a/fdbt-dev/data/netexData/periodGeoZoneGroup.xml
+++ b/fdbt-dev/data/netexData/periodGeoZoneGroup.xml
@@ -310,12 +310,12 @@
                       <GroupTicket id="op:group" version="1.0">
                         <MaximumNumberOfPersons>5</MaximumNumberOfPersons>
                         <companionProfiles>
-                          <CompanionProfile version="1.0" id="op:companion@adult">
+                          <CompanionProfile version="1.0" id="op:companion@adult-0">
                             <UserProfileRef version="1.0" ref="op:adult"/>
                             <MinimumNumberOfPersons>1</MinimumNumberOfPersons>
                             <MaximumNumberOfPersons>2</MaximumNumberOfPersons>
                           </CompanionProfile>
-                          <CompanionProfile version="1.0" id="op:companion@child">
+                          <CompanionProfile version="1.0" id="op:companion@child-1">
                             <UserProfileRef version="1.0" ref="op:child"/>
                             <MinimumNumberOfPersons>1</MinimumNumberOfPersons>
                             <MaximumNumberOfPersons>3</MaximumNumberOfPersons>

--- a/fdbt-dev/data/netexData/returnCircularGroup.xml
+++ b/fdbt-dev/data/netexData/returnCircularGroup.xml
@@ -343,12 +343,12 @@
                       <GroupTicket id="op:group" version="1.0">
                         <MaximumNumberOfPersons>5</MaximumNumberOfPersons>
                         <companionProfiles>
-                          <CompanionProfile version="1.0" id="op:companion@adult">
+                          <CompanionProfile version="1.0" id="op:companion@adult-0">
                             <UserProfileRef version="1.0" ref="op:adult"/>
                             <MinimumNumberOfPersons>1</MinimumNumberOfPersons>
                             <MaximumNumberOfPersons>2</MaximumNumberOfPersons>
                           </CompanionProfile>
-                          <CompanionProfile version="1.0" id="op:companion@child">
+                          <CompanionProfile version="1.0" id="op:companion@child-1">
                             <UserProfileRef version="1.0" ref="op:child"/>
                             <MinimumNumberOfPersons>1</MinimumNumberOfPersons>
                             <MaximumNumberOfPersons>3</MaximumNumberOfPersons>

--- a/fdbt-dev/data/netexData/singleGroup.xml
+++ b/fdbt-dev/data/netexData/singleGroup.xml
@@ -548,12 +548,12 @@
                       <GroupTicket id="op:group" version="1.0">
                         <MaximumNumberOfPersons>5</MaximumNumberOfPersons>
                         <companionProfiles>
-                          <CompanionProfile version="1.0" id="op:companion@adult">
+                          <CompanionProfile version="1.0" id="op:companion@adult-0">
                             <UserProfileRef version="1.0" ref="op:adult"/>
                             <MinimumNumberOfPersons>1</MinimumNumberOfPersons>
                             <MaximumNumberOfPersons>2</MaximumNumberOfPersons>
                           </CompanionProfile>
-                          <CompanionProfile version="1.0" id="op:companion@child">
+                          <CompanionProfile version="1.0" id="op:companion@child-1">
                             <UserProfileRef version="1.0" ref="op:child"/>
                             <MinimumNumberOfPersons>1</MinimumNumberOfPersons>
                             <MaximumNumberOfPersons>3</MaximumNumberOfPersons>

--- a/repos/fdbt-netex-output/src/netex-convertor/sharedHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/sharedHelpers.ts
@@ -134,9 +134,9 @@ export const getGroupElement = (groupDefinition: GroupDefinition): NetexObject =
                         $t: groupDefinition.maxPeople,
                     },
                     companionProfiles: {
-                        CompanionProfile: groupDefinition.companions.map(companion => ({
+                        CompanionProfile: groupDefinition.companions.map((companion, index) => ({
                             version: '1.0',
-                            id: `op:companion@${companion.passengerType}`,
+                            id: `op:companion@${companion.passengerType}-${index}`,
                             UserProfileRef: {
                                 version: '1.0',
                                 ref: `op:${companion.passengerType}`,

--- a/repos/fdbt-site/src/pages/api/managePassengerGroup.ts
+++ b/repos/fdbt-site/src/pages/api/managePassengerGroup.ts
@@ -1,4 +1,4 @@
-import { convertToFullPassengerType, updateGroupPassengerType } from '../../data/auroradb';
+import { updateGroupPassengerType } from '../../data/auroradb';
 import { isArray } from 'lodash';
 import { NextApiResponse } from 'next';
 import { GS_PASSENGER_GROUP_ATTRIBUTE } from '../../constants/attributes';
@@ -7,7 +7,6 @@ import { CompanionReference, ErrorInfo, GroupPassengerTypeDb, NextApiRequestWith
 import { updateSessionAttribute } from '../../utils/sessions';
 import { getAndValidateNoc, redirectTo, redirectToError } from './apiUtils';
 import { checkIntegerIsValid, removeExcessWhiteSpace } from './apiUtils/validator';
-import { sentenceCaseString } from '../../utils';
 import logger from '../../utils/logger';
 
 export const formatRequestBody = (req: NextApiRequestWithSession): GroupPassengerTypeDb => {
@@ -137,23 +136,6 @@ export const collectErrors = async (userInput: GroupPassengerTypeDb, nocCode: st
             errorMessage: 'Enter a group name of up to 50 characters',
             id: 'passenger-group-name',
             userInput: userInput.name || '',
-        });
-    }
-
-    // make sure underlying passenger types are not duplicated
-
-    const fullGroupPassengerType = await convertToFullPassengerType(userInput, nocCode);
-
-    const seen = new Set();
-
-    const duplicateName = fullGroupPassengerType.groupPassengerType.companions.find(
-        (item) => seen.size === seen.add(item.passengerType).size,
-    )?.passengerType;
-
-    if (duplicateName) {
-        errors.push({
-            errorMessage: `A group cannot contain multiple "${sentenceCaseString(duplicateName)}" passenger types`,
-            id: 'passenger-group',
         });
     }
 

--- a/repos/fdbt-site/tests/pages/api/managePassengerGroup.test.ts
+++ b/repos/fdbt-site/tests/pages/api/managePassengerGroup.test.ts
@@ -147,7 +147,7 @@ describe('managePassengerGroup', () => {
         });
     });
 
-    it('should return 302 redirect to /managePassengerGroup when group has two of the same passenger types', async () => {
+    it('should return 302 redirect to /viewPassengerTypes when group has two of the same passenger types and allow creation', async () => {
         const writeHeadMock = jest.fn();
 
         getGroupPassengerTypesFromGlobalSettingsSpy.mockResolvedValueOnce([]);
@@ -203,37 +203,31 @@ describe('managePassengerGroup', () => {
         await managePassengerGroup(req, res);
 
         expect(writeHeadMock).toBeCalledWith(302, {
-            Location: '/managePassengerGroup',
+            Location: '/viewPassengerTypes',
         });
 
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, GS_PASSENGER_GROUP_ATTRIBUTE, {
-            errors: [
-                {
-                    errorMessage: 'A group cannot contain multiple "Adult" passenger types',
-                    id: 'passenger-group',
-                },
-            ],
-            inputs: {
-                groupPassengerType: {
-                    companions: [
-                        {
-                            id: 12,
-                            minNumber: '1',
-                            maxNumber: '2',
-                        },
-                        {
-                            id: 43,
-                            minNumber: '1',
-                            maxNumber: '2',
-                        },
-                    ],
-                    maxGroupSize: '5',
-                    name: 'Family5',
-                },
-                id: undefined,
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, GS_PASSENGER_GROUP_ATTRIBUTE, undefined);
+
+        expect(insertGroupPassengerTypeSpy).toBeCalledWith(
+            'TEST',
+            {
+                companions: [
+                    {
+                        id: 12,
+                        maxNumber: '2',
+                        minNumber: '1',
+                    },
+                    {
+                        id: 43,
+                        maxNumber: '2',
+                        minNumber: '1',
+                    },
+                ],
+                maxGroupSize: '5',
                 name: 'Family5',
             },
-        });
+            'Family5',
+        );
     });
 
     it('should return 302 redirect to /managePassengerGroup when there have been correct user inputs but there is a group with the same name', async () => {


### PR DESCRIPTION
# Description

-   Allowing users to enter the same passenger type (e.g. Adult) into the same group, and changing netex repo to allow for this also.

# Testing instructions

-   Ensure UI allows this change, and netex repo supports it.

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
