### PR TITLE
feat: force scheme operators to fill out operator details

### DIFF
--- a/repos/fdbt-site/src/pages/fareType.tsx
+++ b/repos/fdbt-site/src/pages/fareType.tsx
@@ -6,7 +6,7 @@ import FormElementWrapper from '../components/FormElementWrapper';
 import RadioButtons from '../components/RadioButtons';
 import { INTERNAL_NOC } from '../constants';
 import { FARE_TYPE_ATTRIBUTE, GS_REFERER, OPERATOR_ATTRIBUTE, TXC_SOURCE_ATTRIBUTE } from '../constants/attributes';
-import { getAllServicesByNocCode } from '../data/auroradb';
+import { getAllServicesByNocCode, getOperatorDetails } from '../data/auroradb';
 import { ErrorInfo, NextPageContextWithSession, RadioOption } from '../interfaces';
 import { isFareTypeAttributeWithErrors } from '../interfaces/typeGuards';
 import TwoThirdsLayout from '../layout/Layout';
@@ -174,6 +174,11 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
 
     if (schemeOp) {
         updateSessionAttribute(ctx.req, FARE_TYPE_ATTRIBUTE, { fareType: 'multiOperator' });
+        const operatorDetails = await getOperatorDetails(nocCode);
+        if (!operatorDetails && ctx.res) {
+            updateSessionAttribute(ctx.req, GS_REFERER, 'fareType');
+            redirectTo(ctx.res, '/manageOperatorDetails');
+        }
     }
 
     const fareTypeAttribute = getSessionAttribute(ctx.req, FARE_TYPE_ATTRIBUTE);

--- a/repos/fdbt-site/src/pages/manageOperatorDetails.tsx
+++ b/repos/fdbt-site/src/pages/manageOperatorDetails.tsx
@@ -6,7 +6,7 @@ import { ErrorInfo, NextPageContextWithSession } from '../interfaces';
 import FormElementWrapper, { FormGroupWrapper } from '../components/FormElementWrapper';
 import { getSessionAttribute, updateSessionAttribute } from '../utils/sessions';
 import { GS_OPERATOR_DETAILS_ATTRIBUTE } from '../constants/attributes';
-import { getAndValidateNoc, getCsrfToken } from '../utils';
+import { getAndValidateNoc, getCsrfToken, isSchemeOperator } from '../utils';
 import { getOperatorDetails, getOperatorDetailsFromNocTable } from '../data/auroradb';
 import { extractGlobalSettingsReferer } from '../utils/globalSettings';
 import SubNavigation from '../layout/SubNavigation';
@@ -147,6 +147,7 @@ export const getServerSideProps = async (
 ): Promise<{ props: ManageOperatorDetailsProps }> => {
     const attribute = getSessionAttribute(ctx.req, GS_OPERATOR_DETAILS_ATTRIBUTE);
     const noc = getAndValidateNoc(ctx);
+    const schemeOp = isSchemeOperator(ctx);
 
     const operatorDetails =
         attribute && 'input' in attribute
@@ -168,6 +169,13 @@ export const getServerSideProps = async (
     if (saved) {
         // only want the saved banner to display once
         updateSessionAttribute(ctx.req, GS_OPERATOR_DETAILS_ATTRIBUTE, undefined);
+    }
+
+    if (schemeOp && operatorDetails.operatorName === '') {
+        errors.splice(0, 0, {
+            errorMessage: 'Before you can create any fare information, you must provide the information below',
+            id: 'operatorName-input',
+        });
     }
 
     return {

--- a/repos/fdbt-site/src/utils/globalSettings.ts
+++ b/repos/fdbt-site/src/utils/globalSettings.ts
@@ -8,9 +8,13 @@ export const extractGlobalSettingsReferer = (ctx: NextPageContextWithSession): s
     const refererPage = path?.[path.length - 1];
     if (
         refererPage &&
-        ['selectPassengerType', 'selectTimeRestrictions', 'selectPurchaseMethods', 'selectPeriodValidity'].includes(
-            refererPage,
-        )
+        [
+            'selectPassengerType',
+            'selectTimeRestrictions',
+            'selectPurchaseMethods',
+            'selectPeriodValidity',
+            'fareType',
+        ].includes(refererPage)
     ) {
         updateSessionAttribute(ctx.req, GS_REFERER, refererPage);
     }


### PR DESCRIPTION
# Description

-   To ensure scheme operators fill out their operator details before creating netex.

# Testing instructions

-  Run locally and use disabeAuth=scheme , then attempt to create netex.

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
