### PR TITLE
Fix/cfd 434 time restriction and passenger type selection retention

### DIFF
--- a/repos/fdbt-site/src/components/PassengerTypeCard.tsx
+++ b/repos/fdbt-site/src/components/PassengerTypeCard.tsx
@@ -5,9 +5,10 @@ import { getProofDocumentsString, sentenceCaseString } from '../utils';
 interface PassengerTypeCardProps {
     contents: FullGroupPassengerType | SinglePassengerType;
     deleteActionHandler?: (id: number, name: string, isGroup: boolean) => void;
+    defaultChecked: boolean;
 }
 
-const PassengerTypeCard = ({ contents, deleteActionHandler }: PassengerTypeCardProps): ReactElement => {
+const PassengerTypeCard = ({ contents, deleteActionHandler, defaultChecked }: PassengerTypeCardProps): ReactElement => {
     const { name, id } = contents;
     const isGroup = 'groupPassengerType' in contents;
     return (
@@ -45,6 +46,7 @@ const PassengerTypeCard = ({ contents, deleteActionHandler }: PassengerTypeCardP
                                 type="radio"
                                 value={id}
                                 aria-label={name}
+                                defaultChecked={defaultChecked}
                             />
                             {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
                             <label className="govuk-label govuk-radios__label" />

--- a/repos/fdbt-site/src/interfaces/index.ts
+++ b/repos/fdbt-site/src/interfaces/index.ts
@@ -438,6 +438,7 @@ export interface MultiOperatorInfoWithErrors {
 export interface FullTimeRestrictionAttribute {
     fullTimeRestrictions: FullTimeRestriction[];
     errors: ErrorInfo[];
+    id?: number;
 }
 
 export interface TimeInput {
@@ -531,6 +532,7 @@ export interface PassengerType {
     ageRangeMax?: string;
     proof?: string;
     proofDocuments?: string[];
+    id?: number;
 }
 
 export interface PassengerTypeWithErrors {

--- a/repos/fdbt-site/src/pages/api/defineTimeRestrictions.ts
+++ b/repos/fdbt-site/src/pages/api/defineTimeRestrictions.ts
@@ -53,7 +53,8 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
 
             const fareDayEnd = await getFareDayEnd(noc);
 
-            const timeRestrictions = results[0].contents.map((timeRestriction) => ({
+            const dbTimeRestriction = results[0];
+            const timeRestrictions = dbTimeRestriction.contents.map((timeRestriction) => ({
                 ...timeRestriction,
                 timeBands: timeRestriction.timeBands.map((timeBand) => {
                     let endTime: string;
@@ -77,7 +78,10 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             updateSessionAttribute(req, FULL_TIME_RESTRICTIONS_ATTRIBUTE, {
                 fullTimeRestrictions: timeRestrictions,
                 errors: [],
+                id: dbTimeRestriction.id,
             });
+
+            updateSessionAttribute(req, TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE, undefined);
 
             redirectTo(res, '/fareConfirmation');
             return;

--- a/repos/fdbt-site/src/pages/api/selectPassengerType.ts
+++ b/repos/fdbt-site/src/pages/api/selectPassengerType.ts
@@ -24,26 +24,31 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             return;
         }
 
-        const databaseCheck = await getPassengerTypeById(selectedPassengerType, nocCode);
-        const groupDataBaseCheck = await getGroupPassengerTypeById(selectedPassengerType, nocCode);
+        const dbIndividual = await getPassengerTypeById(selectedPassengerType, nocCode);
+        const dbGroup = await getGroupPassengerTypeById(selectedPassengerType, nocCode);
 
-        if (!databaseCheck && !groupDataBaseCheck) {
+        if (dbGroup) {
+            const fullGroup = await convertToFullPassengerType(dbGroup, nocCode);
+            updateSessionAttribute(req, PASSENGER_TYPE_ATTRIBUTE, {
+                passengerType: GROUP_PASSENGER_TYPE,
+                id: dbGroup.id,
+            });
+            updateSessionAttribute(req, GROUP_PASSENGER_INFO_ATTRIBUTE, fullGroup.groupPassengerType.companions);
+
+            updateSessionAttribute(req, GROUP_SIZE_ATTRIBUTE, {
+                maxGroupSize: dbGroup.groupPassengerType.maxGroupSize,
+            });
+        } else if (dbIndividual) {
+            updateSessionAttribute(req, PASSENGER_TYPE_ATTRIBUTE, {
+                ...dbIndividual.passengerType,
+                id: dbIndividual.id,
+            });
+        } else {
             updateSessionAttribute(req, PASSENGER_TYPE_ATTRIBUTE, {
                 errors,
             });
             redirectTo(res, '/selectPassengerType');
             return;
-        }
-        if (groupDataBaseCheck) {
-            const fullGroup = await convertToFullPassengerType(groupDataBaseCheck, nocCode);
-            updateSessionAttribute(req, PASSENGER_TYPE_ATTRIBUTE, { passengerType: GROUP_PASSENGER_TYPE });
-            updateSessionAttribute(req, GROUP_PASSENGER_INFO_ATTRIBUTE, fullGroup.groupPassengerType.companions);
-
-            updateSessionAttribute(req, GROUP_SIZE_ATTRIBUTE, {
-                maxGroupSize: groupDataBaseCheck.groupPassengerType.maxGroupSize,
-            });
-        } else {
-            updateSessionAttribute(req, PASSENGER_TYPE_ATTRIBUTE, databaseCheck?.passengerType);
         }
 
         redirectTo(res, getPassengerTypeRedirectLocation(req));

--- a/repos/fdbt-site/src/pages/globalSettings.tsx
+++ b/repos/fdbt-site/src/pages/globalSettings.tsx
@@ -74,7 +74,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     const noc = getAndValidateNoc(ctx);
 
     if (!noc) {
-        throw new Error('No NOC found for useer.');
+        throw new Error('No NOC found for user.');
     }
 
     if (!globalSettingsEnabled && ctx.res) {

--- a/repos/fdbt-site/src/pages/selectTimeRestrictions.tsx
+++ b/repos/fdbt-site/src/pages/selectTimeRestrictions.tsx
@@ -177,7 +177,6 @@ export const getServerSideProps = async (
 
     const timeRestrictions = await getTimeRestrictionByNocCode(nationalOperatorCode);
 
-    console.log({ timeRestrictions, selectedId });
     return { props: { csrfToken, errors, timeRestrictions, selectedId } };
 };
 

--- a/repos/fdbt-site/src/pages/selectTimeRestrictions.tsx
+++ b/repos/fdbt-site/src/pages/selectTimeRestrictions.tsx
@@ -6,8 +6,8 @@ import CsrfForm from '../components/CsrfForm';
 import { getAndValidateNoc, getCsrfToken } from '../utils';
 import { getTimeRestrictionByNocCode } from '../data/auroradb';
 import { TimeRestrictionCardBody } from './viewTimeRestrictions';
-import { getSessionAttribute } from 'src/utils/sessions';
-import { TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE } from 'src/constants/attributes';
+import { getSessionAttribute } from '../utils/sessions';
+import { FULL_TIME_RESTRICTIONS_ATTRIBUTE, TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE } from '../constants/attributes';
 
 const title = 'Define Time Restrictions - Create Fares Data Service';
 const description = 'Define Time Restrictions page of the Create Fares Data Service';
@@ -16,9 +16,15 @@ interface SelectTimeRestrictionsProps {
     csrfToken: string;
     errors: ErrorInfo[];
     timeRestrictions: PremadeTimeRestriction[];
+    selectedId: number | null;
 }
 
-const SelectTimeRestrictions = ({ csrfToken, errors, timeRestrictions }: SelectTimeRestrictionsProps): ReactElement => {
+const SelectTimeRestrictions = ({
+    csrfToken,
+    errors,
+    timeRestrictions,
+    selectedId,
+}: SelectTimeRestrictionsProps): ReactElement => {
     return (
         <FullColumnLayout title={title} description={description} errors={errors}>
             <ErrorSummary errors={errors} />
@@ -57,7 +63,9 @@ const SelectTimeRestrictions = ({ csrfToken, errors, timeRestrictions }: SelectT
                                         type="radio"
                                         value="Premade"
                                         data-aria-controls="conditional-time-restriction"
-                                        defaultChecked={errors.some((error) => error.id === 'time-restriction')}
+                                        defaultChecked={
+                                            errors.some((error) => error.id === 'time-restriction') || !!selectedId
+                                        }
                                     />
                                     <label className="govuk-label govuk-radios__label" htmlFor="yes-choice">
                                         Yes
@@ -71,7 +79,11 @@ const SelectTimeRestrictions = ({ csrfToken, errors, timeRestrictions }: SelectT
                                     <div className="govuk-form-group card-row">
                                         {timeRestrictions.length ? (
                                             timeRestrictions.map((item) => (
-                                                <TimeRestrictionCard key={item.id} timeRestriction={item} />
+                                                <TimeRestrictionCard
+                                                    key={item.id}
+                                                    timeRestriction={item}
+                                                    selectedId={selectedId}
+                                                />
                                             ))
                                         ) : (
                                             <p className="govuk-body govuk-error-message">
@@ -116,7 +128,13 @@ const SelectTimeRestrictions = ({ csrfToken, errors, timeRestrictions }: SelectT
     );
 };
 
-const TimeRestrictionCard = ({ timeRestriction }: { timeRestriction: PremadeTimeRestriction }): ReactElement => {
+const TimeRestrictionCard = ({
+    timeRestriction,
+    selectedId,
+}: {
+    timeRestriction: PremadeTimeRestriction;
+    selectedId: number | null;
+}): ReactElement => {
     return (
         <div className="card">
             <div className="card__body time-restriction">
@@ -129,6 +147,7 @@ const TimeRestrictionCard = ({ timeRestriction }: { timeRestriction: PremadeTime
                             type="radio"
                             value={timeRestriction.name}
                             aria-label={timeRestriction.name}
+                            defaultChecked={selectedId === timeRestriction.id}
                         />
                         {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
                         <label className="govuk-label govuk-radios__label" />
@@ -148,6 +167,7 @@ export const getServerSideProps = async (
     let errors: ErrorInfo[] = [];
 
     const timeRestrictionsDefinition = getSessionAttribute(ctx.req, TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE);
+    const selectedId = getSessionAttribute(ctx.req, FULL_TIME_RESTRICTIONS_ATTRIBUTE)?.id ?? null;
 
     if (timeRestrictionsDefinition && 'errors' in timeRestrictionsDefinition) {
         errors = timeRestrictionsDefinition.errors;
@@ -157,7 +177,8 @@ export const getServerSideProps = async (
 
     const timeRestrictions = await getTimeRestrictionByNocCode(nationalOperatorCode);
 
-    return { props: { csrfToken, errors, timeRestrictions } };
+    console.log({ timeRestrictions, selectedId });
+    return { props: { csrfToken, errors, timeRestrictions, selectedId } };
 };
 
 export default SelectTimeRestrictions;

--- a/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
+++ b/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
@@ -158,6 +158,7 @@ const IndividualPassengerTypes = ({
                         contents={singlePassengerType}
                         deleteActionHandler={deleteActionHandler}
                         key={singlePassengerType.id.toString()}
+                        defaultChecked={false}
                     />
                 ))}
             </div>
@@ -197,6 +198,7 @@ const PassengerTypeGroups = ({ deleteActionHandler, passengerTypeGroups }: Passe
                         contents={passengerTypeGroup}
                         deleteActionHandler={deleteActionHandler}
                         key={passengerTypeGroup.id}
+                        defaultChecked={false}
                     />
                 ))}
             </div>

--- a/repos/fdbt-site/tests/pages/__snapshots__/selectPassengerType.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/selectPassengerType.test.tsx.snap
@@ -363,7 +363,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
                 "name": "family",
               }
             }
-            defaultChecked={false}
+            defaultChecked={true}
             key="1"
           />
           <PassengerTypeCard

--- a/repos/fdbt-site/tests/pages/__snapshots__/selectPassengerType.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/selectPassengerType.test.tsx.snap
@@ -163,6 +163,7 @@ exports[`pages selectPassengerType should render correctly with no saved groups 
                 },
               }
             }
+            defaultChecked={false}
             key="3"
           />
           <PassengerTypeCard
@@ -178,6 +179,7 @@ exports[`pages selectPassengerType should render correctly with no saved groups 
                 },
               }
             }
+            defaultChecked={false}
             key="2"
           />
         </div>
@@ -302,6 +304,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
                 },
               }
             }
+            defaultChecked={false}
             key="3"
           />
           <PassengerTypeCard
@@ -317,6 +320,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
                 },
               }
             }
+            defaultChecked={false}
             key="2"
           />
         </div>
@@ -359,6 +363,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
                 "name": "family",
               }
             }
+            defaultChecked={false}
             key="1"
           />
           <PassengerTypeCard
@@ -383,6 +388,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
                 "name": "couple",
               }
             }
+            defaultChecked={false}
             key="4"
           />
         </div>
@@ -501,6 +507,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
                 },
               }
             }
+            defaultChecked={false}
             key="3"
           />
           <PassengerTypeCard
@@ -516,6 +523,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
                 },
               }
             }
+            defaultChecked={false}
             key="2"
           />
         </div>
@@ -558,6 +566,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
                 "name": "family",
               }
             }
+            defaultChecked={false}
             key="1"
           />
           <PassengerTypeCard
@@ -582,6 +591,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
                 "name": "couple",
               }
             }
+            defaultChecked={false}
             key="4"
           />
         </div>

--- a/repos/fdbt-site/tests/pages/api/defineTimeRestrictions.test.ts
+++ b/repos/fdbt-site/tests/pages/api/defineTimeRestrictions.test.ts
@@ -111,6 +111,7 @@ describe('defineTimeRestrictions', () => {
                 },
             ],
             errors: [],
+            id: 1,
         });
         expect(writeHeadMock).toBeCalledWith(302, {
             Location: '/fareConfirmation',
@@ -167,6 +168,7 @@ describe('defineTimeRestrictions', () => {
                 { day: 'bankHoliday', timeBands: [{ startTime: '1400', endTime: '1600' }] },
             ],
             errors: [],
+            id: 1,
         });
         expect(writeHeadMock).toBeCalledWith(302, {
             Location: '/fareConfirmation',

--- a/repos/fdbt-site/tests/pages/api/selectPassengerType.test.ts
+++ b/repos/fdbt-site/tests/pages/api/selectPassengerType.test.ts
@@ -121,6 +121,7 @@ describe('selectPassengerType', () => {
         });
         expect(updateSessionAttributeSpy).toBeCalledWith(req, PASSENGER_TYPE_ATTRIBUTE, {
             passengerType: GROUP_PASSENGER_TYPE,
+            id: 3,
         });
         expect(updateSessionAttributeSpy).toBeCalledWith(
             req,
@@ -156,6 +157,9 @@ describe('selectPassengerType', () => {
             Location: '/defineTimeRestrictions',
         });
 
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, PASSENGER_TYPE_ATTRIBUTE, databaseResult.passengerType);
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, PASSENGER_TYPE_ATTRIBUTE, {
+            passengerType: 'adult',
+            id: 3,
+        });
     });
 });

