### PR TITLE
feat: Updating to 2021 CloudFront Security Policy

### DIFF
--- a/fdbt-aws/cloudformation/service/eu-west-2/cloudfront.yml
+++ b/fdbt-aws/cloudformation/service/eu-west-2/cloudfront.yml
@@ -190,4 +190,4 @@ Resources:
         ViewerCertificate:
           AcmCertificateArn: !Ref CertificateArn
           SslSupportMethod: sni-only
-          MinimumProtocolVersion: TLSv1.2_2019
+          MinimumProtocolVersion: TLSv1.2_2021


### PR DESCRIPTION
# Description

Using the latest and recommended CloudFront TLS Security policy, removes
ciphers that are potentially vulnerable from being supported for TLS
connections to the site

# Testing instructions

-   Do we have a list of supported browsers, some very old clients (IE6 etc) may not be able to connect

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
