### PR TITLE
feat: rewrite of WAF rule logic cfd-510

### DIFF
--- a/fdbt-aws/cloudformation/service/us-east-1/waf-test.yml
+++ b/fdbt-aws/cloudformation/service/us-east-1/waf-test.yml
@@ -1,18 +1,56 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: CloudFormation template for WAF resources in PreProd and Prod
+Description: CloudFormation template for WAF resources in Test
 
 Parameters:
   Stage:
     Type: String
     AllowedValues:
-      - preprod
-      - prod
+      - test
 
   ProductName:
     Type: String
     Default: fdbt
 
+  IwIpSetList:
+    Type: CommaDelimitedList
+    Default: ""
+
+  CiIpSetList:
+    Type: CommaDelimitedList
+    Default: ""
+
+  PersonalUserIpSetList:
+    Type: CommaDelimitedList
+    Default: ""
+
 Resources:
+  IwIpSet:
+    Type: AWS::WAFv2::IPSet
+    Properties:
+      Description: IP Set for Infinity Works office
+      Name: IwIpSet
+      Scope: CLOUDFRONT
+      IPAddressVersion: IPV4
+      Addresses: !Ref IwIpSetList
+
+  CiIpSet:
+    Type: AWS::WAFv2::IPSet
+    Properties:
+      Description: IP Set for CI
+      Name: CiIpSet
+      Scope: CLOUDFRONT
+      IPAddressVersion: IPV4
+      Addresses: !Ref CiIpSetList
+
+  PersonalUserIpSet:
+    Type: AWS::WAFv2::IPSet
+    Properties:
+      Description: Personal IPs for IW and DFT users of the tool
+      Name: PersonalUserIpSet
+      Scope: CLOUDFRONT
+      IPAddressVersion: IPV4
+      Addresses: !Ref PersonalUserIpSetList
+
   SiteAccessAcl:
     Type: AWS::WAFv2::WebACL
     Properties:
@@ -20,7 +58,7 @@ Resources:
       Scope: CLOUDFRONT
       Description: Restricts access to site
       DefaultAction:
-        Allow: {}
+        Block: {}
       VisibilityConfig:
         SampledRequestsEnabled: true
         CloudWatchMetricsEnabled: true
@@ -34,7 +72,7 @@ Resources:
                 - SizeConstraintStatement:
                     FieldToMatch:
                       Body: {}
-                    ComparisonOperator: GT
+                    ComparisonOperator: LT
                     Size: 8192
                     TextTransformations:
                       - Priority: 0
@@ -50,7 +88,7 @@ Resources:
                             Type: NONE
                         PositionalConstraint: STARTS_WITH
           Action:
-            Block: {}
+            Allow: {}
           VisibilityConfig:
             SampledRequestsEnabled: true
             CloudWatchMetricsEnabled: true
@@ -74,14 +112,47 @@ Resources:
               VendorName: AWS
               Name: AWSManagedRulesCommonRuleSet
               ExcludedRules:
-                - Name: SizeRestrictions_BODY # handled by BodySizeRestriction
-                - Name: NoUserAgent_HEADER # allow Cypress tests to run
+                - SizeRestrictions_BODY # handled by BodySizeRestriction
+                - NoUserAgent_HEADER # allow Cypress tests to run
           OverrideAction:
             None: {}
           VisibilityConfig:
             SampledRequestsEnabled: true
             CloudWatchMetricsEnabled: true
             MetricName: AWS-AWSManagedRulesCommonRuleSet
+        - Name: AllowIw
+          Action:
+            Allow: {}
+          Priority: 10
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AllowIwRuleMetric
+          Statement:
+            IPSetReferenceStatement:
+              Arn: !GetAtt IwIpSet.Arn
+        - Name: AllowCi
+          Action:
+            Allow: {}
+          Priority: 11
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AllowCiRuleMetric
+          Statement:
+            IPSetReferenceStatement:
+              Arn: !GetAtt CiIpSet.Arn
+        - Name: AllowPersonalUserIP
+          Action:
+            Allow: {}
+          Priority: 12
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AllowPersonalUserIPRuleMetric
+          Statement:
+            IPSetReferenceStatement:
+              Arn: !GetAtt PersonalUserIpSet.Arn
 
 Outputs:
   WafAclArn:


### PR DESCRIPTION
# Description

This inverts the WAF to be allow all, as we need public access in prod
Then in test the rules will block non-ip set included ip addresses

# Testing instructions

- Ensure Test is only accessible to allowed IPs (take your IP out of IP Set to test)
- Ensure Preprod is accessible

# Type of change

-   [x] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