--- a/repos/fdbt-site/tests/pages/selectPassengerType.test.tsx
+++ b/repos/fdbt-site/tests/pages/selectPassengerType.test.tsx
@@ -84,6 +84,7 @@ describe('pages', () => {
                     csrfToken="csrf"
                     savedGroups={savedGroups}
                     savedPassengerTypes={savedPassengerTypes}
+                    selectedId={null}
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -95,6 +96,7 @@ describe('pages', () => {
                     csrfToken="csrf"
                     savedGroups={savedGroups}
                     savedPassengerTypes={savedPassengerTypes}
+                    selectedId={null}
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -106,6 +108,7 @@ describe('pages', () => {
                     csrfToken="csrf"
                     savedGroups={[]}
                     savedPassengerTypes={savedPassengerTypes}
+                    selectedId={null}
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -113,7 +116,13 @@ describe('pages', () => {
 
         it('should render correctly with no saved groups and no saved passenger types', () => {
             const tree = shallow(
-                <SelectPassengerType errors={[]} csrfToken="csrf" savedGroups={[]} savedPassengerTypes={[]} />,
+                <SelectPassengerType
+                    errors={[]}
+                    csrfToken="csrf"
+                    savedGroups={[]}
+                    savedPassengerTypes={[]}
+                    selectedId={null}
+                />,
             );
             expect(tree).toMatchSnapshot();
         });

--- a/repos/fdbt-site/tests/pages/selectPassengerType.test.tsx
+++ b/repos/fdbt-site/tests/pages/selectPassengerType.test.tsx
@@ -84,7 +84,7 @@ describe('pages', () => {
                     csrfToken="csrf"
                     savedGroups={savedGroups}
                     savedPassengerTypes={savedPassengerTypes}
-                    selectedId={null}
+                    selectedId={1}
                 />,
             );
             expect(tree).toMatchSnapshot();


### PR DESCRIPTION
# Description

This PR allows the user to retain their selection of passenger type and time restriction when clicking change on the first conformation page.

# Testing instructions

1. Create a fare with a passenger type and time restriction
2. Click change on first confirmation page
3. Look to see if previous selection is pre-selected

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
