### PR TITLE
fix: CFD-408 settings overview heading

### DIFF
--- a/repos/fdbt-site/src/components/GlobalSettingsViewPage.tsx
+++ b/repos/fdbt-site/src/components/GlobalSettingsViewPage.tsx
@@ -101,11 +101,11 @@ export const GlobalSettingsViewPage = <T extends Entity>({
         <BaseLayout title={title} description={description} showNavigation referer={referer}>
             <div className="govuk-width-container" data-card-count={entities.length}>
                 <div className="govuk-grid-row">
-                    <div className="govuk-grid-column-one-third">
+                    <div className="govuk-grid-column-one-quarter">
                         <SubNavigation />
                     </div>
 
-                    <div className="govuk-grid-column-two-thirds">
+                    <div className="govuk-grid-column-three-quarters">
                         <h1 className="govuk-heading-xl">{title}</h1>
                         <p className="govuk-body govuk-!-margin-bottom-8">{description}</p>
 

--- a/repos/fdbt-site/src/components/UnableToDeletePopup.tsx
+++ b/repos/fdbt-site/src/components/UnableToDeletePopup.tsx
@@ -23,7 +23,7 @@ const UnableToDeletePopup = ({
                     {groupsInUse?.join(', ')}
                 </span>
 
-                <button className="govuk-button govuk-button--secondary" onClick={cancelActionHandler}>
+                <button className="govuk-button govuk-button" onClick={cancelActionHandler}>
                     Ok
                 </button>
             </form>

--- a/repos/fdbt-site/src/pages/globalSettings.tsx
+++ b/repos/fdbt-site/src/pages/globalSettings.tsx
@@ -33,7 +33,7 @@ const GlobalSettings = ({ globalSettingsCounts, referer }: GlobalSettingsProps):
                     </div>
 
                     <div className="govuk-grid-column-three-quarters">
-                        <h1 className="govuk-heading-m">Settings overview</h1>
+                        <h1 className="govuk-heading-xl">Settings overview</h1>
                         <p className="govuk-body-m">
                             Operators may customise the following definitions relevant to their fares or choose to use
                             default settings.

--- a/repos/fdbt-site/src/pages/manageFareDayEnd.tsx
+++ b/repos/fdbt-site/src/pages/manageFareDayEnd.tsx
@@ -32,11 +32,11 @@ const ManageFareDayEnd = ({ errors, csrfToken, fareDayEnd, referer, saved }: Man
         <BaseLayout title={title} description={description} showNavigation referer={referer}>
             <div className="govuk-width-container">
                 <div className="govuk-grid-row">
-                    <div className="govuk-grid-column-one-third">
+                    <div className="govuk-grid-column-one-quarter">
                         <SubNavigation />
                     </div>
 
-                    <div className="govuk-grid-column-two-thirds">
+                    <div className="govuk-grid-column-three-quarters">
                         <ErrorSummary errors={errors} />
 
                         <h1 className="govuk-heading-xl">Fare day end</h1>

--- a/repos/fdbt-site/src/pages/selectPassengerType.tsx
+++ b/repos/fdbt-site/src/pages/selectPassengerType.tsx
@@ -82,7 +82,9 @@ const SelectPassengerType = ({
                                         </>
                                     ) : (
                                         <div className="govuk-grid-column-two-thirds">
-                                            <p className="govuk-body">You currently have no saved groups</p>
+                                            <p className="govuk-body">
+                                                <em>You currently have no saved groups</em>
+                                            </p>
                                         </div>
                                     )}
                                 </div>

--- a/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
+++ b/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
@@ -59,11 +59,11 @@ const ViewPassengerTypes = ({
     return (
         <BaseLayout title={title} description={description} showNavigation referer={referer}>
             <div className="govuk-grid-row" data-card-count={singlePassengerTypes.length + groupPassengerTypes.length}>
-                <div className="govuk-grid-column-one-third">
+                <div className="govuk-grid-column-one-quarter">
                     <SubNavigation />
                 </div>
 
-                <div className="govuk-grid-column-two-thirds">
+                <div className="govuk-grid-column-three-quarters">
                     <h1 className="govuk-heading-xl">Passenger types</h1>
                     <p className="govuk-body govuk-!-margin-bottom-8">
                         Define age range and required proof documents of your passengers as well as passenger groups

--- a/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
+++ b/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
@@ -132,7 +132,9 @@ const NoIndividualPassengerTypes = (): ReactElement => {
     return (
         <>
             <h2 className="govuk-heading-l">Individual</h2>
-            <p className="govuk-body">You currently have no passenger types saved.</p>
+            <p className="govuk-body">
+                <em>You currently have no passenger types saved.</em>
+            </p>
         </>
     );
 };
@@ -172,7 +174,9 @@ const NoPassengerTypeGroups = (): ReactElement => {
                 Individual passengers must be created before they can be added to a group.
             </div>
 
-            <p className="govuk-body">You currently have no passenger groups saved.</p>
+            <p className="govuk-body">
+                <em>You currently have no passenger groups saved.</em>
+            </p>
         </>
     );
 };

--- a/repos/fdbt-site/tests/components/__snapshots__/GlobalSettingsViewPage.test.tsx.snap
+++ b/repos/fdbt-site/tests/components/__snapshots__/GlobalSettingsViewPage.test.tsx.snap
@@ -15,12 +15,12 @@ exports[`GlobalSettingsViewPage should render correctly when entities exist 1`] 
       className="govuk-grid-row"
     >
       <div
-        className="govuk-grid-column-one-third"
+        className="govuk-grid-column-one-quarter"
       >
         <SubNavigation />
       </div>
       <div
-        className="govuk-grid-column-two-thirds"
+        className="govuk-grid-column-three-quarters"
       >
         <h1
           className="govuk-heading-xl"
@@ -200,12 +200,12 @@ exports[`GlobalSettingsViewPage should render correctly when no entities 1`] = `
       className="govuk-grid-row"
     >
       <div
-        className="govuk-grid-column-one-third"
+        className="govuk-grid-column-one-quarter"
       >
         <SubNavigation />
       </div>
       <div
-        className="govuk-grid-column-two-thirds"
+        className="govuk-grid-column-three-quarters"
       >
         <h1
           className="govuk-heading-xl"

--- a/repos/fdbt-site/tests/pages/__snapshots__/globalSettings.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/globalSettings.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`pages globalSettings should render correctly 1`] = `
         className="govuk-grid-column-three-quarters"
       >
         <h1
-          className="govuk-heading-m"
+          className="govuk-heading-xl"
         >
           Settings overview
         </h1>

--- a/repos/fdbt-site/tests/pages/__snapshots__/manageFareDayEnd.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/manageFareDayEnd.test.tsx.snap
@@ -14,12 +14,12 @@ exports[`pages manage passenger types should render correctly 1`] = `
       className="govuk-grid-row"
     >
       <div
-        className="govuk-grid-column-one-third"
+        className="govuk-grid-column-one-quarter"
       >
         <SubNavigation />
       </div>
       <div
-        className="govuk-grid-column-two-thirds"
+        className="govuk-grid-column-three-quarters"
       >
         <ErrorSummary
           errors={Array []}
@@ -106,12 +106,12 @@ exports[`pages manage passenger types should render error state if error 1`] = `
       className="govuk-grid-row"
     >
       <div
-        className="govuk-grid-column-one-third"
+        className="govuk-grid-column-one-quarter"
       >
         <SubNavigation />
       </div>
       <div
-        className="govuk-grid-column-two-thirds"
+        className="govuk-grid-column-three-quarters"
       >
         <ErrorSummary
           errors={
@@ -219,12 +219,12 @@ exports[`pages manage passenger types should render popup if saved 1`] = `
       className="govuk-grid-row"
     >
       <div
-        className="govuk-grid-column-one-third"
+        className="govuk-grid-column-one-quarter"
       >
         <SubNavigation />
       </div>
       <div
-        className="govuk-grid-column-two-thirds"
+        className="govuk-grid-column-three-quarters"
       >
         <ErrorSummary
           errors={Array []}

--- a/repos/fdbt-site/tests/pages/__snapshots__/selectPassengerType.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/selectPassengerType.test.tsx.snap
@@ -195,7 +195,9 @@ exports[`pages selectPassengerType should render correctly with no saved groups 
             <p
               className="govuk-body"
             >
-              You currently have no saved groups
+              <em>
+                You currently have no saved groups
+              </em>
             </p>
           </div>
         </div>

--- a/repos/fdbt-site/tests/pages/__snapshots__/viewPassengerTypes.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/viewPassengerTypes.test.tsx.snap
@@ -12,12 +12,12 @@ exports[`pages view passenger types should render correctly when groups and indi
     data-card-count={2}
   >
     <div
-      className="govuk-grid-column-one-third"
+      className="govuk-grid-column-one-quarter"
     >
       <SubNavigation />
     </div>
     <div
-      className="govuk-grid-column-two-thirds"
+      className="govuk-grid-column-three-quarters"
     >
       <h1
         className="govuk-heading-xl"
@@ -115,12 +115,12 @@ exports[`pages view passenger types should render correctly when no individual o
     data-card-count={0}
   >
     <div
-      className="govuk-grid-column-one-third"
+      className="govuk-grid-column-one-quarter"
     >
       <SubNavigation />
     </div>
     <div
-      className="govuk-grid-column-two-thirds"
+      className="govuk-grid-column-three-quarters"
     >
       <h1
         className="govuk-heading-xl"
@@ -164,12 +164,12 @@ exports[`pages view passenger types should render correctly when only individual
     data-card-count={1}
   >
     <div
-      className="govuk-grid-column-one-third"
+      className="govuk-grid-column-one-quarter"
     >
       <SubNavigation />
     </div>
     <div
-      className="govuk-grid-column-two-thirds"
+      className="govuk-grid-column-three-quarters"
     >
       <h1
         className="govuk-heading-xl"
@@ -238,12 +238,12 @@ exports[`pages view passenger types should render correctly when only passenger 
     data-card-count={1}
   >
     <div
-      className="govuk-grid-column-one-third"
+      className="govuk-grid-column-one-quarter"
     >
       <SubNavigation />
     </div>
     <div
-      className="govuk-grid-column-two-thirds"
+      className="govuk-grid-column-three-quarters"
     >
       <h1
         className="govuk-heading-xl"


### PR DESCRIPTION
# Description

Change titlestyle from 'm' to 'xl'

# Testing instructions

Check that on /globalSettings page "Settings overview" is styled in XL size

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
