### PR TITLE
feat: Adding WAF with Managed Rule Sets

### DIFF
--- a/fdbt-aws/cloudformation/service/us-east-1/waf.yml
+++ b/fdbt-aws/cloudformation/service/us-east-1/waf.yml
@@ -17,6 +17,14 @@ Parameters:
     Type: CommaDelimitedList
     Default: ""
 
+  CiIpSetList:
+    Type: CommaDelimitedList
+    Default: ""
+
+  PersonalUserIpSetList:
+    Type: CommaDelimitedList
+    Default: ""
+
 Conditions:
   IsTest: !Equals [!Ref Stage, "test"]
 
@@ -39,7 +47,7 @@ Resources:
       Name: CiIpSet
       Scope: CLOUDFRONT
       IPAddressVersion: IPV4
-      Addresses: []
+      Addresses: !Ref CiIpSetList
 
   PersonalUserIpSet:
     Type: AWS::WAFv2::IPSet
@@ -49,7 +57,7 @@ Resources:
       Name: PersonalUserIpSet
       Scope: CLOUDFRONT
       IPAddressVersion: IPV4
-      Addresses: []
+      Addresses: !Ref PersonalUserIpSetList
 
   RestrictIPAccessAcl:
     Type: AWS::WAFv2::WebACL
@@ -65,10 +73,66 @@ Resources:
         CloudWatchMetricsEnabled: true
         MetricName: RestrictAccessMetric
       Rules:
+        - Name: BodySizeRestriction
+          Priority: 0
+          Statement:
+            AndStatement:
+              Statements:
+                - SizeConstraintStatement:
+                    FieldToMatch:
+                      Body: {}
+                    ComparisonOperator: LT
+                    Size: 8192
+                    TextTransformations:
+                      - Priority: 0
+                        Type: NONE
+                - NotStatement:
+                    Statement:
+                      ByteMatchStatement:
+                        SearchString: /api/csv
+                        FieldToMatch:
+                          UriPath: {}
+                        TextTransformations:
+                          - Priority: 0
+                            Type: NONE
+                        PositionalConstraint: STARTS_WITH
+          Action:
+            Allow: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: BodySize
+        - Name: AWS-AWSManagedRulesAmazonIpReputationList
+          Priority: 1
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesAmazonIpReputationList
+          OverrideAction:
+            None: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AWS-AWSManagedRulesAmazonIpReputationList
+        - Name: AWS-AWSManagedRulesCommonRuleSet
+          Priority: 2
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesCommonRuleSet
+              ExcludedRules:
+                - SizeRestrictions_BODY # handled by BodySizeRestriction
+                - NoUserAgent_HEADER # allow Cypress tests to run
+          OverrideAction:
+            None: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AWS-AWSManagedRulesCommonRuleSet
         - Name: AllowIw
           Action:
             Allow: {}
-          Priority: 0
+          Priority: 10
           VisibilityConfig:
             SampledRequestsEnabled: true
             CloudWatchMetricsEnabled: true
@@ -79,7 +143,7 @@ Resources:
         - Name: AllowCi
           Action:
             Allow: {}
-          Priority: 3
+          Priority: 11
           VisibilityConfig:
             SampledRequestsEnabled: true
             CloudWatchMetricsEnabled: true
@@ -90,7 +154,7 @@ Resources:
         - Name: AllowPersonalUserIP
           Action:
             Allow: {}
-          Priority: 4
+          Priority: 12
           VisibilityConfig:
             SampledRequestsEnabled: true
             CloudWatchMetricsEnabled: true


### PR DESCRIPTION
# Description

Adding a WAF to attach to the CloudFront distribution of the Fargate
hosted site
Using AWS managed rule groups as a baseline, with additional account
level protection of network traffic provided by AWS Shield

# Testing instructions

-   Particular attention to file uploads as these are most likely to trigger WAF rules

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
