### PR TITLE
feat: time restrictions use id's

### DIFF
--- a/repos/exporter/lib/database.ts
+++ b/repos/exporter/lib/database.ts
@@ -80,3 +80,49 @@ export const getPassengerTypeById = async (passengerId: number, noc: string): Pr
         passengerType: JSON.parse(contents) as PassengerType,
     };
 };
+
+export interface DbTimeRestriction {
+    day: TimeRestrictionDay;
+    timeBands: DbTimeBand[];
+}
+
+export interface DbTimeBand {
+    startTime: string;
+    endTime: string | { fareDayEnd: boolean };
+}
+
+export type TimeRestrictionDay =
+    | 'monday'
+    | 'tuesday'
+    | 'wednesday'
+    | 'thursday'
+    | 'friday'
+    | 'saturday'
+    | 'sunday'
+    | 'bankHoliday';
+
+export const getTimeRestrictionsByIdAndNoc = async (timeRestrictionId: number, noc: string): Promise<DbTimeRestriction[]> => {
+    try {
+        const queryInput = `
+            SELECT contents
+            FROM timeRestriction
+            WHERE nocCode = ?
+            AND id = ?
+        `;
+
+        const queryResults = await executeQuery<
+            {
+                id: number;
+                nocCode: string;
+                name: string;
+                contents: string;
+            }[]
+        >(queryInput, [noc, timeRestrictionId]);
+
+        return queryResults.map((item) => {
+            return JSON.parse(item.contents) as DbTimeRestriction;
+        });
+    } catch (error) {
+        throw new Error(`Could not retrieve time restriction by nocCode from AuroraDB: ${error.stack}`);
+    }
+};

--- a/repos/exporter/lib/handler.ts
+++ b/repos/exporter/lib/handler.ts
@@ -1,7 +1,7 @@
 import { Handler } from 'aws-lambda';
 import { S3 } from 'aws-sdk';
-import { WithIds, BaseTicket, TicketWithIds } from '../shared/matchingJsonTypes';
-import { getPassengerTypeById, getTimeRestrictionsByIdAndNoc } from './database';
+import { WithIds, BaseTicket, TimeBand, FullTimeRestriction } from '../shared/matchingJsonTypes';
+import { getFareDayEnd, getPassengerTypeById, getTimeRestrictionsByIdAndNoc } from './database';
 import { ExportLambdaBody } from '../shared/integrationTypes';
 import 'source-map-support/register';
 
@@ -43,9 +43,38 @@ export const handler: Handler<ExportLambdaBody> = async ({ paths, noc }) => {
                     ? { passengerType: 'group' }
                     : (await getPassengerTypeById(productData.passengerType.id, noc)).passengerType;
 
-            const timeRestriction = productData.timeRestriction && 'id' in productData.timeRestriction ? await getTimeRestrictionsByIdAndNoc(productData.timeRestriction.id, noc) : [];
+            const timeRestriction = productData.timeRestriction
+                ? await getTimeRestrictionsByIdAndNoc(productData.timeRestriction.id, noc)
+                : [];
 
-            const ticket: BaseTicket = { ...productData, ...passengerType, ...timeRestriction };
+            const fareDayEnd = await getFareDayEnd(noc);
+
+            const timeRestrictionWithUpdatedFareDayEnds: FullTimeRestriction[] = timeRestriction.map((timeRestriction) => ({
+                ...timeRestriction,
+                timeBands: timeRestriction.timeBands.map((timeBand) => {
+                    let endTime: string;
+                    if (typeof timeBand.endTime === 'string') {
+                        endTime = timeBand.endTime;
+                    } else {
+                        if (!fareDayEnd) {
+                            throw new Error('No fare day end set for time restriction');
+                        }
+
+                        endTime = fareDayEnd;
+                    }
+
+                    return {
+                        ...timeBand,
+                        endTime: endTime,
+                    };
+                }),
+            }));
+
+            const ticket: BaseTicket = {
+                ...productData,
+                ...passengerType,
+                timeRestriction: timeRestrictionWithUpdatedFareDayEnds,
+            };
 
             await s3.putObject({ Key: path, Bucket: MATCHING_DATA_BUCKET, Body: JSON.stringify(ticket) }).promise();
         }),

--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -2,6 +2,7 @@ import awsParamStore from 'aws-param-store';
 import dateFormat from 'dateformat';
 import { ResultSetHeader } from 'mysql2';
 import { createPool, Pool } from 'mysql2/promise';
