### PR TITLE
fix: cfd 486 serverless log retention plugin install added

### DIFF
--- a/repos/fdbt-netex-output/package-lock.json
+++ b/repos/fdbt-netex-output/package-lock.json
@@ -8865,6 +8865,12 @@
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
         },
+        "nco": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/nco/-/nco-1.0.1.tgz",
+            "integrity": "sha1-ho3kI7T0X4wFVV8cyyiqeIvgbFI=",
+            "dev": true
+        },
         "needle": {
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/needle/-/needle-2.8.0.tgz",
@@ -9958,6 +9964,24 @@
                 "bluebird": "^3.4.6",
                 "dynamodb-localhost": "0.0.9",
                 "lodash": "^4.17.0"
+            }
+        },
+        "serverless-plugin-log-retention": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/serverless-plugin-log-retention/-/serverless-plugin-log-retention-2.0.0.tgz",
+            "integrity": "sha512-TXKMfLdVxhamyaDbqr+gwjIeiqSnDw3z+bZQy0W2ctRpcedUY8hg58wwMZqAFyMS3QekHT9srCe4Qv7lfPwkGw==",
+            "dev": true,
+            "requires": {
+                "nco": "1.0.1",
+                "semver": "5.4.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.4.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+                    "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+                    "dev": true
+                }
             }
         },
         "serverless-plugin-typescript": {

--- a/repos/fdbt-netex-output/package.json
+++ b/repos/fdbt-netex-output/package.json
@@ -59,6 +59,7 @@
         "lint-staged": "^10.0.8",
         "prettier": "^1.19.1",
         "serverless-dynamodb-local": "^0.2.40",
+        "serverless-plugin-log-retention": "^2.0.0",
         "serverless-plugin-typescript": "^2.0.0",
         "ts-jest": "^26.4.4",
         "ts-node": "^10.0.0"

--- a/repos/fdbt-netex-output/src/netex-validator/package-lock.json
+++ b/repos/fdbt-netex-output/src/netex-validator/package-lock.json
@@ -3697,6 +3697,12 @@
                 "type": "^2.5.0"
             }
         },
+        "nco": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/nco/-/nco-1.0.1.tgz",
+            "integrity": "sha1-ho3kI7T0X4wFVV8cyyiqeIvgbFI=",
+            "dev": true
+        },
         "nested-error-stacks": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
@@ -4674,6 +4680,24 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
                     "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+                    "dev": true
+                }
+            }
+        },
+        "serverless-plugin-log-retention": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/serverless-plugin-log-retention/-/serverless-plugin-log-retention-2.0.0.tgz",
+            "integrity": "sha512-TXKMfLdVxhamyaDbqr+gwjIeiqSnDw3z+bZQy0W2ctRpcedUY8hg58wwMZqAFyMS3QekHT9srCe4Qv7lfPwkGw==",
+            "dev": true,
+            "requires": {
+                "nco": "1.0.1",
+                "semver": "5.4.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.4.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+                    "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
                     "dev": true
                 }
             }

--- a/repos/fdbt-netex-output/src/netex-validator/package.json
+++ b/repos/fdbt-netex-output/src/netex-validator/package.json
@@ -13,6 +13,7 @@
         "serverless-python-requirements": "^5.1.0"
     },
     "devDependencies": {
-        "serverless": "^2.45.2"
+        "serverless": "^2.45.2",
+        "serverless-plugin-log-retention": "^2.0.0"
     }
 }

--- a/repos/fdbt-reference-data-service/src/retrievers/package-lock.json
+++ b/repos/fdbt-reference-data-service/src/retrievers/package-lock.json
@@ -3692,6 +3692,12 @@
         "type": "^2.5.0"
       }
     },
+    "nco": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nco/-/nco-1.0.1.tgz",
+      "integrity": "sha1-ho3kI7T0X4wFVV8cyyiqeIvgbFI=",
+      "dev": true
+    },
     "nested-error-stacks": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
@@ -4719,6 +4725,24 @@
         "lodash.merge": "^4.6.2",
         "lodash.union": "^4.6.0",
         "lodash.upperfirst": "^4.3.1"
+      }
+    },
+    "serverless-plugin-log-retention": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/serverless-plugin-log-retention/-/serverless-plugin-log-retention-2.0.0.tgz",
+      "integrity": "sha512-TXKMfLdVxhamyaDbqr+gwjIeiqSnDw3z+bZQy0W2ctRpcedUY8hg58wwMZqAFyMS3QekHT9srCe4Qv7lfPwkGw==",
+      "dev": true,
+      "requires": {
+        "nco": "1.0.1",
+        "semver": "5.4.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
+        }
       }
     },
     "serverless-python-requirements": {

--- a/repos/fdbt-reference-data-service/src/retrievers/package.json
+++ b/repos/fdbt-reference-data-service/src/retrievers/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "serverless": "^2.45.2",
     "serverless-plugin-aws-alerts": "^1.7.3",
+    "serverless-plugin-log-retention": "^2.0.0",
     "serverless-python-requirements": "^5.1.0"
   },
   "scripts": {

--- a/repos/fdbt-reference-data-service/src/uploaders/package-lock.json
+++ b/repos/fdbt-reference-data-service/src/uploaders/package-lock.json
@@ -3692,6 +3692,12 @@
         "type": "^2.5.0"
       }
     },
+    "nco": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nco/-/nco-1.0.1.tgz",
+      "integrity": "sha1-ho3kI7T0X4wFVV8cyyiqeIvgbFI=",
+      "dev": true
+    },
     "nested-error-stacks": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
@@ -4719,6 +4725,24 @@
         "lodash.merge": "^4.6.2",
         "lodash.union": "^4.6.0",
         "lodash.upperfirst": "^4.3.1"
+      }
+    },
+    "serverless-plugin-log-retention": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/serverless-plugin-log-retention/-/serverless-plugin-log-retention-2.0.0.tgz",
+      "integrity": "sha512-TXKMfLdVxhamyaDbqr+gwjIeiqSnDw3z+bZQy0W2ctRpcedUY8hg58wwMZqAFyMS3QekHT9srCe4Qv7lfPwkGw==",
+      "dev": true,
+      "requires": {
+        "nco": "1.0.1",
+        "semver": "5.4.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
+        }
       }
     },
     "serverless-python-requirements": {

--- a/repos/fdbt-reference-data-service/src/uploaders/package.json
+++ b/repos/fdbt-reference-data-service/src/uploaders/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "serverless": "^2.45.2",
     "serverless-plugin-aws-alerts": "^1.7.3",
+    "serverless-plugin-log-retention": "^2.0.0",
     "serverless-python-requirements": "^5.1.0"
   }
 }


### PR DESCRIPTION
# Description

-   The plugins were missed from the package.json, so weren't available in the pipeline

# Testing instructions

-   Serverless should deploy successfully when merged

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
