### PR TITLE
fix: Added warning around users not using all their fare stages

### DIFF
--- a/repos/fdbt-site/src/components/MatchingBase.tsx
+++ b/repos/fdbt-site/src/components/MatchingBase.tsx
@@ -21,6 +21,7 @@ interface MatchingBaseProps {
     travelineHintText: string;
     heading: string;
     apiEndpoint: string;
+    unusedStage: boolean;
     csrfToken: string;
 }
 
@@ -100,6 +101,7 @@ const MatchingBase = ({
     travelineHintText,
     heading,
     apiEndpoint,
+    unusedStage,
     csrfToken,
 }: MatchingBaseProps): ReactElement => {
     const errors: ErrorInfo[] = [];
@@ -187,6 +189,12 @@ const MatchingBase = ({
             errorMessage: 'One or more fare stages have not been assigned, assign each fare stage to a stop',
             id: 'option-0',
         });
+    } else if (unusedStage) {
+        errors.push({
+            errorMessage:
+                'One or more fare stages have not been used across either matching page - to correct this use the link below to navigate back to the previous matching page, or use the unused fare stage(s) on this page.',
+            id: 'option-0',
+        });
     }
 
     return (
@@ -194,6 +202,11 @@ const MatchingBase = ({
             <CsrfForm action={apiEndpoint} method="post" className="matching-page" csrfToken={csrfToken}>
                 <>
                     <ErrorSummary errors={errors} />
+                    {unusedStage ? (
+                        <a className="govuk-button govuk-button--secondary" href="/outboundMatching">
+                            Redo my outbound matching
+                        </a>
+                    ) : null}
                     <WarningSummary
                         errors={warnings}
                         label="Check this box if you wish to proceed without assigning all fare stages, then click Continue"

--- a/repos/fdbt-site/src/pages/inboundMatching.tsx
+++ b/repos/fdbt-site/src/pages/inboundMatching.tsx
@@ -1,9 +1,8 @@
 import React, { ReactElement } from 'react';
 import { INBOUND_MATCHING_ATTRIBUTE } from '../constants/attributes';
 import MatchingBase from '../components/MatchingBase';
-import { NextPageContextWithSession } from '../interfaces';
+import { BasicService, NextPageContextWithSession, Stop, UserFareStages } from '../interfaces';
 import { getSessionAttribute } from '../utils/sessions';
-import { MatchingProps } from './matching';
 import { getMatchingProps } from '../utils/apiUtils/matching';
 
 const heading = 'Inbound - Match stops to fare stages';
@@ -13,6 +12,17 @@ const hintText = 'Select a fare stage for each stop on the inbound journey.';
 const travelineHintText = 'This data has been taken from the Traveline National Dataset and NaPTAN database.';
 const apiEndpoint = '/api/inboundMatching';
 
+interface InboundMatchingProps {
+    userFareStages: UserFareStages;
+    stops: Stop[];
+    service: BasicService;
+    error: string;
+    warning?: boolean;
+    selectedFareStages: string[][];
+    unusedStage: boolean;
+    csrfToken: string;
+}
+
 const InboundMatching = ({
     userFareStages,
     stops,
@@ -21,7 +31,8 @@ const InboundMatching = ({
     warning,
     csrfToken,
     selectedFareStages,
-}: MatchingProps): ReactElement => (
+    unusedStage,
+}: InboundMatchingProps): ReactElement => (
     <MatchingBase
         userFareStages={userFareStages}
         stops={stops}
@@ -35,14 +46,15 @@ const InboundMatching = ({
         hintText={hintText}
         travelineHintText={travelineHintText}
         apiEndpoint={apiEndpoint}
+        unusedStage={unusedStage}
         csrfToken={csrfToken}
     />
 );
 
-export const getServerSideProps = async (ctx: NextPageContextWithSession): Promise<{ props: MatchingProps }> => {
+export const getServerSideProps = async (ctx: NextPageContextWithSession): Promise<{ props: InboundMatchingProps }> => {
     const matchingAttribute = getSessionAttribute(ctx.req, INBOUND_MATCHING_ATTRIBUTE);
-
-    return await getMatchingProps(ctx, matchingAttribute);
+    const unusedStage = !!ctx.query.unusedStage;
+    return { props: { ...(await getMatchingProps(ctx, matchingAttribute)).props, unusedStage } };
 };
 
 export default InboundMatching;

--- a/repos/fdbt-site/src/pages/matching.tsx
+++ b/repos/fdbt-site/src/pages/matching.tsx
@@ -34,6 +34,7 @@ const Matching = ({
         travelineHintText={travelineHintText}
         apiEndpoint={apiEndpoint}
         csrfToken={csrfToken}
+        unusedStage={false}
     />
 );
 

--- a/repos/fdbt-site/src/pages/outboundMatching.tsx
+++ b/repos/fdbt-site/src/pages/outboundMatching.tsx
@@ -36,6 +36,7 @@ const OutboundMatching = ({
         travelineHintText={travelineHintText}
         apiEndpoint={apiEndpoint}
         csrfToken={csrfToken}
+        unusedStage={false}
     />
 );
 

--- a/repos/fdbt-site/tests/components/MatchingBase.test.tsx
+++ b/repos/fdbt-site/tests/components/MatchingBase.test.tsx
@@ -56,6 +56,7 @@ describe('MatchingBase', () => {
                         selectedFareStages={selectedFareStages}
                         csrfToken=""
                         {...baseProps}
+                        unusedStage={false}
                     />,
                 );
                 expect(wrapper).toMatchSnapshot();
@@ -72,6 +73,7 @@ describe('MatchingBase', () => {
                         selectedFareStages={selectedFareStages}
                         csrfToken=""
                         {...baseProps}
+                        unusedStage={false}
                     />,
                 );
                 expect(wrapper).toMatchSnapshot();
@@ -100,6 +102,7 @@ describe('MatchingBase', () => {
                     csrfToken=""
                     // eslint-disable-next-line react/jsx-props-no-spreading
                     {...baseProps}
+                    unusedStage={false}
                 />,
             );
 
@@ -129,6 +132,7 @@ describe('MatchingBase', () => {
                     csrfToken=""
                     // eslint-disable-next-line react/jsx-props-no-spreading
                     {...baseProps}
+                    unusedStage={false}
                 />,
             );
 
@@ -159,6 +163,7 @@ describe('MatchingBase', () => {
                         csrfToken=""
                         // eslint-disable-next-line react/jsx-props-no-spreading
                         {...baseProps}
+                        unusedStage={false}
                     />,
                 );
             });

--- a/repos/fdbt-site/tests/pages/__snapshots__/inboundMatching.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/inboundMatching.test.tsx.snap
@@ -193,6 +193,7 @@ exports[`Inbound Matching Page should render correctly 1`] = `
   }
   title="Inbound Matching - Create Fares Data Service"
   travelineHintText="This data has been taken from the Traveline National Dataset and NaPTAN database."
+  unusedStage={false}
   userFareStages={
     Object {
       "fareStages": Array [
@@ -518,6 +519,7 @@ exports[`Inbound Matching Page should render with error 1`] = `
   }
   title="Inbound Matching - Create Fares Data Service"
   travelineHintText="This data has been taken from the Traveline National Dataset and NaPTAN database."
+  unusedStage={false}
   userFareStages={
     Object {
       "fareStages": Array [
@@ -843,6 +845,7 @@ exports[`Inbound Matching Page should render with warning 1`] = `
   }
   title="Inbound Matching - Create Fares Data Service"
   travelineHintText="This data has been taken from the Traveline National Dataset and NaPTAN database."
+  unusedStage={false}
   userFareStages={
     Object {
       "fareStages": Array [

--- a/repos/fdbt-site/tests/pages/__snapshots__/matching.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/matching.test.tsx.snap
@@ -193,6 +193,7 @@ exports[`Matching Page should render correctly 1`] = `
   }
   title="Matching - Create Fares Data Service"
   travelineHintText="This data has been taken from the Traveline National Dataset and NaPTAN database."
+  unusedStage={false}
   userFareStages={
     Object {
       "fareStages": Array [
@@ -518,6 +519,7 @@ exports[`Matching Page should render with error 1`] = `
   }
   title="Matching - Create Fares Data Service"
   travelineHintText="This data has been taken from the Traveline National Dataset and NaPTAN database."
+  unusedStage={false}
   userFareStages={
     Object {
       "fareStages": Array [

--- a/repos/fdbt-site/tests/pages/__snapshots__/outboundMatching.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/outboundMatching.test.tsx.snap
@@ -193,6 +193,7 @@ exports[`OutboundMatching Page should render correctly 1`] = `
   }
   title="Outbound Matching - Create Fares Data Service"
   travelineHintText="This data has been taken from the Traveline National Dataset and NaPTAN database."
+  unusedStage={false}
   userFareStages={
     Object {
       "fareStages": Array [
@@ -518,6 +519,7 @@ exports[`OutboundMatching Page should render with error 1`] = `
   }
   title="Outbound Matching - Create Fares Data Service"
   travelineHintText="This data has been taken from the Traveline National Dataset and NaPTAN database."
+  unusedStage={false}
   userFareStages={
     Object {
       "fareStages": Array [
@@ -843,6 +845,7 @@ exports[`OutboundMatching Page should render with warning 1`] = `
   }
   title="Outbound Matching - Create Fares Data Service"
   travelineHintText="This data has been taken from the Traveline National Dataset and NaPTAN database."
+  unusedStage={false}
   userFareStages={
     Object {
       "fareStages": Array [

--- a/repos/fdbt-site/tests/pages/api/inboundMatching.test.ts
+++ b/repos/fdbt-site/tests/pages/api/inboundMatching.test.ts
@@ -1,3 +1,4 @@
+import { MATCHING_ATTRIBUTE } from './../../../src/constants/attributes';
 import inboundMatching from '../../../src/pages/api/inboundMatching';
 import { getMockRequestAndResponse, service, mockMatchingUserFareStages } from '../../testData/mockData';
 import * as sessions from '../../../src/utils/sessions';
@@ -24,6 +25,37 @@ describe('Inbound Matching API', () => {
                 service: JSON.stringify(service),
                 userfarestages: JSON.stringify(mockMatchingUserFareStages),
             },
+            session: {
+                [MATCHING_ATTRIBUTE]: {
+                    service: {
+                        lineName: '',
+                        lineId: '',
+                        nocCode: '',
+                        operatorShortName: '',
+                        serviceDescription: '',
+                    },
+                    userFareStages: {
+                        fareStages: [
+                            {
+                                stageName: '',
+                                prices: [
+                                    {
+                                        price: '',
+                                        fareZones: [],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    matchingFareZones: {
+                        thing: {
+                            name: '',
+                            stops: [],
+                            prices: [],
+                        },
+                    },
+                },
+            },
             mockWriteHeadFn: writeHeadMock,
         });
         inboundMatching(req, res);
@@ -42,6 +74,37 @@ describe('Inbound Matching API', () => {
                 ...selectedOptionsWithAnUnassignedStop,
                 service: JSON.stringify(service),
                 userfarestages: JSON.stringify(mockMatchingUserFareStages),
+            },
+            session: {
+                [MATCHING_ATTRIBUTE]: {
+                    service: {
+                        lineName: '',
+                        lineId: '',
+                        nocCode: '',
+                        operatorShortName: '',
+                        serviceDescription: '',
+                    },
+                    userFareStages: {
+                        fareStages: [
+                            {
+                                stageName: '',
+                                prices: [
+                                    {
+                                        price: '',
+                                        fareZones: [],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    matchingFareZones: {
+                        thing: {
+                            name: '',
+                            stops: [],
+                            prices: [],
+                        },
+                    },
+                },
             },
             mockWriteHeadFn: writeHeadMock,
         });

--- a/repos/fdbt-site/tests/pages/inboundMatching.test.tsx
+++ b/repos/fdbt-site/tests/pages/inboundMatching.test.tsx
@@ -33,6 +33,7 @@ describe('Inbound Matching Page', () => {
                 warning={false}
                 selectedFareStages={selectedFareStages}
                 csrfToken=""
+                unusedStage={false}
             />,
         );
     });
@@ -55,6 +56,7 @@ describe('Inbound Matching Page', () => {
                 warning={true}
                 selectedFareStages={selectedFareStages}
                 csrfToken=""
+                unusedStage={false}
             />,
         );
         expect(wrapper).toMatchSnapshot();
@@ -70,6 +72,7 @@ describe('Inbound Matching Page', () => {
                 warning={false}
                 selectedFareStages={selectedFareStages}
                 csrfToken=""
+                unusedStage={false}
             />,
         );
         expect(wrapper).toMatchSnapshot();
@@ -85,6 +88,7 @@ describe('Inbound Matching Page', () => {
                 warning={false}
                 selectedFareStages={selectedFareStages}
                 csrfToken=""
+                unusedStage={false}
             />,
         );
         expect(mountedWrapper.find('.farestage-select').first().find('option')).toHaveLength(10);


### PR DESCRIPTION
# Description

-   To stop users from not using all fare stages across both matching pages, which results in invalid netex being created.

# Testing instructions

-   Run locally and for a return ticket, attempt to use some of the fare stages on each matching page, leaving one or more unused entirely.

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
