### PR TITLE
feat: Updating CSP with additional directives

### DIFF
--- a/fdbt-aws/cloudformation/service/us-east-1/lambda.yml
+++ b/fdbt-aws/cloudformation/service/us-east-1/lambda.yml
@@ -46,14 +46,14 @@ Resources:
               headers['strict-transport-security'] = [{key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains; preload'}];
 
               if (!headers['content-security-policy']) {
-                headers['content-security-policy'] = [{key: 'Content-Security-Policy', value: "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'"}];
+                headers['content-security-policy'] = [{key: 'Content-Security-Policy', value: "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'; connect-src 'self'; upgrade-insecure-requests"}];
               }
 
               headers['x-content-type-options'] = [{key: 'X-Content-Type-Options', value: 'nosniff'}];
               headers['x-frame-options'] = [{key: 'X-Frame-Options', value: 'DENY'}];
               headers['x-xss-protection'] = [{key: 'X-XSS-Protection', value: '1; mode=block'}];
               headers['referrer-policy'] = [{key: 'Referrer-Policy', value: 'same-origin'}];
-              
+
               callback(null, response);
           };
 

--- a/repos/fdbt-site/server/middleware/security.ts
+++ b/repos/fdbt-site/server/middleware/security.ts
@@ -41,6 +41,7 @@ export default (server: Express): void => {
                     imgSrc: ["'self'", 'data:', 'https:'],
                     defaultSrc: ["'self'"],
                     connectSrc: ["'self'", 'https://www.google-analytics.com'],
+                    upgradeInsecureRequests: true,
                 },
             },
             hsts: {


### PR DESCRIPTION
# Description

Added to fallback CSP in the Cloudfront Lambda@edge:
'connect-src' directive restricts the URLs which can be loaded using script interfaces
'upgrade-insecure-requests' directive instructs user agents to treat all HTTP urls as though they are HTTPS URLs

Added to the site CSP:
'upgrade-insecure-requests' directive instructs user agents to treat all HTTP urls as though they are HTTPS URLs

# Testing instructions

- Ensure no resources fail to load (as they don't have a HTTPS source)

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