+import { DbTimeRestriction } from 'shared/dbTypes';
 import { FromDb, OperatorDetails } from '../../shared/matchingJsonTypes';
 import { INTERNAL_NOC } from '../constants';
 import {
@@ -19,7 +20,6 @@ import {
     GroupPassengerTypeDb,
     GroupPassengerTypeReference,
     FullGroupPassengerType,
-    DbTimeRestriction,
     MyFaresService,
     MyFaresProduct,
     MyFaresOtherProduct,

--- a/repos/fdbt-site/src/interfaces/index.ts
+++ b/repos/fdbt-site/src/interfaces/index.ts
@@ -2,7 +2,7 @@ import { IncomingMessage, ServerResponse } from 'http';
 import { NextApiRequest, NextPageContext } from 'next';
 import { DocumentContext } from 'next/document';
 import { ReactElement } from 'react';
-import { SinglePassengerType } from '../../shared/dbTypes';
+import { DbTimeRestriction, SinglePassengerType } from '../../shared/dbTypes';
 import {
     BaseProduct,
     CarnetDetails,
@@ -16,7 +16,6 @@ import {
     SalesOfferPackage,
     SelectedService,
     TicketType,
-    TimeRestrictionDay,
 } from '../../shared/matchingJsonTypes';
 
 // Session Attributes and Cookies
@@ -257,16 +256,6 @@ export interface PremadeTimeRestriction {
     id: number;
     name: string;
     contents: DbTimeRestriction[];
-}
-
-export interface DbTimeBand {
-    startTime: string;
-    endTime: string | { fareDayEnd: boolean };
-}
-
-export interface DbTimeRestriction {
-    day: TimeRestrictionDay;
-    timeBands: DbTimeBand[];
 }
 
 export interface DbTimeInput {

--- a/repos/fdbt-site/src/pages/api/manageTimeRestriction.ts
+++ b/repos/fdbt-site/src/pages/api/manageTimeRestriction.ts
@@ -1,6 +1,6 @@
 import isArray from 'lodash/isArray';
 import { NextApiResponse } from 'next';
-import { TimeRestrictionDay } from 'shared/matchingJsonTypes';
+import { DbTimeBand, TimeRestrictionDay } from 'shared/matchingJsonTypes';
 import { GS_TIME_RESTRICTION_ATTRIBUTE } from '../../constants/attributes';
 import {
     getTimeRestrictionByNameAndNoc,
@@ -8,11 +8,12 @@ import {
     updateTimeRestriction,
     getFareDayEnd,
 } from '../../data/auroradb';
-import { ErrorInfo, NextApiRequestWithSession, DbTimeRestriction, DbTimeBand } from '../../interfaces';
+import { ErrorInfo, NextApiRequestWithSession } from '../../interfaces';
 import { updateSessionAttribute } from '../../utils/sessions';
 import { getAndValidateNoc, redirectTo, redirectToError } from '../../utils/apiUtils';
 import { isValid24hrTimeFormat, removeAllWhiteSpace, removeExcessWhiteSpace } from '../../utils/apiUtils/validator';
 import { toArray } from '../../utils';
+import { DbTimeRestriction } from 'shared/dbTypes';
 
 export const collectInputsFromRequest = (
     req: NextApiRequestWithSession,

--- a/repos/fdbt-site/src/pages/viewTimeRestrictions.tsx
+++ b/repos/fdbt-site/src/pages/viewTimeRestrictions.tsx
@@ -1,10 +1,11 @@
 import React, { FunctionComponent, ReactElement } from 'react';
 import { GlobalSettingsViewPage } from '../components/GlobalSettingsViewPage';
 import { getTimeRestrictionByNocCode } from '../data/auroradb';
-import { NextPageContextWithSession, PremadeTimeRestriction, DbTimeBand } from '../interfaces';
+import { NextPageContextWithSession, PremadeTimeRestriction } from '../interfaces';
 import { getAndValidateNoc, getCsrfToken } from '../utils';
 import { extractGlobalSettingsReferer } from '../utils/globalSettings';
 import { globalSettingsDeleteEnabled, myFaresEnabled } from '../constants/featureFlag';
+import { DbTimeBand } from 'shared/matchingJsonTypes';
 
 const title = 'Time restrictions';
 const description = 'Define certain days and time periods that your tickets can be used within.';

--- a/repos/fdbt-site/src/utils/apiUtils/userData.ts
+++ b/repos/fdbt-site/src/utils/apiUtils/userData.ts
@@ -189,8 +189,8 @@ export const getBaseTicketAttributes = <T extends TicketType>(
         uuid,
         timeRestriction:
             fullTimeRestriction && fullTimeRestriction.fullTimeRestrictions.length > 0
-                ? fullTimeRestriction.fullTimeRestrictions
-                : [],
+                ? { id: fullTimeRestriction.id }
+                : {},
         ticketPeriod: getTicketPeriod(ticketPeriodAttribute),
     };
 };

--- a/repos/fdbt-site/src/utils/apiUtils/userData.ts
+++ b/repos/fdbt-site/src/utils/apiUtils/userData.ts
@@ -187,10 +187,7 @@ export const getBaseTicketAttributes = <T extends TicketType>(
         passengerType: { id: passengerTypeAttribute.id },
         email,
         uuid,
-        timeRestriction:
-            fullTimeRestriction && fullTimeRestriction.fullTimeRestrictions.length > 0
-                ? { id: fullTimeRestriction.id }
-                : {},
+        timeRestriction: fullTimeRestriction?.id ? { id: fullTimeRestriction.id } : undefined,
         ticketPeriod: getTicketPeriod(ticketPeriodAttribute),
     };
 };
@@ -501,10 +498,7 @@ export const getSchemeOperatorTicketJson = (
         passengerType: { id: passengerTypeAttribute.id },
         email,
         uuid,
-        timeRestriction:
-            fullTimeRestriction && fullTimeRestriction.fullTimeRestrictions.length > 0
-                ? fullTimeRestriction.fullTimeRestrictions
-                : [],
+        timeRestriction: fullTimeRestriction?.id ? { id: fullTimeRestriction.id } : undefined,
         ticketPeriod: getTicketPeriod(ticketPeriodAttribute),
     };
 };

--- a/repos/fdbt-site/tests/pages/api/apiUtils/userData.test.ts
+++ b/repos/fdbt-site/tests/pages/api/apiUtils/userData.test.ts
@@ -1162,6 +1162,7 @@ describe('userData', () => {
                             },
                         ],
                         errors: [],
+                        id: 2,
                     },
                 },
             });
