### PR TITLE
feat: CFD-387 Fare day end as an option for time restrictions

### DIFF
--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -6,7 +6,6 @@ import { FromDb } from '../../shared/matchingJsonTypes';
 import { INTERNAL_NOC } from '../constants';
 import {
     CompanionInfo,
-    FullTimeRestriction,
     GroupPassengerType,
     Operator,
     OperatorGroup,
@@ -20,6 +19,7 @@ import {
     GroupPassengerTypeDb,
     GroupPassengerTypeReference,
     FullGroupPassengerType,
+    DbTimeRestriction,
 } from '../interfaces';
 import logger from '../utils/logger';
 
@@ -593,7 +593,7 @@ export const getOperatorGroupsByNameAndNoc = async (name: string, nocCode: strin
 
 export const insertTimeRestriction = async (
     nocCode: string,
-    timeRestriction: FullTimeRestriction[],
+    timeRestriction: DbTimeRestriction[],
     name: string,
 ): Promise<void> => {
     logger.info('', {
@@ -618,7 +618,7 @@ export const insertTimeRestriction = async (
 export const updateTimeRestriction = async (
     id: number,
     nocCode: string,
-    timeRestriction: FullTimeRestriction[],
+    timeRestriction: DbTimeRestriction[],
     name: string,
 ): Promise<void> => {
     logger.info('', {

--- a/repos/fdbt-site/src/design/modules/_layout.scss
+++ b/repos/fdbt-site/src/design/modules/_layout.scss
@@ -332,7 +332,11 @@ svg:not(:root) {
 
     .govuk-form-group {
         margin-bottom: 0;
-        max-width: 230px;
+    }
+
+    .item {
+        margin-top: auto;
+        margin-left: govuk-spacing(4);
     }
 }
 

--- a/repos/fdbt-site/src/interfaces/index.ts
+++ b/repos/fdbt-site/src/interfaces/index.ts
@@ -15,6 +15,7 @@ import {
     SalesOfferPackage,
     SelectedService,
     TicketType,
+    TimeRestrictionDay,
 } from '../../shared/matchingJsonTypes';
 
 // Session Attributes and Cookies
@@ -252,7 +253,22 @@ export interface ResponseWithLocals extends ServerResponse {
 export interface PremadeTimeRestriction {
     id: number;
     name: string;
-    contents: FullTimeRestriction[];
+    contents: DbTimeRestriction[];
+}
+
+export interface DbTimeBand {
+    startTime: string;
+    endTime: string | { fareDayEnd: boolean };
+}
+
+export interface DbTimeRestriction {
+    day: TimeRestrictionDay;
+    timeBands: DbTimeBand[];
+}
+
+export interface DbTimeInput {
+    timeInput: string | { fareDayEnd: boolean };
+    day: string;
 }
 
 // AWS and Reference Data (e.g. NOC, TNDS, NaPTAN datasets)

--- a/repos/fdbt-site/src/pages/api/apiUtils/index.ts
+++ b/repos/fdbt-site/src/pages/api/apiUtils/index.ts
@@ -65,7 +65,7 @@ export const redirectToError = (
     context: string,
     error: Error,
 ): void => {
-    logger.error(error.toString(), { context, message, error: error.stack?.toString() });
+    logger.error(message, { context, error: error.stack });
     redirectTo(res, '/error');
 };
 

--- a/repos/fdbt-site/src/pages/api/defineTimeRestrictions.ts
+++ b/repos/fdbt-site/src/pages/api/defineTimeRestrictions.ts
@@ -2,7 +2,7 @@ import isArray from 'lodash/isArray';
 import { NextApiResponse } from 'next';
 import { globalSettingsEnabled } from '../../constants/featureFlag';
 import { FULL_TIME_RESTRICTIONS_ATTRIBUTE, TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE } from '../../constants/attributes';
-import { getTimeRestrictionByNameAndNoc } from '../../data/auroradb';
+import { getTimeRestrictionByNameAndNoc, getFareDayEnd } from '../../data/auroradb';
 import { NextApiRequestWithSession, TimeRestriction, TimeRestrictionsDefinitionWithErrors } from '../../interfaces';
 import { updateSessionAttribute } from '../../utils/sessions';
 import { getAndValidateNoc, redirectTo, redirectToError } from './apiUtils/index';
@@ -51,8 +51,31 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                 );
             }
 
+            const fareDayEnd = await getFareDayEnd(noc);
+
+            const timeRestrictions = results[0].contents.map((timeRestriction) => ({
+                ...timeRestriction,
+                timeBands: timeRestriction.timeBands.map((timeBand) => {
+                    let endTime: string;
+                    if (typeof timeBand.endTime === 'string') {
+                        endTime = timeBand.endTime;
+                    } else {
+                        if (!fareDayEnd) {
+                            throw new Error('No fare day end set for time restriction');
+                        }
+
+                        endTime = fareDayEnd;
+                    }
+
+                    return {
+                        ...timeBand,
+                        endTime: endTime,
+                    };
+                }),
+            }));
+
             updateSessionAttribute(req, FULL_TIME_RESTRICTIONS_ATTRIBUTE, {
-                fullTimeRestrictions: results[0].contents,
+                fullTimeRestrictions: timeRestrictions,
                 errors: [],
             });
 

--- a/repos/fdbt-site/src/pages/api/manageFareDayEnd.ts
+++ b/repos/fdbt-site/src/pages/api/manageFareDayEnd.ts
@@ -9,11 +9,9 @@ import { fareDayEndInputId } from '../manageFareDayEnd';
 
 export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
     try {
-        const deleting = req.query.delete;
+        const fareDayEnd = removeExcessWhiteSpace(req.body.fareDayEnd);
 
-        const fareDayEnd = deleting ? '' : removeExcessWhiteSpace(req.body.fareDayEnd);
-
-        if (isValid24hrTimeFormat(fareDayEnd) || deleting) {
+        if (isValid24hrTimeFormat(fareDayEnd)) {
             const noc = getAndValidateNoc(req, res);
             await upsertFareDayEnd(noc, fareDayEnd);
 

--- a/repos/fdbt-site/src/pages/api/manageTimeRestriction.ts
+++ b/repos/fdbt-site/src/pages/api/manageTimeRestriction.ts
@@ -2,43 +2,46 @@ import isArray from 'lodash/isArray';
 import { NextApiResponse } from 'next';
 import { TimeRestrictionDay } from 'shared/matchingJsonTypes';
 import { GS_TIME_RESTRICTION_ATTRIBUTE } from '../../constants/attributes';
-import { getTimeRestrictionByNameAndNoc, insertTimeRestriction, updateTimeRestriction } from '../../data/auroradb';
-import { ErrorInfo, FullTimeRestriction, NextApiRequestWithSession, TimeBand } from '../../interfaces';
+import {
+    getTimeRestrictionByNameAndNoc,
+    insertTimeRestriction,
+    updateTimeRestriction,
+    getFareDayEnd,
+} from '../../data/auroradb';
+import { ErrorInfo, NextApiRequestWithSession, DbTimeRestriction, DbTimeBand } from '../../interfaces';
 import { updateSessionAttribute } from '../../utils/sessions';
 import { getAndValidateNoc, redirectTo, redirectToError } from './apiUtils';
 import { isValid24hrTimeFormat, removeAllWhiteSpace, removeExcessWhiteSpace } from './apiUtils/validator';
+import { toArray } from '../../utils';
 
 export const collectInputsFromRequest = (
     req: NextApiRequestWithSession,
     timeRestrictionDays: TimeRestrictionDay[],
-): FullTimeRestriction[] =>
+): DbTimeRestriction[] =>
     timeRestrictionDays.map((day) => {
-        const startTimeInputs = req.body[`startTime${day}`];
-        const endTimeInputs = req.body[`endTime${day}`];
-        if (isArray(startTimeInputs) && isArray(endTimeInputs)) {
-            const timeBands = startTimeInputs.map((startTime, index) => ({
-                startTime: removeAllWhiteSpace(startTime),
-                endTime: removeAllWhiteSpace(endTimeInputs[index]),
-            }));
+        const startTimeInputs = toArray(req.body[`startTime${day}`]);
+        const endTimeInputs = toArray(req.body[`endTime${day}`]);
+        const fareDayEnd = !!req.body[`fareDayEnd${day}`];
 
-            return {
-                day,
-                timeBands,
-            };
-        } else {
-            return {
-                day,
-                timeBands: [
-                    {
-                        startTime: removeAllWhiteSpace(startTimeInputs),
-                        endTime: removeAllWhiteSpace(endTimeInputs),
-                    },
-                ],
-            };
-        }
+        const timeBands = startTimeInputs.map((startTime, index) => ({
+            startTime: removeAllWhiteSpace(startTime),
+            endTime:
+                fareDayEnd && index === startTimeInputs.length - 1
+                    ? { fareDayEnd: true }
+                    : removeAllWhiteSpace(endTimeInputs[index]),
+        }));
+
+        return {
+            day,
+            timeBands,
+        };
     });
 
-export const collectErrors = (refinedName: string, fullTimeRestrictions: FullTimeRestriction[]): ErrorInfo[] => {
+export const collectErrors = (
+    refinedName: string,
+    fullTimeRestrictions: DbTimeRestriction[],
+    fareDayEnd: string | undefined,
+): ErrorInfo[] => {
     const errors: ErrorInfo[] = [];
 
     if (!refinedName) {
@@ -71,7 +74,7 @@ export const collectErrors = (refinedName: string, fullTimeRestrictions: FullTim
                 }
             }
 
-            if (timeBand.endTime && !isValid24hrTimeFormat(timeBand.endTime)) {
+            if (typeof timeBand.endTime === 'string' && timeBand.endTime && !isValid24hrTimeFormat(timeBand.endTime)) {
                 if (timeBand.endTime === '2400') {
                     errors.push({
                         errorMessage: '2400 is not a valid input. Use 0000.',
@@ -89,6 +92,7 @@ export const collectErrors = (refinedName: string, fullTimeRestrictions: FullTim
 
             if (
                 isValid24hrTimeFormat(timeBand.startTime) &&
+                typeof timeBand.endTime === 'string' &&
                 isValid24hrTimeFormat(timeBand.endTime) &&
                 timeBand.startTime === timeBand.endTime
             ) {
@@ -106,20 +110,27 @@ export const collectErrors = (refinedName: string, fullTimeRestrictions: FullTim
                     userInput: '',
                 });
             }
+
+            if (typeof timeBand.endTime === 'object' && !fareDayEnd) {
+                errors.push({
+                    errorMessage: 'You do not have a fare day end time defined.',
+                    id: `end-time-${fullTimeRestriction.day}-${index}`,
+                });
+            }
         });
     });
 
     return errors;
 };
 
-export const removeDuplicateAndEmptyTimebands = (fullTimeRestrictions: FullTimeRestriction[]): FullTimeRestriction[] =>
+export const removeDuplicateAndEmptyTimebands = (fullTimeRestrictions: DbTimeRestriction[]): DbTimeRestriction[] =>
     fullTimeRestrictions.map((fullTimeRestriction) => {
-        const timeBands: TimeBand[] = fullTimeRestriction.timeBands.reduce((unique, o) => {
+        const timeBands: DbTimeBand[] = fullTimeRestriction.timeBands.reduce((unique, o) => {
             if (!unique.some((obj) => obj.startTime === o.startTime && obj.endTime === o.endTime)) {
                 unique.push(o);
             }
             return unique;
-        }, [] as TimeBand[]);
+        }, [] as DbTimeBand[]);
 
         const filteredTimeBands = timeBands.filter((timeBand) => timeBand.startTime || timeBand.endTime);
 
@@ -143,8 +154,8 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
         const id = req.body.id && Number(req.body.id);
         const inputs = collectInputsFromRequest(req, timeRestrictionDaysArray);
         const sanitisedInputs = removeDuplicateAndEmptyTimebands(inputs);
-        const errors = collectErrors(refinedName, sanitisedInputs);
         const noc = getAndValidateNoc(req, res);
+        const errors = collectErrors(refinedName, sanitisedInputs, await getFareDayEnd(noc));
 
         if (errors.length === 0) {
             const results = await getTimeRestrictionByNameAndNoc(refinedName, noc);

--- a/repos/fdbt-site/src/pages/api/register.ts
+++ b/repos/fdbt-site/src/pages/api/register.ts
@@ -105,10 +105,16 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                 throw new Error(`unexpected challenge: ${ChallengeName}`);
             }
         } catch (error) {
-            logger.error(error, {
+            const meta = {
                 context: 'api.register',
                 message: 'registration failed',
-            });
+            };
+
+            if (error.name === 'NotAuthorizedException') {
+                logger.warn(error, meta);
+            } else {
+                logger.error(error, meta);
+            }
 
             inputChecks.push({
                 userInput: '',

--- a/repos/fdbt-site/src/pages/manageFareDayEnd.tsx
+++ b/repos/fdbt-site/src/pages/manageFareDayEnd.tsx
@@ -69,18 +69,10 @@ const ManageFareDayEnd = ({ errors, csrfToken, fareDayEnd, referer, saved }: Man
                                 </fieldset>
                             </FormGroupWrapper>
                             <input type="submit" value={`Save`} className="govuk-button" />
-                            <button
-                                className="govuk-button govuk-button--warning govuk-!-margin-left-4"
-                                formAction={`/api/manageFareDayEnd?delete=true&_csrf=${csrfToken}`}
-                                formMethod="post"
-                                type="submit"
-                            >
-                                Delete
-                            </button>
                             {showSaved && (
                                 <InfoPopup
                                     title="Success"
-                                    text={`You have ${fareDayEnd ? 'saved' : 'reset'} your fare day end time.`}
+                                    text={`You have saved your fare day end time.`}
                                     okActionHandler={() => setShowSaved(false)}
                                 />
                             )}

--- a/repos/fdbt-site/src/pages/viewTimeRestrictions.tsx
+++ b/repos/fdbt-site/src/pages/viewTimeRestrictions.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, ReactElement } from 'react';
 import { GlobalSettingsViewPage } from '../components/GlobalSettingsViewPage';
 import { getTimeRestrictionByNocCode } from '../data/auroradb';
-import { NextPageContextWithSession, PremadeTimeRestriction, TimeBand } from '../interfaces';
+import { NextPageContextWithSession, PremadeTimeRestriction, DbTimeBand } from '../interfaces';
 import { getAndValidateNoc, getCsrfToken } from '../utils';
 import { extractGlobalSettingsReferer } from '../utils/globalSettings';
 
@@ -25,12 +25,13 @@ interface TimeRestrictionProps {
     referer: string | null;
 }
 
-const formatTime = (time: string): string => (time ? `${time.substring(0, 2)}:${time.substring(2, 4)}` : '');
+const formatTime = (time: string | object): string =>
+    typeof time === 'object' ? 'Fare day end' : time ? `${time.substring(0, 2)}:${time.substring(2, 4)}` : '';
 
-const formatTimeBand = (timeBand: TimeBand): string =>
+const formatTimeBand = (timeBand: DbTimeBand): string =>
     `${formatTime(timeBand.startTime)}–${formatTime(timeBand.endTime)}`;
 
-const formatTimeBands = (timeBands: TimeBand[]): string =>
+const formatTimeBands = (timeBands: DbTimeBand[]): string =>
     timeBands.length > 0 ? timeBands.map((timeBand) => formatTimeBand(timeBand)).join(', ') : 'Valid all day';
 
 const formatDayRestriction = (timeRestriction: PremadeTimeRestriction, day: string): JSX.Element => {

--- a/repos/fdbt-site/src/utils/index.ts
+++ b/repos/fdbt-site/src/utils/index.ts
@@ -214,7 +214,7 @@ export const getCsrfToken = (ctx: DocumentContextWithSession | NextPageContextWi
     (ctx.res as ResponseWithLocals)?.locals?.csrfToken ?? '';
 
 export const toArray = (thing: string | string[] | undefined): string[] => {
-    if (!thing) {
+    if (thing === undefined) {
         return [];
     }
 

--- a/repos/fdbt-site/src/utils/nextLogger.ts
+++ b/repos/fdbt-site/src/utils/nextLogger.ts
@@ -1,10 +1,14 @@
 import logger from './internalLogger';
 
-const passLogger = (level: string): ((obj: AnyError) => void) => {
+const passLogger = (level: string): ((...obj: AnyError[]) => void) => {
     const logMethod = getLogMethod(level);
 
-    return (obj) => {
-        const message = getMessage(obj);
+    return (first: AnyError, ...obj: AnyError[]) => {
+        let message = getMessage(first);
+        if (typeof obj[0] === 'string') {
+            message += ' ' + obj[0];
+            obj.splice(0);
+        }
 
         return logMethod(message, obj);
     };
@@ -28,7 +32,7 @@ const getMessage = (obj: AnyError): string => {
     if (obj.length === 1) {
         return obj[0];
     }
-    return obj.toString();
+    return typeof obj === 'string' ? obj : JSON.stringify(obj);
 };
 
 type AnyError = (Error & { [key: string]: unknown }) | string[] | string;

--- a/repos/fdbt-site/tests/pages/__snapshots__/manageFareDayEnd.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/manageFareDayEnd.test.tsx.snap
@@ -77,14 +77,6 @@ exports[`pages manage passenger types should render correctly 1`] = `
             type="submit"
             value="Save"
           />
-          <button
-            className="govuk-button govuk-button--warning govuk-!-margin-left-4"
-            formAction="/api/manageFareDayEnd?delete=true&_csrf="
-            formMethod="post"
-            type="submit"
-          >
-            Delete
-          </button>
         </CsrfForm>
       </div>
     </div>
@@ -190,14 +182,6 @@ exports[`pages manage passenger types should render error state if error 1`] = `
             type="submit"
             value="Save"
           />
-          <button
-            className="govuk-button govuk-button--warning govuk-!-margin-left-4"
-            formAction="/api/manageFareDayEnd?delete=true&_csrf="
-            formMethod="post"
-            type="submit"
-          >
-            Delete
-          </button>
         </CsrfForm>
       </div>
     </div>
@@ -282,14 +266,6 @@ exports[`pages manage passenger types should render popup if saved 1`] = `
             type="submit"
             value="Save"
           />
-          <button
-            className="govuk-button govuk-button--warning govuk-!-margin-left-4"
-            formAction="/api/manageFareDayEnd?delete=true&_csrf="
-            formMethod="post"
-            type="submit"
-          >
-            Delete
-          </button>
           <InfoPopup
             okActionHandler={[Function]}
             text="You have saved your fare day end time."

--- a/repos/fdbt-site/tests/pages/__snapshots__/manageTimeRestriction.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/manageTimeRestriction.test.tsx.snap
@@ -141,23 +141,51 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-monday-0"
                             name="endTimemonday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndmonday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-monday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -239,23 +267,51 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-tuesday-0"
                             name="endTimetuesday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndtuesday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-tuesday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -337,23 +393,51 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-wednesday-0"
                             name="endTimewednesday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndwednesday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-wednesday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -435,23 +519,51 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-thursday-0"
                             name="endTimethursday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndthursday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-thursday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -533,23 +645,51 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-friday-0"
                             name="endTimefriday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndfriday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-friday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -631,23 +771,51 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-saturday-0"
                             name="endTimesaturday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndsaturday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-saturday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -729,23 +897,51 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-sunday-0"
                             name="endTimesunday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndsunday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-sunday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -827,23 +1023,51 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-bankHoliday-0"
                             name="endTimebankHoliday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndbankHoliday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-bankHoliday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
           </div>
@@ -1126,23 +1350,51 @@ exports[`pages manage time restriction should render error state on day restrict
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue="2300"
+                            disabled={false}
                             id="end-time-monday-0"
                             name="endTimemonday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndmonday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-monday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -1229,23 +1481,51 @@ exports[`pages manage time restriction should render error state on day restrict
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-input--error"
                             defaultValue="2400"
+                            disabled={false}
                             id="end-time-tuesday-0"
                             name="endTimetuesday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndtuesday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-tuesday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -1332,23 +1612,51 @@ exports[`pages manage time restriction should render error state on day restrict
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue="1200"
+                            disabled={false}
                             id="end-time-wednesday-0"
                             name="endTimewednesday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndwednesday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-wednesday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -1435,23 +1743,51 @@ exports[`pages manage time restriction should render error state on day restrict
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-thursday-0"
                             name="endTimethursday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndthursday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-thursday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -1533,23 +1869,51 @@ exports[`pages manage time restriction should render error state on day restrict
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-friday-0"
                             name="endTimefriday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndfriday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-friday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -1631,23 +1995,51 @@ exports[`pages manage time restriction should render error state on day restrict
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-saturday-0"
                             name="endTimesaturday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndsaturday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-saturday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -1729,23 +2121,51 @@ exports[`pages manage time restriction should render error state on day restrict
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-sunday-0"
                             name="endTimesunday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndsunday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-sunday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -1827,23 +2247,51 @@ exports[`pages manage time restriction should render error state on day restrict
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-bankHoliday-0"
                             name="endTimebankHoliday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndbankHoliday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-bankHoliday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
           </div>
@@ -2086,23 +2534,51 @@ exports[`pages manage time restriction should render error state on name form gr
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue="2300"
+                            disabled={false}
                             id="end-time-monday-0"
                             name="endTimemonday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndmonday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-monday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -2184,23 +2660,51 @@ exports[`pages manage time restriction should render error state on name form gr
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-tuesday-0"
                             name="endTimetuesday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndtuesday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-tuesday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -2282,23 +2786,51 @@ exports[`pages manage time restriction should render error state on name form gr
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-wednesday-0"
                             name="endTimewednesday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndwednesday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-wednesday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -2380,23 +2912,51 @@ exports[`pages manage time restriction should render error state on name form gr
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-thursday-0"
                             name="endTimethursday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndthursday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-thursday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -2478,23 +3038,51 @@ exports[`pages manage time restriction should render error state on name form gr
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-friday-0"
                             name="endTimefriday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndfriday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-friday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -2576,23 +3164,51 @@ exports[`pages manage time restriction should render error state on name form gr
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-saturday-0"
                             name="endTimesaturday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndsaturday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-saturday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -2674,23 +3290,51 @@ exports[`pages manage time restriction should render error state on name form gr
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-sunday-0"
                             name="endTimesunday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndsunday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-sunday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -2772,23 +3416,51 @@ exports[`pages manage time restriction should render error state on name form gr
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-bankHoliday-0"
                             name="endTimebankHoliday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndbankHoliday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-bankHoliday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
           </div>
@@ -3010,23 +3682,51 @@ exports[`pages manage time restriction should render error state on time restric
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-monday-0"
                             name="endTimemonday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndmonday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-monday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -3108,23 +3808,51 @@ exports[`pages manage time restriction should render error state on time restric
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-tuesday-0"
                             name="endTimetuesday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndtuesday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-tuesday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -3206,23 +3934,51 @@ exports[`pages manage time restriction should render error state on time restric
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-wednesday-0"
                             name="endTimewednesday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndwednesday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-wednesday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -3304,23 +4060,51 @@ exports[`pages manage time restriction should render error state on time restric
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-thursday-0"
                             name="endTimethursday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndthursday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-thursday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -3402,23 +4186,51 @@ exports[`pages manage time restriction should render error state on time restric
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-friday-0"
                             name="endTimefriday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndfriday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-friday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -3500,23 +4312,51 @@ exports[`pages manage time restriction should render error state on time restric
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-saturday-0"
                             name="endTimesaturday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndsaturday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-saturday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -3598,23 +4438,51 @@ exports[`pages manage time restriction should render error state on time restric
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-sunday-0"
                             name="endTimesunday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndsunday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-sunday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
             <div
@@ -3696,23 +4564,51 @@ exports[`pages manage time restriction should render error state on time restric
                             aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
+                            disabled={false}
                             id="end-time-bankHoliday-0"
                             name="endTimebankHoliday"
                             type="text"
                           />
                         </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndbankHoliday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
                   <button
-                    className="govuk-button govuk-button--secondary govuk-!-margin-left-3 time-restrictions-button-placement"
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
                     id="add-another-button-bankHoliday"
                     onClick={[Function]}
                     type="button"
                   >
                     Add another
                   </button>
-                </fieldset>
+                </div>
               </div>
             </div>
           </div>
@@ -3747,6 +4643,1320 @@ exports[`pages manage time restriction should render error state on time restric
             Object {
               "errorMessage": "You must select at least one day.",
               "id": "time-restriction-days",
+            },
+          ]
+        }
+      >
+        <input
+          className="govuk-input govuk-input--width-30 govuk-product-name-input__inner__input"
+          defaultValue="test"
+          id="time-restriction-name"
+          maxLength={50}
+          name="timeRestrictionName"
+          type="text"
+        />
+      </FormElementWrapper>
+    </div>
+    <input
+      className="govuk-button"
+      id="continue-button"
+      type="submit"
+      value="Update time restriction"
+    />
+  </CsrfForm>
+</TwoThirdsLayout>
+`;
+
+exports[`pages manage time restriction should render with fare day end selections 1`] = `
+<TwoThirdsLayout
+  description="Manage Time Restrictions page of the Create Fares Data Service"
+  errors={
+    Array [
+      Object {
+        "errorMessage": "Start time is required if end time is provided",
+        "id": "start-time-monday-0",
+        "userInput": "",
+      },
+      Object {
+        "errorMessage": "2400 is not a valid input. Use 0000.",
+        "id": "end-time-tuesday-0",
+        "userInput": "2400",
+      },
+      Object {
+        "errorMessage": "Start time and end time cannot be the same",
+        "id": "start-time-wednesday-0",
+        "userInput": "1200",
+      },
+      Object {
+        "errorMessage": "Start time and end time cannot be the same",
+        "id": "end-time-wednesday-0",
+        "userInput": "1200",
+      },
+      Object {
+        "errorMessage": "Time must be in 24hr format",
+        "id": "start-time-thursday-0",
+        "userInput": "-1",
+      },
+    ]
+  }
+  title="Manage Time Restrictions - Create Fares Data Service"
+>
+  <CsrfForm
+    action="/api/manageTimeRestriction"
+    csrfToken=""
+    method="post"
+  >
+    <ErrorSummary
+      errors={
+        Array [
+          Object {
+            "errorMessage": "Start time is required if end time is provided",
+            "id": "start-time-monday-0",
+            "userInput": "",
+          },
+          Object {
+            "errorMessage": "2400 is not a valid input. Use 0000.",
+            "id": "end-time-tuesday-0",
+            "userInput": "2400",
+          },
+          Object {
+            "errorMessage": "Start time and end time cannot be the same",
+            "id": "start-time-wednesday-0",
+            "userInput": "1200",
+          },
+          Object {
+            "errorMessage": "Start time and end time cannot be the same",
+            "id": "end-time-wednesday-0",
+            "userInput": "1200",
+          },
+          Object {
+            "errorMessage": "Time must be in 24hr format",
+            "id": "start-time-thursday-0",
+            "userInput": "-1",
+          },
+        ]
+      }
+    />
+    <h1
+      className="govuk-heading-l"
+      id="manage-time-restriction-page-heading"
+    >
+      Provide time restriction details
+    </h1>
+    <span
+      className="govuk-hint"
+      id="manage-time-restriction-hint"
+    >
+      Select the days of the week that the tickets are valid for. If applicable, enter the times at which your tickets start and end. If they are valid at all times, select the day and leave the time blank. You cannot enter an end time without a start time.
+    </span>
+    <div
+      className="govuk-inset-text"
+      id="manage-time-restriction-inset-hint"
+    >
+      Enter times in 24hr format. For example 0900 is 9am, 1730 is 5:30pm.
+    </div>
+    <div
+      className="govuk-form-group"
+    >
+      <fieldset
+        aria-describedby="time-restriction-heading"
+        className="govuk-fieldset"
+      >
+        <legend
+          className="govuk-fieldset__legend govuk-fieldset__legend--m"
+        >
+          <h1
+            className="govuk-fieldset__heading"
+            id="time-restriction-heading"
+          >
+            Select the days of the week that are applicable
+          </h1>
+        </legend>
+        <input
+          name="id"
+          type="hidden"
+          value={0}
+        />
+        <FormElementWrapper
+          errorClass="govuk-checkboxes--error"
+          errorId="time-restriction-days"
+          errors={
+            Array [
+              Object {
+                "errorMessage": "Start time is required if end time is provided",
+                "id": "start-time-monday-0",
+                "userInput": "",
+              },
+              Object {
+                "errorMessage": "2400 is not a valid input. Use 0000.",
+                "id": "end-time-tuesday-0",
+                "userInput": "2400",
+              },
+              Object {
+                "errorMessage": "Start time and end time cannot be the same",
+                "id": "start-time-wednesday-0",
+                "userInput": "1200",
+              },
+              Object {
+                "errorMessage": "Start time and end time cannot be the same",
+                "id": "end-time-wednesday-0",
+                "userInput": "1200",
+              },
+              Object {
+                "errorMessage": "Time must be in 24hr format",
+                "id": "start-time-thursday-0",
+                "userInput": "-1",
+              },
+            ]
+          }
+        >
+          <div
+            className="govuk-checkboxes"
+            data-module="govuk-checkboxes"
+          >
+            <div
+              key="monday"
+            >
+              <div
+                className="govuk-checkboxes__item"
+                key="monday"
+              >
+                <input
+                  className="govuk-checkboxes__input"
+                  data-aria-controls="conditional-input-0"
+                  defaultChecked={true}
+                  id="time-restriction-day-0"
+                  name="timeRestrictionDays"
+                  type="checkbox"
+                  value="monday"
+                />
+                <label
+                  className="govuk-label govuk-checkboxes__label"
+                  htmlFor="time-restriction-day-0"
+                >
+                  Monday
+                </label>
+              </div>
+              <div
+                className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                id="conditional-input-0"
+              >
+                <fieldset
+                  className="govuk-fieldset flex-container time-restrictions-table"
+                >
+                  <div
+                    className="govuk-form-group govuk-form-group--error"
+                  >
+                    <div
+                      className="global-settings-time-restriction-row"
+                      key="0"
+                    >
+                      <p
+                        className="govuk-error-message"
+                      >
+                        Start time is required if end time is provided
+                      </p>
+                      <div
+                        className="govuk-form-group"
+                      >
+                        <div>
+                          <label
+                            className="govuk-label"
+                            htmlFor="start-time-monday-0"
+                          >
+                            Start time 
+                            <span
+                              className="govuk-visually-hidden"
+                            >
+                              for 
+                              monday
+                            </span>
+                          </label>
+                          <input
+                            aria-describedby="time-restrictions-hint"
+                            className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 govuk-input--error"
+                            defaultValue="1111"
+                            id="start-time-monday-0"
+                            name="startTimemonday"
+                            type="text"
+                          />
+                        </div>
+                        <div>
+                          <label
+                            className="govuk-label"
+                            htmlFor="end-time-monday-0"
+                          >
+                            End time 
+                            <span
+                              className="govuk-visually-hidden"
+                            >
+                              for 
+                              monday
+                            </span>
+                          </label>
+                          <input
+                            aria-describedby="time-restrictions-hint"
+                            className="govuk-input govuk-input--width-5 false"
+                            defaultValue="2300"
+                            disabled={false}
+                            id="end-time-monday-0"
+                            name="endTimemonday"
+                            type="text"
+                          />
+                        </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndmonday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
+                  <button
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
+                    id="add-another-button-monday"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Add another
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              key="tuesday"
+            >
+              <div
+                className="govuk-checkboxes__item"
+                key="tuesday"
+              >
+                <input
+                  className="govuk-checkboxes__input"
+                  data-aria-controls="conditional-input-1"
+                  defaultChecked={true}
+                  id="time-restriction-day-1"
+                  name="timeRestrictionDays"
+                  type="checkbox"
+                  value="tuesday"
+                />
+                <label
+                  className="govuk-label govuk-checkboxes__label"
+                  htmlFor="time-restriction-day-1"
+                >
+                  Tuesday
+                </label>
+              </div>
+              <div
+                className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                id="conditional-input-1"
+              >
+                <fieldset
+                  className="govuk-fieldset flex-container time-restrictions-table"
+                >
+                  <div
+                    className="govuk-form-group govuk-form-group--error"
+                  >
+                    <div
+                      className="global-settings-time-restriction-row"
+                      key="0"
+                    >
+                      <p
+                        className="govuk-error-message"
+                      >
+                        2400 is not a valid input. Use 0000.
+                      </p>
+                      <div
+                        className="govuk-form-group"
+                      >
+                        <div>
+                          <label
+                            className="govuk-label"
+                            htmlFor="start-time-tuesday-0"
+                          >
+                            Start time 
+                            <span
+                              className="govuk-visually-hidden"
+                            >
+                              for 
+                              tuesday
+                            </span>
+                          </label>
+                          <input
+                            aria-describedby="time-restrictions-hint"
+                            className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
+                            defaultValue="0100"
+                            id="start-time-tuesday-0"
+                            name="startTimetuesday"
+                            type="text"
+                          />
+                        </div>
+                        <div>
+                          <label
+                            className="govuk-label"
+                            htmlFor="end-time-tuesday-0"
+                          >
+                            End time 
+                            <span
+                              className="govuk-visually-hidden"
+                            >
+                              for 
+                              tuesday
+                            </span>
+                          </label>
+                          <input
+                            aria-describedby="time-restrictions-hint"
+                            className="govuk-input govuk-input--width-5 govuk-input--error"
+                            defaultValue="1234"
+                            disabled={true}
+                            id="end-time-tuesday-0"
+                            name="endTimetuesday"
+                            type="text"
+                          />
+                        </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={true}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndtuesday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
+                  <button
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
+                    id="add-another-button-tuesday"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Add another
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              key="wednesday"
+            >
+              <div
+                className="govuk-checkboxes__item"
+                key="wednesday"
+              >
+                <input
+                  className="govuk-checkboxes__input"
+                  data-aria-controls="conditional-input-2"
+                  defaultChecked={true}
+                  id="time-restriction-day-2"
+                  name="timeRestrictionDays"
+                  type="checkbox"
+                  value="wednesday"
+                />
+                <label
+                  className="govuk-label govuk-checkboxes__label"
+                  htmlFor="time-restriction-day-2"
+                >
+                  Wednesday
+                </label>
+              </div>
+              <div
+                className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                id="conditional-input-2"
+              >
+                <fieldset
+                  className="govuk-fieldset flex-container time-restrictions-table"
+                >
+                  <div
+                    className="govuk-form-group govuk-form-group--error"
+                  >
+                    <div
+                      className="global-settings-time-restriction-row"
+                      key="0"
+                    >
+                      <p
+                        className="govuk-error-message"
+                      >
+                        Start time and end time cannot be the same
+                      </p>
+                      <div
+                        className="govuk-form-group"
+                      >
+                        <div>
+                          <label
+                            className="govuk-label"
+                            htmlFor="start-time-wednesday-0"
+                          >
+                            Start time 
+                            <span
+                              className="govuk-visually-hidden"
+                            >
+                              for 
+                              wednesday
+                            </span>
+                          </label>
+                          <input
+                            aria-describedby="time-restrictions-hint"
+                            className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 govuk-input--error"
+                            defaultValue="1200"
+                            id="start-time-wednesday-0"
+                            name="startTimewednesday"
+                            type="text"
+                          />
+                        </div>
+                        <div>
+                          <label
+                            className="govuk-label"
+                            htmlFor="end-time-wednesday-0"
+                          >
+                            End time 
+                            <span
+                              className="govuk-visually-hidden"
+                            >
+                              for 
+                              wednesday
+                            </span>
+                          </label>
+                          <input
+                            aria-describedby="time-restrictions-hint"
+                            className="govuk-input govuk-input--width-5 false"
+                            defaultValue="1300"
+                            disabled={false}
+                            id="end-time-wednesday-0"
+                            name="endTimewednesday"
+                            type="text"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="global-settings-time-restriction-row"
+                      key="1"
+                    >
+                      <div
+                        className="govuk-form-group"
+                      >
+                        <div>
+                          <label
+                            className="govuk-label"
+                            htmlFor="start-time-wednesday-1"
+                          >
+                            Start time 
+                            <span
+                              className="govuk-visually-hidden"
+                            >
+                              for 
+                              wednesday
+                            </span>
+                          </label>
+                          <input
+                            aria-describedby="time-restrictions-hint"
+                            className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
+                            defaultValue="1500"
+                            id="start-time-wednesday-1"
+                            name="startTimewednesday"
+                            type="text"
+                          />
+                        </div>
+                        <div>
+                          <label
+                            className="govuk-label"
+                            htmlFor="end-time-wednesday-1"
+                          >
+                            End time 
+                            <span
+                              className="govuk-visually-hidden"
+                            >
+                              for 
+                              wednesday
+                            </span>
+                          </label>
+                          <input
+                            aria-describedby="time-restrictions-hint"
+                            className="govuk-input govuk-input--width-5 false"
+                            defaultValue="1234"
+                            disabled={true}
+                            id="end-time-wednesday-1"
+                            name="endTimewednesday"
+                            type="text"
+                          />
+                        </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={true}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndwednesday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
+                  <button
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
+                    id="add-another-button-wednesday"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Add another
+                  </button>
+                  <button
+                    className="govuk-button govuk-button--warning govuk-!-margin-left-3 time-restrictions-button-placement"
+                    id="add-another-button-wednesday"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Delete last row
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              key="thursday"
+            >
+              <div
+                className="govuk-checkboxes__item"
+                key="thursday"
+              >
+                <input
+                  className="govuk-checkboxes__input"
+                  data-aria-controls="conditional-input-3"
+                  defaultChecked={false}
+                  id="time-restriction-day-3"
+                  name="timeRestrictionDays"
+                  type="checkbox"
+                  value="thursday"
+                />
+                <label
+                  className="govuk-label govuk-checkboxes__label"
+                  htmlFor="time-restriction-day-3"
+                >
+                  Thursday
+                </label>
+              </div>
+              <div
+                className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                id="conditional-input-3"
+              >
+                <fieldset
+                  className="govuk-fieldset flex-container time-restrictions-table"
+                >
+                  <div
+                    className="govuk-form-group govuk-form-group--error"
+                  >
+                    <div
+                      className="global-settings-time-restriction-row"
+                      key="0"
+                    >
+                      <p
+                        className="govuk-error-message"
+                      >
+                        Time must be in 24hr format
+                      </p>
+                      <div
+                        className="govuk-form-group"
+                      >
+                        <div>
+                          <label
+                            className="govuk-label"
+                            htmlFor="start-time-thursday-0"
+                          >
+                            Start time 
+                            <span
+                              className="govuk-visually-hidden"
+                            >
+                              for 
+                              thursday
+                            </span>
+                          </label>
+                          <input
+                            aria-describedby="time-restrictions-hint"
+                            className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 govuk-input--error"
+                            defaultValue=""
+                            id="start-time-thursday-0"
+                            name="startTimethursday"
+                            type="text"
+                          />
+                        </div>
+                        <div>
+                          <label
+                            className="govuk-label"
+                            htmlFor="end-time-thursday-0"
+                          >
+                            End time 
+                            <span
+                              className="govuk-visually-hidden"
+                            >
+                              for 
+                              thursday
+                            </span>
+                          </label>
+                          <input
+                            aria-describedby="time-restrictions-hint"
+                            className="govuk-input govuk-input--width-5 false"
+                            defaultValue=""
+                            disabled={false}
+                            id="end-time-thursday-0"
+                            name="endTimethursday"
+                            type="text"
+                          />
+                        </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndthursday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
+                  <button
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
+                    id="add-another-button-thursday"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Add another
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              key="friday"
+            >
+              <div
+                className="govuk-checkboxes__item"
+                key="friday"
+              >
+                <input
+                  className="govuk-checkboxes__input"
+                  data-aria-controls="conditional-input-4"
+                  defaultChecked={false}
+                  id="time-restriction-day-4"
+                  name="timeRestrictionDays"
+                  type="checkbox"
+                  value="friday"
+                />
+                <label
+                  className="govuk-label govuk-checkboxes__label"
+                  htmlFor="time-restriction-day-4"
+                >
+                  Friday
+                </label>
+              </div>
+              <div
+                className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                id="conditional-input-4"
+              >
+                <fieldset
+                  className="govuk-fieldset flex-container time-restrictions-table"
+                >
+                  <div
+                    className="govuk-form-group false"
+                  >
+                    <div
+                      className="global-settings-time-restriction-row"
+                      key="0"
+                    >
+                      <div
+                        className="govuk-form-group"
+                      >
+                        <div>
+                          <label
+                            className="govuk-label"
+                            htmlFor="start-time-friday-0"
+                          >
+                            Start time 
+                            <span
+                              className="govuk-visually-hidden"
+                            >
+                              for 
+                              friday
+                            </span>
+                          </label>
+                          <input
+                            aria-describedby="time-restrictions-hint"
+                            className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
+                            defaultValue=""
+                            id="start-time-friday-0"
+                            name="startTimefriday"
+                            type="text"
+                          />
+                        </div>
+                        <div>
+                          <label
+                            className="govuk-label"
+                            htmlFor="end-time-friday-0"
+                          >
+                            End time 
+                            <span
+                              className="govuk-visually-hidden"
+                            >
+                              for 
+                              friday
+                            </span>
+                          </label>
+                          <input
+                            aria-describedby="time-restrictions-hint"
+                            className="govuk-input govuk-input--width-5 false"
+                            defaultValue=""
+                            disabled={false}
+                            id="end-time-friday-0"
+                            name="endTimefriday"
+                            type="text"
+                          />
+                        </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndfriday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
+                  <button
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
+                    id="add-another-button-friday"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Add another
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              key="saturday"
+            >
+              <div
+                className="govuk-checkboxes__item"
+                key="saturday"
+              >
+                <input
+                  className="govuk-checkboxes__input"
+                  data-aria-controls="conditional-input-5"
+                  defaultChecked={false}
+                  id="time-restriction-day-5"
+                  name="timeRestrictionDays"
+                  type="checkbox"
+                  value="saturday"
+                />
+                <label
+                  className="govuk-label govuk-checkboxes__label"
+                  htmlFor="time-restriction-day-5"
+                >
+                  Saturday
+                </label>
+              </div>
+              <div
+                className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                id="conditional-input-5"
+              >
+                <fieldset
+                  className="govuk-fieldset flex-container time-restrictions-table"
+                >
+                  <div
+                    className="govuk-form-group false"
+                  >
+                    <div
+                      className="global-settings-time-restriction-row"
+                      key="0"
+                    >
+                      <div
+                        className="govuk-form-group"
+                      >
+                        <div>
+                          <label
+                            className="govuk-label"
+                            htmlFor="start-time-saturday-0"
+                          >
+                            Start time 
+                            <span
+                              className="govuk-visually-hidden"
+                            >
+                              for 
+                              saturday
+                            </span>
+                          </label>
+                          <input
+                            aria-describedby="time-restrictions-hint"
+                            className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
+                            defaultValue=""
+                            id="start-time-saturday-0"
+                            name="startTimesaturday"
+                            type="text"
+                          />
+                        </div>
+                        <div>
+                          <label
+                            className="govuk-label"
+                            htmlFor="end-time-saturday-0"
+                          >
+                            End time 
+                            <span
+                              className="govuk-visually-hidden"
+                            >
+                              for 
+                              saturday
+                            </span>
+                          </label>
+                          <input
+                            aria-describedby="time-restrictions-hint"
+                            className="govuk-input govuk-input--width-5 false"
+                            defaultValue=""
+                            disabled={false}
+                            id="end-time-saturday-0"
+                            name="endTimesaturday"
+                            type="text"
+                          />
+                        </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndsaturday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
+                  <button
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
+                    id="add-another-button-saturday"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Add another
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              key="sunday"
+            >
+              <div
+                className="govuk-checkboxes__item"
+                key="sunday"
+              >
+                <input
+                  className="govuk-checkboxes__input"
+                  data-aria-controls="conditional-input-6"
+                  defaultChecked={false}
+                  id="time-restriction-day-6"
+                  name="timeRestrictionDays"
+                  type="checkbox"
+                  value="sunday"
+                />
+                <label
+                  className="govuk-label govuk-checkboxes__label"
+                  htmlFor="time-restriction-day-6"
+                >
+                  Sunday
+                </label>
+              </div>
+              <div
+                className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                id="conditional-input-6"
+              >
+                <fieldset
+                  className="govuk-fieldset flex-container time-restrictions-table"
+                >
+                  <div
+                    className="govuk-form-group false"
+                  >
+                    <div
+                      className="global-settings-time-restriction-row"
+                      key="0"
+                    >
+                      <div
+                        className="govuk-form-group"
+                      >
+                        <div>
+                          <label
+                            className="govuk-label"
+                            htmlFor="start-time-sunday-0"
+                          >
+                            Start time 
+                            <span
+                              className="govuk-visually-hidden"
+                            >
+                              for 
+                              sunday
+                            </span>
+                          </label>
+                          <input
+                            aria-describedby="time-restrictions-hint"
+                            className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
+                            defaultValue=""
+                            id="start-time-sunday-0"
+                            name="startTimesunday"
+                            type="text"
+                          />
+                        </div>
+                        <div>
+                          <label
+                            className="govuk-label"
+                            htmlFor="end-time-sunday-0"
+                          >
+                            End time 
+                            <span
+                              className="govuk-visually-hidden"
+                            >
+                              for 
+                              sunday
+                            </span>
+                          </label>
+                          <input
+                            aria-describedby="time-restrictions-hint"
+                            className="govuk-input govuk-input--width-5 false"
+                            defaultValue=""
+                            disabled={false}
+                            id="end-time-sunday-0"
+                            name="endTimesunday"
+                            type="text"
+                          />
+                        </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndsunday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
+                  <button
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
+                    id="add-another-button-sunday"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Add another
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              key="bankHoliday"
+            >
+              <div
+                className="govuk-checkboxes__item"
+                key="bankHoliday"
+              >
+                <input
+                  className="govuk-checkboxes__input"
+                  data-aria-controls="conditional-input-7"
+                  defaultChecked={false}
+                  id="time-restriction-day-7"
+                  name="timeRestrictionDays"
+                  type="checkbox"
+                  value="bankHoliday"
+                />
+                <label
+                  className="govuk-label govuk-checkboxes__label"
+                  htmlFor="time-restriction-day-7"
+                >
+                  Bank holiday
+                </label>
+              </div>
+              <div
+                className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                id="conditional-input-7"
+              >
+                <fieldset
+                  className="govuk-fieldset flex-container time-restrictions-table"
+                >
+                  <div
+                    className="govuk-form-group false"
+                  >
+                    <div
+                      className="global-settings-time-restriction-row"
+                      key="0"
+                    >
+                      <div
+                        className="govuk-form-group"
+                      >
+                        <div>
+                          <label
+                            className="govuk-label"
+                            htmlFor="start-time-bankHoliday-0"
+                          >
+                            Start time 
+                            <span
+                              className="govuk-visually-hidden"
+                            >
+                              for 
+                              bankHoliday
+                            </span>
+                          </label>
+                          <input
+                            aria-describedby="time-restrictions-hint"
+                            className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
+                            defaultValue=""
+                            id="start-time-bankHoliday-0"
+                            name="startTimebankHoliday"
+                            type="text"
+                          />
+                        </div>
+                        <div>
+                          <label
+                            className="govuk-label"
+                            htmlFor="end-time-bankHoliday-0"
+                          >
+                            End time 
+                            <span
+                              className="govuk-visually-hidden"
+                            >
+                              for 
+                              bankHoliday
+                            </span>
+                          </label>
+                          <input
+                            aria-describedby="time-restrictions-hint"
+                            className="govuk-input govuk-input--width-5 false"
+                            defaultValue=""
+                            disabled={false}
+                            id="end-time-bankHoliday-0"
+                            name="endTimebankHoliday"
+                            type="text"
+                          />
+                        </div>
+                        <span
+                          className="govuk-label item"
+                        >
+                          OR 
+                        </span>
+                        <div
+                          className="govuk-checkboxes__item item"
+                        >
+                          <input
+                            checked={false}
+                            className="govuk-checkboxes__input"
+                            id="use-fare-day-end"
+                            name="fareDayEndbankHoliday"
+                            onChange={[Function]}
+                            type="checkbox"
+                          />
+                          <label
+                            className="govuk-label govuk-checkboxes__label"
+                            htmlFor="use-fare-day-end"
+                          >
+                            Use fare day end
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </fieldset>
+                <div
+                  className="flex-container govuk-!-margin-bottom-4"
+                >
+                  <button
+                    className="govuk-button govuk-button--secondary time-restrictions-button-placement"
+                    id="add-another-button-bankHoliday"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Add another
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </FormElementWrapper>
+      </fieldset>
+    </div>
+    <div
+      className="govuk-form-group"
+      id="time-restriction-name"
+    >
+      <label
+        htmlFor="time-restriction-name"
+      >
+        <h1
+          className="govuk-heading-m"
+          id="time-restriction-name-heading"
+        >
+          Provide a name for your time restriction
+        </h1>
+      </label>
+      <p
+        className="govuk-hint"
+        id="group-name-hint"
+      >
+        50 characters maximum
+      </p>
+      <FormElementWrapper
+        errorClass="govuk-input--error"
+        errorId="time-restriction-name"
+        errors={
+          Array [
+            Object {
+              "errorMessage": "Start time is required if end time is provided",
+              "id": "start-time-monday-0",
+              "userInput": "",
+            },
+            Object {
+              "errorMessage": "2400 is not a valid input. Use 0000.",
+              "id": "end-time-tuesday-0",
+              "userInput": "2400",
+            },
+            Object {
+              "errorMessage": "Start time and end time cannot be the same",
+              "id": "start-time-wednesday-0",
+              "userInput": "1200",
+            },
+            Object {
+              "errorMessage": "Start time and end time cannot be the same",
+              "id": "end-time-wednesday-0",
+              "userInput": "1200",
+            },
+            Object {
+              "errorMessage": "Time must be in 24hr format",
+              "id": "start-time-thursday-0",
+              "userInput": "-1",
             },
           ]
         }

--- a/repos/fdbt-site/tests/pages/api/defineTimeRestrictions.test.ts
+++ b/repos/fdbt-site/tests/pages/api/defineTimeRestrictions.test.ts
@@ -12,8 +12,9 @@ import { getMockRequestAndResponse, mockIdTokenMultiple } from '../../testData/m
 describe('defineTimeRestrictions', () => {
     const writeHeadMock = jest.fn();
 
-    afterEach(() => {
+    beforeEach(() => {
         jest.resetAllMocks();
+        jest.spyOn(auroradb, 'getFareDayEnd').mockResolvedValue('0440');
     });
 
     it('should set the TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE and redirect to fare confirmation when no errors are found', async () => {
@@ -121,7 +122,6 @@ describe('defineTimeRestrictions', () => {
     it('should populate endTimes with fareDayEnd selected', async () => {
         const updateSessionAttributeSpy = jest.spyOn(sessions, 'updateSessionAttribute');
         const getTimeRestrictionByNameAndNocSpy = jest.spyOn(auroradb, 'getTimeRestrictionByNameAndNoc');
-        jest.spyOn(auroradb, 'getFareDayEnd').mockResolvedValue('0440');
         getTimeRestrictionByNameAndNocSpy.mockImplementation().mockResolvedValue([
             {
                 id: 1,

--- a/repos/fdbt-site/tests/pages/api/manageTimeRestriction.test.ts
+++ b/repos/fdbt-site/tests/pages/api/manageTimeRestriction.test.ts
@@ -6,11 +6,11 @@ import { GS_TIME_RESTRICTION_ATTRIBUTE } from '../../../src/constants/attributes
 
 const updateSessionAttributeSpy = jest.spyOn(session, 'updateSessionAttribute');
 const getTimeRestrictionByNameAndNocSpy = jest.spyOn(aurora, 'getTimeRestrictionByNameAndNoc');
-const insertTimeRestrictionSpy = jest.spyOn(aurora, 'insertTimeRestriction');
-insertTimeRestrictionSpy.mockResolvedValue();
+const insertTimeRestrictionSpy = jest.spyOn(aurora, 'insertTimeRestriction').mockResolvedValue();
 
-afterEach(() => {
+beforeEach(() => {
     jest.resetAllMocks();
+    jest.spyOn(aurora, 'getFareDayEnd').mockResolvedValue('1234');
 });
 
 describe('manageTimeRestriction', () => {
@@ -234,7 +234,6 @@ describe('manageTimeRestriction', () => {
     it('should handle fare day end for time restrictions ', async () => {
         const writeHeadMock = jest.fn();
         getTimeRestrictionByNameAndNocSpy.mockResolvedValueOnce([]);
-        jest.spyOn(aurora, 'getFareDayEnd').mockResolvedValue('1234');
         const { req, res } = getMockRequestAndResponse({
             cookieValues: {},
             body: {

--- a/repos/fdbt-site/tests/pages/api/manageTimeRestriction.test.ts
+++ b/repos/fdbt-site/tests/pages/api/manageTimeRestriction.test.ts
@@ -230,4 +230,57 @@ describe('manageTimeRestriction', () => {
             'test',
         );
     });
+
+    it('should handle fare day end for time restrictions ', async () => {
+        const writeHeadMock = jest.fn();
+        getTimeRestrictionByNameAndNocSpy.mockResolvedValueOnce([]);
+        jest.spyOn(aurora, 'getFareDayEnd').mockResolvedValue('1234');
+        const { req, res } = getMockRequestAndResponse({
+            cookieValues: {},
+            body: {
+                timeRestrictionDays: ['monday', 'tuesday', 'wednesday', 'bankHoliday'],
+                startTimemonday: '0600',
+                endTimemonday: '2200',
+                startTimetuesday: ['0600', '1300'],
+                endTimetuesday: ['1200'],
+                fareDayEndtuesday: 'on',
+                startTimewednesday: '0600',
+                fareDayEndwednesday: 'on',
+                startTimethursday: '',
+                endTimethursday: '',
+                startTimefriday: '',
+                endTimefriday: '',
+                startTimesaturday: '',
+                endTimesaturday: '',
+                startTimesunday: '',
+                endTimesunday: '',
+                startTimebankHoliday: '',
+                endTimebankHoliday: '',
+                timeRestrictionName: 'test',
+            },
+            uuid: {},
+            mockWriteHeadFn: writeHeadMock,
+        });
+        await manageTimeRestriction(req, res);
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, GS_TIME_RESTRICTION_ATTRIBUTE, undefined);
+        expect(insertTimeRestrictionSpy).toBeCalledWith(
+            'TEST',
+            [
+                { day: 'monday', timeBands: [{ startTime: '0600', endTime: '2200' }] },
+                {
+                    day: 'tuesday',
+                    timeBands: [
+                        { startTime: '0600', endTime: '1200' },
+                        { startTime: '1300', endTime: { fareDayEnd: true } },
+                    ],
+                },
+                { day: 'wednesday', timeBands: [{ startTime: '0600', endTime: { fareDayEnd: true } }] },
+                { day: 'bankHoliday', timeBands: [] },
+            ],
+            'test',
+        );
+        expect(writeHeadMock).toBeCalledWith(302, {
+            Location: '/viewTimeRestrictions',
+        });
+    });
 });

--- a/repos/fdbt-site/tests/pages/manageTimeRestriction.test.tsx
+++ b/repos/fdbt-site/tests/pages/manageTimeRestriction.test.tsx
@@ -7,7 +7,13 @@ describe('pages', () => {
     describe('manage time restriction', () => {
         it('should render correctly', () => {
             const tree = shallow(
-                <ManageTimeRestriction csrfToken={''} errors={[]} inputs={undefined} editMode={false} />,
+                <ManageTimeRestriction
+                    csrfToken={''}
+                    errors={[]}
+                    inputs={undefined}
+                    editMode={false}
+                    fareDayEnd={'1234'}
+                />,
             );
 
             expect(tree).toMatchSnapshot();
@@ -22,7 +28,9 @@ describe('pages', () => {
                 contents: [],
             };
 
-            const tree = shallow(<ManageTimeRestriction csrfToken={''} errors={errors} inputs={inputs} editMode />);
+            const tree = shallow(
+                <ManageTimeRestriction csrfToken={''} errors={errors} inputs={inputs} editMode fareDayEnd={'1234'} />,
+            );
 
             expect(tree).toMatchSnapshot();
         });
@@ -59,7 +67,53 @@ describe('pages', () => {
                 ],
             };
 
-            const tree = shallow(<ManageTimeRestriction csrfToken={''} errors={errors} inputs={inputs} editMode />);
+            const tree = shallow(
+                <ManageTimeRestriction csrfToken={''} errors={errors} inputs={inputs} editMode fareDayEnd={'1234'} />,
+            );
+
+            expect(tree).toMatchSnapshot();
+        });
+
+        it('should render with fare day end selections', () => {
+            const errors = [
+                {
+                    errorMessage: 'Start time is required if end time is provided',
+                    id: 'start-time-monday-0',
+                    userInput: '',
+                },
+                { errorMessage: '2400 is not a valid input. Use 0000.', id: 'end-time-tuesday-0', userInput: '2400' },
+                {
+                    errorMessage: 'Start time and end time cannot be the same',
+                    id: 'start-time-wednesday-0',
+                    userInput: '1200',
+                },
+                {
+                    errorMessage: 'Start time and end time cannot be the same',
+                    id: 'end-time-wednesday-0',
+                    userInput: '1200',
+                },
+                { errorMessage: 'Time must be in 24hr format', id: 'start-time-thursday-0', userInput: '-1' },
+            ];
+
+            const inputs: PremadeTimeRestriction = {
+                id: 0,
+                name: 'test',
+                contents: [
+                    { day: 'monday', timeBands: [{ startTime: '1111', endTime: '2300' }] },
+                    { day: 'tuesday', timeBands: [{ startTime: '0100', endTime: { fareDayEnd: true } }] },
+                    {
+                        day: 'wednesday',
+                        timeBands: [
+                            { startTime: '1200', endTime: '1300' },
+                            { startTime: '1500', endTime: { fareDayEnd: true } },
+                        ],
+                    },
+                ],
+            };
+
+            const tree = shallow(
+                <ManageTimeRestriction csrfToken={''} errors={errors} inputs={inputs} editMode fareDayEnd={'1234'} />,
+            );
 
             expect(tree).toMatchSnapshot();
         });
@@ -84,7 +138,13 @@ describe('pages', () => {
             };
 
             const tree = shallow(
-                <ManageTimeRestriction csrfToken={''} errors={errors} inputs={inputs} editMode={false} />,
+                <ManageTimeRestriction
+                    csrfToken={''}
+                    errors={errors}
+                    inputs={inputs}
+                    editMode={false}
+                    fareDayEnd={'1234'}
+                />,
             );
 
             expect(tree).toMatchSnapshot();


### PR DESCRIPTION
# Description

-   Adds fare day end as an option for time restrictions

# Testing instructions

-   Check that the fare day end option on the time restrictions page functions correctly
-   Check the validation
-   Check that you can use a fare day end time restriction in the fare journey and you generate NetEX with the correct value in the time restriction

# Type of change

-   [X] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
