### PR TITLE
fix: Error when parsing unassigned fare stages

### DIFF
--- a/repos/fdbt-site/src/utils/apiUtils/matching.ts
+++ b/repos/fdbt-site/src/utils/apiUtils/matching.ts
@@ -1,5 +1,4 @@
 import { NextApiRequest } from 'next';
-import isArray from 'lodash/isArray';
 import { Stop, UserFareStages } from '../../interfaces';
 import { MatchingFareZones, MatchingFareZonesData } from '../../interfaces/matchingInterface';
 
@@ -30,18 +29,20 @@ export const getMatchingFareZonesAndUnassignedStopsFromForm = (
     const bodyValues: string[] = Object.values(req.body);
     const unassignedStops: Stop[] = [];
 
-    bodyValues.forEach((stopSelection: string) => {
-        const stageName = stopSelection[0];
-
-        if (isArray(stopSelection) && stageName === 'notApplicable') {
+    bodyValues.forEach((stopSelection: string | string[]) => {
+        if (stopSelection === 'yes') {
+            // skip the 'yes' value
+        } else if (Array.isArray(stopSelection) && stopSelection[0] === 'notApplicable') {
             unassignedStops.push(JSON.parse(stopSelection[1]));
-        } else if (!isArray(stopSelection)) {
+        } else if (!Array.isArray(stopSelection)) {
             const item = JSON.parse(stopSelection);
-            if ('naptanCode' in item) {
+            if ('stopName' in item) {
                 unassignedStops.push(item);
             }
-        } else if (stageName && typeof stageName === 'string' && isArray(stopSelection)) {
+        } else if (Array.isArray(stopSelection) && stopSelection[0]) {
             const stop = JSON.parse(stopSelection[1]);
+
+            const stageName = stopSelection[0];
 
             if (matchingFareZones[stageName]) {
                 matchingFareZones[stageName].stops.push(stop);


### PR DESCRIPTION
# Description

-   Fix error when parsing unassigned fare stages

# Testing instructions

-   Check the box that allows you to skip using all fare stages for a return stop mapping
-   Check you get no errors

# Type of change

-   [ ] feat - A new feature
-   [X] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
