### PR TITLE
fix: Disable auto selection of fare day end option + UI test fixes

### DIFF
--- a/repos/fdbt-site/cypress_tests/cypress/support/index.ts
+++ b/repos/fdbt-site/cypress_tests/cypress/support/index.ts
@@ -32,6 +32,7 @@ before(() => {
 
 const addTestFareDayEnd = (): void => {
     clickElementById('fare-day-end-input').clear().type('2323');
+    clickElementByText('Save');
 };
 
 const addTestPassengerTypes = (): void => {

--- a/repos/fdbt-site/src/components/GlobalSettingsViewPage.tsx
+++ b/repos/fdbt-site/src/components/GlobalSettingsViewPage.tsx
@@ -1,6 +1,5 @@
 import { capitalize } from 'lodash';
 import React, { FunctionComponent, ReactElement, useState } from 'react';
-import { globalSettingsDeleteEnabled } from '../../src/constants/featureFlag';
 import DeleteConfirmationPopup from '../components/DeleteConfirmationPopup';
 import { BaseLayout } from '../layout/Layout';
 import SubNavigation from '../layout/SubNavigation';
@@ -15,6 +14,7 @@ interface GlobalSettingsViewPageProps<T extends Entity> {
     description: string;
     entityDescription: string;
     CardBody: FunctionComponent<{ entity: T }>;
+    deleteEnabled: boolean;
 }
 
 export const GlobalSettingsViewPage = <T extends Entity>({
@@ -25,6 +25,7 @@ export const GlobalSettingsViewPage = <T extends Entity>({
     description,
     entityDescription,
     CardBody,
+    deleteEnabled,
 }: GlobalSettingsViewPageProps<T>): ReactElement => {
     const entityUrl = entityDescription
         .split(' ')
@@ -73,7 +74,7 @@ export const GlobalSettingsViewPage = <T extends Entity>({
                                         </a>
                                     </li>
 
-                                    {globalSettingsDeleteEnabled && (
+                                    {deleteEnabled && (
                                         <li className="actions__item">
                                             <button
                                                 className="govuk-link govuk-!-font-size-16 govuk-!-font-weight-regular actions__delete"

--- a/repos/fdbt-site/src/components/PassengerTypeCard.tsx
+++ b/repos/fdbt-site/src/components/PassengerTypeCard.tsx
@@ -1,5 +1,4 @@
 import React, { ReactElement } from 'react';
-import { globalSettingsDeleteEnabled } from '../../src/constants/featureFlag';
 import { FullGroupPassengerType, SinglePassengerType } from '../interfaces';
 import { getProofDocumentsString, sentenceCaseString } from '../utils';
 
@@ -7,9 +6,15 @@ interface PassengerTypeCardProps {
     contents: FullGroupPassengerType | SinglePassengerType;
     deleteActionHandler?: (id: number, name: string, isGroup: boolean) => void;
     defaultChecked: boolean;
+    deleteEnabled: boolean;
 }
 
-const PassengerTypeCard = ({ contents, deleteActionHandler, defaultChecked }: PassengerTypeCardProps): ReactElement => {
+const PassengerTypeCard = ({
+    contents,
+    deleteActionHandler,
+    defaultChecked,
+    deleteEnabled,
+}: PassengerTypeCardProps): ReactElement => {
     const { name, id } = contents;
     const isGroup = 'groupPassengerType' in contents;
     return (
@@ -27,7 +32,7 @@ const PassengerTypeCard = ({ contents, deleteActionHandler, defaultChecked }: Pa
                                 </a>
                             </li>
 
-                            {globalSettingsDeleteEnabled && (
+                            {deleteEnabled && (
                                 <li className="actions__item">
                                     <button
                                         className="govuk-link govuk-!-font-size-16 govuk-!-font-weight-regular actions__delete"

--- a/repos/fdbt-site/src/components/RadioConditionalInput.tsx
+++ b/repos/fdbt-site/src/components/RadioConditionalInput.tsx
@@ -382,7 +382,7 @@ const renderConditionalRadioButton = (
     return (
         <div key={radio.id}>
             <div className="govuk-radios__item">
-                {radio.inputErrors.length > 0 || conditionalRadioInputDefaultExists(radio)
+                {radio.inputErrors.length > 0 || (conditionalRadioInputDefaultExists(radio) && !radio.disableAutoSelect)
                     ? checkedRadioInput
                     : uncheckedRadioInput}
                 {radioLabel}

--- a/repos/fdbt-site/src/constants/featureFlag.ts
+++ b/repos/fdbt-site/src/constants/featureFlag.ts
@@ -1,2 +1,2 @@
-export const globalSettingsEnabled = ['test', 'dev'].includes(process.env.STAGE || '');
-export const globalSettingsDeleteEnabled = false;
+export const globalSettingsEnabled = ['test', 'dev'].includes(process.env.STAGE ?? '');
+export const globalSettingsDeleteEnabled = ['test', 'dev'].includes(process.env.STAGE ?? '');

--- a/repos/fdbt-site/src/interfaces/index.ts
+++ b/repos/fdbt-site/src/interfaces/index.ts
@@ -651,6 +651,7 @@ export interface RadioWithoutConditionals extends BaseReactElement {
 }
 
 export interface RadioWithConditionalInputs extends RadioWithoutConditionals {
+    disableAutoSelect?: boolean;
     dataAriaControls: string;
     inputHint: {
         id: string;

--- a/repos/fdbt-site/src/pages/periodValidity.tsx
+++ b/repos/fdbt-site/src/pages/periodValidity.tsx
@@ -51,6 +51,7 @@ export const getFieldset = (errors: ErrorInfo[]): RadioConditionalInputFieldset 
                 id: 'period-end-of-service',
                 name: 'periodValid',
                 value: 'fareDayEnd',
+                disableAutoSelect: true,
                 dataAriaControls: 'period-validity-end-of-service-required-conditional',
                 label: 'End of service day',
                 radioButtonHint: {

--- a/repos/fdbt-site/src/pages/selectPassengerType.tsx
+++ b/repos/fdbt-site/src/pages/selectPassengerType.tsx
@@ -9,6 +9,7 @@ import { isPassengerType, isPassengerTypeAttributeWithErrors } from '../interfac
 import TwoThirdsLayout from '../layout/Layout';
 import { getAndValidateNoc, getCsrfToken } from '../utils';
 import { getSessionAttribute } from '../utils/sessions';
+import { globalSettingsDeleteEnabled } from '../constants/featureFlag';
 
 const title = 'Select Passenger Type - Create Fares Data Service';
 const description = 'Select Passenger Type selection page of the Create Fares Data Service';
@@ -19,6 +20,7 @@ interface PassengerTypeProps {
     savedGroups: FullGroupPassengerType[];
     savedPassengerTypes: SinglePassengerType[];
     selectedId: number | null;
+    deleteEnabled: boolean;
 }
 
 const SelectPassengerType = ({
@@ -27,6 +29,7 @@ const SelectPassengerType = ({
     savedGroups,
     savedPassengerTypes,
     selectedId,
+    deleteEnabled,
 }: PassengerTypeProps): ReactElement => (
     <TwoThirdsLayout title={title} description={description} errors={errors}>
         <CsrfForm action="/api/selectPassengerType" method="post" csrfToken={csrfToken}>
@@ -71,6 +74,7 @@ const SelectPassengerType = ({
                                             defaultChecked={selectedId === passengerType.id}
                                             contents={passengerType}
                                             key={passengerType.id.toString()}
+                                            deleteEnabled={deleteEnabled}
                                         />
                                     ))}
                                 </div>
@@ -84,6 +88,7 @@ const SelectPassengerType = ({
                                                     contents={passengerTypeGroup}
                                                     key={passengerTypeGroup.id.toString()}
                                                     defaultChecked={selectedId === passengerTypeGroup.id}
+                                                    deleteEnabled={deleteEnabled}
                                                 />
                                             ))}
                                         </>
@@ -135,6 +140,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
             savedGroups: groupPassengerTypes,
             savedPassengerTypes: singlePassengerTypes,
             selectedId,
+            deleteEnabled: globalSettingsDeleteEnabled,
         },
     };
 };

--- a/repos/fdbt-site/src/pages/selectPeriodValidity.tsx
+++ b/repos/fdbt-site/src/pages/selectPeriodValidity.tsx
@@ -50,6 +50,7 @@ export const getFieldset = (errors: ErrorInfo[], endOfFareDay?: string): RadioCo
             },
             {
                 id: 'period-end-of-service',
+                disableAutoSelect: true,
                 name: 'periodValid',
                 value: 'fareDayEnd',
                 dataAriaControls: 'period-validity-end-of-service-required-conditional',

--- a/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
+++ b/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
@@ -10,6 +10,7 @@ import SubNavigation from '../layout/SubNavigation';
 import { getAndValidateNoc, getCsrfToken } from '../utils';
 import { extractGlobalSettingsReferer } from '../utils/globalSettings';
 import { updateSessionAttribute } from '../utils/sessions';
+import { globalSettingsDeleteEnabled } from '../constants/featureFlag';
 
 const title = 'Passenger Types - Create Fares Data Service';
 const description = 'View and edit your passenger types.';
@@ -19,6 +20,7 @@ interface PassengerTypeProps {
     singlePassengerTypes: SinglePassengerType[];
     groupPassengerTypes: FullGroupPassengerType[];
     referer: string | null;
+    deleteEnabled: boolean;
 }
 
 const ViewPassengerTypes = ({
@@ -26,6 +28,7 @@ const ViewPassengerTypes = ({
     groupPassengerTypes,
     csrfToken,
     referer,
+    deleteEnabled,
 }: PassengerTypeProps): ReactElement => {
     const [popUpState, setPopUpState] = useState<{
         passengerTypeName: string;
@@ -76,6 +79,7 @@ const ViewPassengerTypes = ({
                             <IndividualPassengerTypes
                                 singlePassengerTypes={singlePassengerTypes}
                                 deleteActionHandler={deleteActionHandler}
+                                deleteEnabled={deleteEnabled}
                             />
                         )}
 
@@ -95,6 +99,7 @@ const ViewPassengerTypes = ({
                             <PassengerTypeGroups
                                 deleteActionHandler={deleteActionHandler}
                                 passengerTypeGroups={groupPassengerTypes}
+                                deleteEnabled={deleteEnabled}
                             />
                         )}
 
@@ -142,11 +147,13 @@ const NoIndividualPassengerTypes = (): ReactElement => {
 interface IndividualPassengerTypesProps {
     singlePassengerTypes: SinglePassengerType[];
     deleteActionHandler: (id: number, name: string, isGroup: boolean) => void;
+    deleteEnabled: boolean;
 }
 
 const IndividualPassengerTypes = ({
     singlePassengerTypes,
     deleteActionHandler,
+    deleteEnabled,
 }: IndividualPassengerTypesProps): ReactElement => {
     return (
         <>
@@ -159,6 +166,7 @@ const IndividualPassengerTypes = ({
                         deleteActionHandler={deleteActionHandler}
                         key={singlePassengerType.id.toString()}
                         defaultChecked={false}
+                        deleteEnabled={deleteEnabled}
                     />
                 ))}
             </div>
@@ -185,9 +193,14 @@ const NoPassengerTypeGroups = (): ReactElement => {
 interface PassengerTypeGroupProps {
     deleteActionHandler: (id: number, name: string, isGroup: boolean) => void;
     passengerTypeGroups: FullGroupPassengerType[];
+    deleteEnabled: boolean;
 }
 
-const PassengerTypeGroups = ({ deleteActionHandler, passengerTypeGroups }: PassengerTypeGroupProps): ReactElement => {
+const PassengerTypeGroups = ({
+    deleteActionHandler,
+    passengerTypeGroups,
+    deleteEnabled,
+}: PassengerTypeGroupProps): ReactElement => {
     return (
         <>
             <h2 className="govuk-heading-l">Groups</h2>
@@ -199,6 +212,7 @@ const PassengerTypeGroups = ({ deleteActionHandler, passengerTypeGroups }: Passe
                         deleteActionHandler={deleteActionHandler}
                         key={passengerTypeGroup.id}
                         defaultChecked={false}
+                        deleteEnabled={deleteEnabled}
                     />
                 ))}
             </div>
@@ -221,6 +235,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
             singlePassengerTypes: singlePassengerTypes,
             groupPassengerTypes,
             referer: extractGlobalSettingsReferer(ctx),
+            deleteEnabled: globalSettingsDeleteEnabled,
         },
     };
 };

--- a/repos/fdbt-site/src/pages/viewPurchaseMethods.tsx
+++ b/repos/fdbt-site/src/pages/viewPurchaseMethods.tsx
@@ -7,6 +7,7 @@ import { getAndValidateNoc, getCsrfToken } from '../utils';
 import { extractGlobalSettingsReferer } from '../utils/globalSettings';
 import { sopTicketFormatConverter } from './salesConfirmation';
 import { formatSOPArray } from './selectSalesOfferPackage';
+import { globalSettingsDeleteEnabled } from '../constants/featureFlag';
 
 const title = 'Purchase methods';
 const description =
@@ -16,9 +17,15 @@ interface PurchaseMethodProps {
     csrfToken: string;
     purchaseMethods: FromDb<SalesOfferPackage>[];
     referer: string | null;
+    deleteEnabled: boolean;
 }
 
-const ViewPurchaseMethods = ({ purchaseMethods, referer, csrfToken }: PurchaseMethodProps): ReactElement => {
+const ViewPurchaseMethods = ({
+    purchaseMethods,
+    referer,
+    csrfToken,
+    deleteEnabled,
+}: PurchaseMethodProps): ReactElement => {
     return (
         <>
             <GlobalSettingsViewPage
@@ -29,6 +36,7 @@ const ViewPurchaseMethods = ({ purchaseMethods, referer, csrfToken }: PurchaseMe
                 title={title}
                 description={description}
                 CardBody={PurchaseMethodCardBody}
+                deleteEnabled={deleteEnabled}
             />
         </>
     );
@@ -59,7 +67,14 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     const nationalOperatorCode = getAndValidateNoc(ctx);
     const purchaseMethods = await getSalesOfferPackagesByNocCode(nationalOperatorCode);
 
-    return { props: { purchaseMethods: purchaseMethods, referer: extractGlobalSettingsReferer(ctx), csrfToken } };
+    return {
+        props: {
+            purchaseMethods: purchaseMethods,
+            referer: extractGlobalSettingsReferer(ctx),
+            csrfToken,
+            deleteEnabled: globalSettingsDeleteEnabled,
+        },
+    };
 };
 
 export default ViewPurchaseMethods;

--- a/repos/fdbt-site/src/pages/viewTimeRestrictions.tsx
+++ b/repos/fdbt-site/src/pages/viewTimeRestrictions.tsx
@@ -4,6 +4,7 @@ import { getTimeRestrictionByNocCode } from '../data/auroradb';
 import { NextPageContextWithSession, PremadeTimeRestriction, DbTimeBand } from '../interfaces';
 import { getAndValidateNoc, getCsrfToken } from '../utils';
 import { extractGlobalSettingsReferer } from '../utils/globalSettings';
+import { globalSettingsDeleteEnabled } from '../constants/featureFlag';
 
 const title = 'Time restrictions';
 const description = 'Define certain days and time periods that your tickets can be used within.';
@@ -23,6 +24,7 @@ interface TimeRestrictionProps {
     csrfToken: string;
     timeRestrictions: PremadeTimeRestriction[];
     referer: string | null;
+    deleteEnabled: boolean;
 }
 
 const formatTime = (time: string | object): string =>
@@ -43,7 +45,12 @@ const formatDayRestriction = (timeRestriction: PremadeTimeRestriction, day: stri
     );
 };
 
-const ViewTimeRestrictions = ({ timeRestrictions, referer, csrfToken }: TimeRestrictionProps): ReactElement => {
+const ViewTimeRestrictions = ({
+    timeRestrictions,
+    referer,
+    csrfToken,
+    deleteEnabled,
+}: TimeRestrictionProps): ReactElement => {
     return (
         <>
             <GlobalSettingsViewPage
@@ -54,6 +61,7 @@ const ViewTimeRestrictions = ({ timeRestrictions, referer, csrfToken }: TimeRest
                 title={title}
                 description={description}
                 CardBody={TimeRestrictionCardBody}
+                deleteEnabled={deleteEnabled}
             />
         </>
     );
@@ -89,7 +97,14 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     const nationalOperatorCode = getAndValidateNoc(ctx);
     const timeRestrictions = await getTimeRestrictionByNocCode(nationalOperatorCode);
 
-    return { props: { timeRestrictions, referer: extractGlobalSettingsReferer(ctx), csrfToken } };
+    return {
+        props: {
+            timeRestrictions,
+            referer: extractGlobalSettingsReferer(ctx),
+            csrfToken,
+            deleteEnabled: globalSettingsDeleteEnabled,
+        },
+    };
 };
 
 export default ViewTimeRestrictions;

--- a/repos/fdbt-site/tests/components/GlobalSettingsViewPage.test.tsx
+++ b/repos/fdbt-site/tests/components/GlobalSettingsViewPage.test.tsx
@@ -1,7 +1,6 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { GlobalSettingsViewPage } from '../../src/components/GlobalSettingsViewPage';
-import * as featureFlag from '../../src/constants/featureFlag';
 
 const CardBody = ({ entity: { id, name } }: { entity: { id: number; name: string } }) => (
     <h1>
@@ -20,6 +19,7 @@ describe('GlobalSettingsViewPage', () => {
                 description="my description"
                 entityDescription="my entity description"
                 CardBody={CardBody}
+                deleteEnabled={false}
             />,
         );
         expect(tree).toMatchSnapshot();
@@ -39,16 +39,13 @@ describe('GlobalSettingsViewPage', () => {
                 description="my description"
                 entityDescription="my entity description"
                 CardBody={CardBody}
+                deleteEnabled={false}
             />,
         );
         expect(tree).toMatchSnapshot();
     });
 
     it('should render correctly when entities exist and delete is enabled', () => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        featureFlag.globalSettingsDeleteEnabled = true;
-
         const tree = shallow(
             <GlobalSettingsViewPage
                 csrfToken={''}
@@ -62,6 +59,7 @@ describe('GlobalSettingsViewPage', () => {
                 description="my description"
                 entityDescription="my entity description"
                 CardBody={CardBody}
+                deleteEnabled={true}
             />,
         );
 

--- a/repos/fdbt-site/tests/pages/__snapshots__/globalSettingsPeriodValidity.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/globalSettingsPeriodValidity.test.tsx.snap
@@ -69,6 +69,7 @@ exports[`pages periodValidity should render correctly 1`] = `
                 },
                 Object {
                   "dataAriaControls": "period-validity-end-of-service-required-conditional",
+                  "disableAutoSelect": true,
                   "id": "period-end-of-service",
                   "inputErrors": Array [],
                   "inputHint": Object {
@@ -194,6 +195,7 @@ exports[`pages periodValidity should render error messaging when errors are pass
                 },
                 Object {
                   "dataAriaControls": "period-validity-end-of-service-required-conditional",
+                  "disableAutoSelect": true,
                   "id": "period-end-of-service",
                   "inputErrors": Array [],
                   "inputHint": Object {

--- a/repos/fdbt-site/tests/pages/__snapshots__/periodValidity.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/periodValidity.test.tsx.snap
@@ -69,6 +69,7 @@ exports[`pages periodValidity should render correctly 1`] = `
                 },
                 Object {
                   "dataAriaControls": "period-validity-end-of-service-required-conditional",
+                  "disableAutoSelect": true,
                   "id": "period-end-of-service",
                   "inputErrors": Array [],
                   "inputHint": Object {
@@ -193,6 +194,7 @@ exports[`pages periodValidity should render error messaging when errors are pass
                 },
                 Object {
                   "dataAriaControls": "period-validity-end-of-service-required-conditional",
+                  "disableAutoSelect": true,
                   "id": "period-end-of-service",
                   "inputErrors": Array [],
                   "inputHint": Object {

--- a/repos/fdbt-site/tests/pages/__snapshots__/selectPassengerType.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/selectPassengerType.test.tsx.snap
@@ -164,6 +164,7 @@ exports[`pages selectPassengerType should render correctly with no saved groups 
               }
             }
             defaultChecked={false}
+            deleteEnabled={false}
             key="3"
           />
           <PassengerTypeCard
@@ -180,6 +181,7 @@ exports[`pages selectPassengerType should render correctly with no saved groups 
               }
             }
             defaultChecked={false}
+            deleteEnabled={false}
             key="2"
           />
         </div>
@@ -305,6 +307,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
               }
             }
             defaultChecked={false}
+            deleteEnabled={false}
             key="3"
           />
           <PassengerTypeCard
@@ -321,6 +324,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
               }
             }
             defaultChecked={false}
+            deleteEnabled={false}
             key="2"
           />
         </div>
@@ -364,6 +368,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
               }
             }
             defaultChecked={true}
+            deleteEnabled={false}
             key="1"
           />
           <PassengerTypeCard
@@ -389,6 +394,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
               }
             }
             defaultChecked={false}
+            deleteEnabled={false}
             key="4"
           />
         </div>
@@ -508,6 +514,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
               }
             }
             defaultChecked={false}
+            deleteEnabled={false}
             key="3"
           />
           <PassengerTypeCard
@@ -524,6 +531,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
               }
             }
             defaultChecked={false}
+            deleteEnabled={false}
             key="2"
           />
         </div>
@@ -567,6 +575,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
               }
             }
             defaultChecked={false}
+            deleteEnabled={false}
             key="1"
           />
           <PassengerTypeCard
@@ -592,6 +601,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
               }
             }
             defaultChecked={false}
+            deleteEnabled={false}
             key="4"
           />
         </div>

--- a/repos/fdbt-site/tests/pages/__snapshots__/viewPassengerTypes.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/viewPassengerTypes.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`pages view passenger types should render correctly when groups and indi
       <div>
         <IndividualPassengerTypes
           deleteActionHandler={[Function]}
+          deleteEnabled={false}
           singlePassengerTypes={
             Array [
               Object {
@@ -62,6 +63,7 @@ exports[`pages view passenger types should render correctly when groups and indi
       >
         <PassengerTypeGroups
           deleteActionHandler={[Function]}
+          deleteEnabled={false}
           passengerTypeGroups={
             Array [
               Object {
@@ -184,6 +186,7 @@ exports[`pages view passenger types should render correctly when only individual
       <div>
         <IndividualPassengerTypes
           deleteActionHandler={[Function]}
+          deleteEnabled={false}
           singlePassengerTypes={
             Array [
               Object {
@@ -270,6 +273,7 @@ exports[`pages view passenger types should render correctly when only passenger 
       >
         <PassengerTypeGroups
           deleteActionHandler={[Function]}
+          deleteEnabled={false}
           passengerTypeGroups={
             Array [
               Object {

--- a/repos/fdbt-site/tests/pages/__snapshots__/viewPurchaseMethods.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/viewPurchaseMethods.test.tsx.snap
@@ -48,6 +48,7 @@ exports[`pages view purchase methods should render correctly with purchase metho
   <GlobalSettingsViewPage
     CardBody={[Function]}
     csrfToken=""
+    deleteEnabled={false}
     description="Define the way your tickets are sold, including where they are bought, the payment method and format"
     entities={
       Array [

--- a/repos/fdbt-site/tests/pages/__snapshots__/viewTimeRestrictions.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/viewTimeRestrictions.test.tsx.snap
@@ -155,6 +155,7 @@ exports[`pages view time restrictions should render correctly when no time restr
   <GlobalSettingsViewPage
     CardBody={[Function]}
     csrfToken=""
+    deleteEnabled={false}
     description="Define certain days and time periods that your tickets can be used within."
     entities={Array []}
     entityDescription="time restriction"
@@ -169,6 +170,7 @@ exports[`pages view time restrictions should render correctly when time restrict
   <GlobalSettingsViewPage
     CardBody={[Function]}
     csrfToken=""
+    deleteEnabled={false}
     description="Define certain days and time periods that your tickets can be used within."
     entities={
       Array [

--- a/repos/fdbt-site/tests/pages/selectPassengerType.test.tsx
+++ b/repos/fdbt-site/tests/pages/selectPassengerType.test.tsx
@@ -85,6 +85,7 @@ describe('pages', () => {
                     savedGroups={savedGroups}
                     savedPassengerTypes={savedPassengerTypes}
                     selectedId={1}
+                    deleteEnabled={false}
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -97,6 +98,7 @@ describe('pages', () => {
                     savedGroups={savedGroups}
                     savedPassengerTypes={savedPassengerTypes}
                     selectedId={null}
+                    deleteEnabled={false}
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -109,6 +111,7 @@ describe('pages', () => {
                     savedGroups={[]}
                     savedPassengerTypes={savedPassengerTypes}
                     selectedId={null}
+                    deleteEnabled={false}
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -122,6 +125,7 @@ describe('pages', () => {
                     savedGroups={[]}
                     savedPassengerTypes={[]}
                     selectedId={null}
+                    deleteEnabled={false}
                 />,
             );
             expect(tree).toMatchSnapshot();

--- a/repos/fdbt-site/tests/pages/viewPassengerTypes.test.tsx
+++ b/repos/fdbt-site/tests/pages/viewPassengerTypes.test.tsx
@@ -7,7 +7,13 @@ describe('pages', () => {
     describe('view passenger types', () => {
         it('should render correctly when no individual or group passenger types', () => {
             const tree = shallow(
-                <ViewPassengerTypes singlePassengerTypes={[]} groupPassengerTypes={[]} csrfToken={''} referer={null} />,
+                <ViewPassengerTypes
+                    singlePassengerTypes={[]}
+                    groupPassengerTypes={[]}
+                    csrfToken={''}
+                    referer={null}
+                    deleteEnabled={false}
+                />,
             );
 
             expect(tree).toMatchSnapshot();
@@ -31,6 +37,7 @@ describe('pages', () => {
                     groupPassengerTypes={[]}
                     csrfToken={''}
                     referer={'hello'}
+                    deleteEnabled={false}
                 />,
             );
 
@@ -68,6 +75,7 @@ describe('pages', () => {
                     groupPassengerTypes={[passengerTypeGroup]}
                     csrfToken={''}
                     referer={null}
+                    deleteEnabled={false}
                 />,
             );
 
@@ -119,6 +127,7 @@ describe('pages', () => {
                     groupPassengerTypes={passengerTypeGroups}
                     csrfToken={''}
                     referer={'hello'}
+                    deleteEnabled={false}
                 />,
             );
             expect(tree).toMatchSnapshot();

--- a/repos/fdbt-site/tests/pages/viewPurchaseMethods.test.tsx
+++ b/repos/fdbt-site/tests/pages/viewPurchaseMethods.test.tsx
@@ -13,7 +13,12 @@ describe('pages', () => {
     describe('view purchase methods', () => {
         it('should render correctly with purchase methods', () => {
             const tree = shallow(
-                <ViewPurchaseMethods csrfToken={''} purchaseMethods={purchaseMethods} referer={'hello'} />,
+                <ViewPurchaseMethods
+                    csrfToken={''}
+                    purchaseMethods={purchaseMethods}
+                    referer={'hello'}
+                    deleteEnabled={false}
+                />,
             );
             expect(tree).toMatchSnapshot();
         });

--- a/repos/fdbt-site/tests/pages/viewTimeRestrictions.test.tsx
+++ b/repos/fdbt-site/tests/pages/viewTimeRestrictions.test.tsx
@@ -56,13 +56,20 @@ const timeRestrictions: PremadeTimeRestriction[] = [
 describe('pages', () => {
     describe('view time restrictions', () => {
         it('should render correctly when no time restrictions', () => {
-            const tree = shallow(<ViewTimeRestrictions csrfToken={''} timeRestrictions={[]} referer={null} />);
+            const tree = shallow(
+                <ViewTimeRestrictions csrfToken={''} timeRestrictions={[]} referer={null} deleteEnabled={false} />,
+            );
             expect(tree).toMatchSnapshot();
         });
 
         it('should render correctly when time restrictions exist', () => {
             const tree = shallow(
-                <ViewTimeRestrictions csrfToken={''} timeRestrictions={timeRestrictions} referer={'hello'} />,
+                <ViewTimeRestrictions
+                    csrfToken={''}
+                    timeRestrictions={timeRestrictions}
+                    referer={'hello'}
+                    deleteEnabled={false}
+                />,
             );
             expect(tree).toMatchSnapshot();
         });

--- a/repos/fdbt-site/tests/testData/mockData.ts
+++ b/repos/fdbt-site/tests/testData/mockData.ts
@@ -3795,6 +3795,7 @@ export const mockPeriodValidityFieldset: RadioConditionalInputFieldset = {
             id: 'period-end-of-service',
             name: 'periodValid',
             value: 'fareDayEnd',
+            disableAutoSelect: true,
             dataAriaControls: 'period-validity-end-of-service-required-conditional',
             label: 'End of service day',
             radioButtonHint: {
@@ -3853,6 +3854,7 @@ export const mockSelectPeriodValidityFieldset: RadioConditionalInputFieldset = {
             id: 'period-end-of-service',
             name: 'periodValid',
             value: 'fareDayEnd',
+            disableAutoSelect: true,
             dataAriaControls: 'period-validity-end-of-service-required-conditional',
             label: 'Fare day end',
             radioButtonHint: {
@@ -3912,6 +3914,8 @@ export const mockPeriodValidityFieldsetWithErrors: RadioConditionalInputFieldset
             id: 'period-end-of-service',
             name: 'periodValid',
             value: 'fareDayEnd',
+
+            disableAutoSelect: true,
             dataAriaControls: 'period-validity-end-of-service-required-conditional',
             label: 'End of service day',
             radioButtonHint: {
@@ -3975,6 +3979,8 @@ export const mockSelectPeriodValidityFieldsetWithErrors: RadioConditionalInputFi
             id: 'period-end-of-service',
             name: 'periodValid',
             value: 'fareDayEnd',
+
+            disableAutoSelect: true,
             dataAriaControls: 'period-validity-end-of-service-required-conditional',
             label: 'Fare day end',
             radioButtonHint: {
@@ -4039,6 +4045,8 @@ export const mockPeriodValidityFieldsetWithInputErrors: RadioConditionalInputFie
             id: 'period-end-of-service',
             name: 'periodValid',
             value: 'fareDayEnd',
+
+            disableAutoSelect: true,
             dataAriaControls: 'period-validity-end-of-service-required-conditional',
             label: 'End of service day',
             radioButtonHint: {
@@ -4102,6 +4110,8 @@ export const mockSelectPeriodValidityFieldsetWithInputErrors: RadioConditionalIn
             id: 'period-end-of-service',
             name: 'periodValid',
             value: 'fareDayEnd',
+
+            disableAutoSelect: true,
             dataAriaControls: 'period-validity-end-of-service-required-conditional',
             label: 'Fare day end',
             radioButtonHint: {


### PR DESCRIPTION
# Description

-   Disable auto selection of fare day end option + UI test fixes

# Testing instructions

-   Make sure the fare day end option on the period validity page is not auto selected

# Type of change

-   [ ] feat - A new feature
-   [X] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
