### PR TITLE
fix: Cleared session in faretype api

### DIFF
--- a/repos/fdbt-site/src/pages/api/fareType.ts
+++ b/repos/fdbt-site/src/pages/api/fareType.ts
@@ -1,7 +1,7 @@
 import camelCase from 'lodash/camelCase';
 import { NextApiResponse } from 'next';
 import { redirectToError, redirectTo } from '../../utils/apiUtils/index';
-import { updateSessionAttribute } from '../../utils/sessions';
+import { regenerateSession, updateSessionAttribute } from '../../utils/sessions';
 import { FARE_TYPE_ATTRIBUTE, PASSENGER_TYPE_ATTRIBUTE, CARNET_FARE_TYPE_ATTRIBUTE } from '../../constants/attributes';
 import { ErrorInfo, NextApiRequestWithSession } from '../../interfaces';
 import { globalSettingsEnabled } from '../../constants/featureFlag';
@@ -10,6 +10,7 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
     try {
         const { fareType } = req.body;
         if (fareType) {
+            regenerateSession(req);
             if (
                 typeof fareType === 'string' &&
                 (fareType === 'carnet' || fareType === 'carnetPeriod' || fareType === 'carnetFlatFare')

--- a/repos/fdbt-site/tests/pages/api/fareType.test.ts
+++ b/repos/fdbt-site/tests/pages/api/fareType.test.ts
@@ -105,4 +105,22 @@ describe('fareType', () => {
             Location: '/selectPassengerType',
         });
     });
+
+    it('should clear the session if fareType is provided', () => {
+        const regenerateSessionSpy = jest.spyOn(sessions, 'regenerateSession');
+        const { req, res } = getMockRequestAndResponse({
+            body: { fareType: 'carnetFlatFare' },
+        });
+        fareType(req, res);
+        expect(regenerateSessionSpy).toBeCalledTimes(1);
+    });
+
+    it('should not clear the session if fareType is not provided', () => {
+        const regenerateSessionSpy = jest.spyOn(sessions, 'regenerateSession');
+        const { req, res } = getMockRequestAndResponse({
+            body: {},
+        });
+        fareType(req, res);
+        expect(regenerateSessionSpy).toBeCalledTimes(0);
+    });
 });


### PR DESCRIPTION
# Description

-  Stops any issues where user navigates back after partially completing a journey, and starts another one.

# Testing instructions

-   Run site locally, and navigate back after starting a journey, ensure session is cleared.

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