@@ -1494,6 +1495,7 @@ describe('userData', () => {
                             },
                         ],
                         errors: [],
+                        id: 2,
                     },
                     [MULTIPLE_PRODUCT_ATTRIBUTE]: {
                         products: [

--- a/repos/fdbt-site/tests/pages/api/salesConfirmation.test.ts
+++ b/repos/fdbt-site/tests/pages/api/salesConfirmation.test.ts
@@ -232,7 +232,7 @@ describe('salesOfferPackages', () => {
             passengerType: { id: 1 },
             email: 'string',
             uuid: 'string',
-            timeRestriction: [],
+            timeRestriction: { id: 2 },
             ticketPeriod: {
                 startDate: 'now',
                 endDate: 'a year later',

--- a/repos/fdbt-site/tests/testData/mockData.ts
+++ b/repos/fdbt-site/tests/testData/mockData.ts
@@ -1159,7 +1159,7 @@ export const expectedSingleTicket: WithIds<SingleTicket> = {
     serviceDescription: 'Worthing - Seaham - Crawley',
     email: 'test@example.com',
     uuid: '1e0459b3-082e-4e70-89db-96e8ae173e10',
-    timeRestriction: mockFullTimeRestriction,
+    timeRestriction: { id: 2 },
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
@@ -1309,7 +1309,7 @@ export const expectedCarnetSingleTicket: WithIds<SingleTicket> = {
     serviceDescription: 'Worthing - Seaham - Crawley',
     email: 'test@example.com',
     uuid: '1e0459b3-082e-4e70-89db-96e8ae173e10',
-    timeRestriction: mockFullTimeRestriction,
+    timeRestriction: { id: 2 },
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
@@ -1464,7 +1464,7 @@ export const expectedNonCircularReturnTicket: WithIds<ReturnTicket> = {
     serviceDescription: 'Worthing - Seaham - Crawley',
     email: 'test@example.com',
     uuid: '1e0459b3-082e-4e70-89db-96e8ae173e10',
-    timeRestriction: mockFullTimeRestriction,
+    timeRestriction: { id: 2 },
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
@@ -1656,7 +1656,7 @@ export const expectedPointToPointPeriodTicket: WithIds<PointToPointPeriodTicket>
     serviceDescription: 'Worthing - Seaham - Crawley',
     email: 'test@example.com',
     uuid: '1e0459b3-082e-4e70-89db-96e8ae173e10',
-    timeRestriction: mockFullTimeRestriction,
+    timeRestriction: { id: 2 },
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
@@ -1852,7 +1852,7 @@ export const expectedCircularReturnTicket: WithIds<ReturnTicket> = {
     serviceDescription: 'Worthing - Seaham - Crawley',
     uuid: '1e0459b3-082e-4e70-89db-96e8ae173e10',
     email: 'test@example.com',
-    timeRestriction: mockFullTimeRestriction,
+    timeRestriction: { id: 2 },
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
@@ -2015,7 +2015,7 @@ export const expectedCarnetReturnTicket: WithIds<ReturnTicket> = {
     serviceDescription: 'Worthing - Seaham - Crawley',
     email: 'test@example.com',
     uuid: '1e0459b3-082e-4e70-89db-96e8ae173e10',
-    timeRestriction: mockFullTimeRestriction,
+    timeRestriction: { id: 2 },
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
@@ -2212,7 +2212,7 @@ export const expectedPeriodGeoZoneTicketWithMultipleProducts: WithIds<PeriodGeoZ
     zoneName: 'Green Lane Shops',
     stops: zoneStops,
     passengerType: { id: 9 },
-    timeRestriction: mockFullTimeRestriction,
+    timeRestriction: { id: 2 },
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
@@ -2257,7 +2257,7 @@ export const expectedMultiOperatorGeoZoneTicketWithMultipleProducts: WithIds<Mul
     zoneName: 'Green Lane Shops',
     stops: zoneStops,
     passengerType: { id: 9 },
-    timeRestriction: mockFullTimeRestriction,
+    timeRestriction: { id: 2 },
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
@@ -2302,7 +2302,7 @@ export const expectedPeriodMultipleServicesTicketWithMultipleProducts: WithIds<P
     email: 'test@example.com',
     passengerType: { id: 9 },
     termTime: false,
-    timeRestriction: mockFullTimeRestriction,
+    timeRestriction: { id: 2 },
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
@@ -2366,7 +2366,7 @@ export const expectedCarnetPeriodMultipleServicesTicketWithMultipleProducts: Wit
     email: 'test@example.com',
     passengerType: { id: 9 },
     termTime: false,
-    timeRestriction: mockFullTimeRestriction,
+    timeRestriction: { id: 2 },
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
@@ -2443,7 +2443,7 @@ export const expectedPeriodMultipleServicesTicketWithMultipleProductsAndMultiple
         email: 'test@example.com',
         passengerType: { id: 9 },
         termTime: false,
-        timeRestriction: mockFullTimeRestriction,
+        timeRestriction: { id: 2 },
         ticketPeriod: {
             startDate: '2020-12-17T09:30:46.0Z',
             endDate: '2020-12-18T09:30:46.0Z',
@@ -2624,7 +2624,6 @@ export const expectedFlatFareTicket: WithIds<FlatFareGeoZoneTicket> | WithIds<Fl
             serviceDescription: 'Infinity Works, Boston - Infinity Works, Berlin',
         },
     ],
-    timeRestriction: [],
 };
 
 export const expectedFlatFareGeoZoneTicket: WithIds<FlatFareGeoZoneTicket> = {
@@ -2647,7 +2646,6 @@ export const expectedFlatFareGeoZoneTicket: WithIds<FlatFareGeoZoneTicket> = {
             salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageThree],
         },
     ],
-    timeRestriction: [],
 };
 
 export const expectedSchemeOperatorTicket = (
@@ -2660,7 +2658,7 @@ export const expectedSchemeOperatorTicket = (
         uuid: '1e0459b3-082e-4e70-89db-96e8ae173e10',
         email: 'test@example.com',
         passengerType: { id: 9 },
-        timeRestriction: mockFullTimeRestriction,
+        timeRestriction: { id: 2 },
         ticketPeriod: {
             startDate: '2020-12-17T09:30:46.0Z',
             endDate: '2020-12-18T09:30:46.0Z',
@@ -2675,7 +2673,7 @@ export const expectedSchemeOperatorAfterFlatFareAdjustmentTicket: WithIds<Scheme
     uuid: '1e0459b3-082e-4e70-89db-96e8ae173e10',
     email: 'test@example.com',
     passengerType: { id: 9 },
-    timeRestriction: mockFullTimeRestriction,
+    timeRestriction: { id: 2 },
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
@@ -2806,7 +2804,7 @@ export const expectedSchemeOperatorMultiServicesTicket: WithIds<SchemeOperatorMu
     uuid: '1e0459b3-082e-4e70-89db-96e8ae173e10',
     email: 'test@example.com',
     passengerType: { id: 9 },
-    timeRestriction: mockFullTimeRestriction,
+    timeRestriction: { id: 2 },
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
@@ -2947,7 +2945,7 @@ export const expectedSchemeOperatorTicketAfterGeoZoneAdjustment: WithIds<SchemeO
     uuid: '1e0459b3-082e-4e70-89db-96e8ae173e10',
     email: 'test@example.com',
     passengerType: { id: 9 },
-    timeRestriction: mockFullTimeRestriction,
+    timeRestriction: { id: 2 },
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
@@ -3107,6 +3105,7 @@ export const expectedSchemeOperatorTicketAfterGeoZoneAdjustment: WithIds<SchemeO
     ],
     products: [
         {
+            carnetDetails: undefined,
             productDuration: '5 weeks',
             productName: 'Weekly Ticket',
             productPrice: '50',
@@ -3130,6 +3129,7 @@ export const expectedSchemeOperatorTicketAfterGeoZoneAdjustment: WithIds<SchemeO
             ],
         },
         {
+            carnetDetails: undefined,
             productDuration: '1 month',
             productName: 'Day Ticket',
             productPrice: '2.50',
@@ -3153,6 +3153,7 @@ export const expectedSchemeOperatorTicketAfterGeoZoneAdjustment: WithIds<SchemeO
             ],
         },
         {
+            carnetDetails: undefined,
             productDuration: '28 years',
             productEndTime: '1900',
             productName: 'Monthly Ticket',
@@ -5240,6 +5241,7 @@ export const mockReturnValidityFieldsetWithRadioErrors: RadioConditionalInputFie
 export const mockFullTimeRestrictionAttribute: FullTimeRestrictionAttribute = {
     fullTimeRestrictions: mockFullTimeRestriction,
     errors: [],
+    id: 2,
 };
 
 export const mockFieldSetForSaveOperatorGroup: RadioConditionalInputFieldset = {

--- a/shared/dbTypes.ts
+++ b/shared/dbTypes.ts
@@ -1,4 +1,4 @@
-import { CompanionInfo } from './matchingJsonTypes';
+import { CompanionInfo, DbTimeBand, TimeRestrictionDay } from './matchingJsonTypes';
 
 export interface FullGroupPassengerType {
     id: number;
@@ -26,4 +26,9 @@ export interface GroupPassengerType {
     name: string;
     maxGroupSize: string;
     companions: CompanionInfo[];
+}
+
+export interface DbTimeRestriction {
+    day: TimeRestrictionDay;
+    timeBands: DbTimeBand[];
 }

--- a/shared/matchingJsonTypes.ts
+++ b/shared/matchingJsonTypes.ts
@@ -136,8 +136,8 @@ export interface BaseTicket<T extends TicketType = TicketType> {
 
 export type WithIds<T> = Omit<
     T,
-    'passengerType' | 'ageRange' | 'ageRangeMin' | 'ageRangeMax' | 'proof' | 'proofDocuments'
-> & { passengerType: { id: number } };
+    'passengerType' | 'ageRange' | 'ageRangeMin' | 'ageRangeMax' | 'proof' | 'proofDocuments' | 'timeRestriction'
+> & { passengerType: { id: number }; timeRestriction: { id: number } | {} };
 
 export interface GroupDefinition {
     maxPeople: string;

--- a/shared/matchingJsonTypes.ts
+++ b/shared/matchingJsonTypes.ts
@@ -137,7 +137,7 @@ export interface BaseTicket<T extends TicketType = TicketType> {
 export type WithIds<T> = Omit<
     T,
     'passengerType' | 'ageRange' | 'ageRangeMin' | 'ageRangeMax' | 'proof' | 'proofDocuments' | 'timeRestriction'
-> & { passengerType: { id: number }; timeRestriction: { id: number } | {} };
+> & { passengerType: { id: number }; timeRestriction?: { id: number } };
 
 export interface GroupDefinition {
     maxPeople: string;
@@ -153,6 +153,11 @@ export interface CompanionInfo {
     ageRangeMin?: string;
     ageRangeMax?: string;
     proofDocuments?: string[];
+}
+
+export interface DbTimeBand {
+    startTime: string;
+    endTime: string | { fareDayEnd: boolean };
 }
 
 export interface UnassignedStops {


### PR DESCRIPTION
# Description

-   To make the site update the matching JSON with ID's, and the exporter uses these ID's to find the appropriate time restriction.

# Testing instructions

-   Testing has been done with Jake to deploy and use the lambda test function.

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
