### PR TITLE
fix: matching page workaround fix

### DIFF
--- a/repos/fdbt-site/src/utils/apiUtils/matching.ts
+++ b/repos/fdbt-site/src/utils/apiUtils/matching.ts
@@ -76,6 +76,18 @@ export const getMatchingFareZonesAndUnassignedStopsFromForm = (
 export const isFareStageUnassigned = (userFareStages: UserFareStages, matchingFareZones: MatchingFareZones): boolean =>
     userFareStages.fareStages.some((stage) => !matchingFareZones[stage.stageName]);
 
+export const fareStageIsUnused = (userFareStageNames: string[], uploadedFareStages: UserFareStages): boolean => {
+    let fareStageIsUnused = false;
+
+    uploadedFareStages.fareStages.forEach((uploadedFareStage) => {
+        if (!userFareStageNames.find((stageName) => uploadedFareStage.stageName === stageName)) {
+            fareStageIsUnused = true;
+        }
+    });
+
+    return fareStageIsUnused;
+};
+
 export const sortingWithoutSequenceNumbers = (journeyPatterns: RawJourneyPattern[]): string[] => {
     try {
         const graph = journeyPatterns.flatMap((journeyPattern) =>


### PR DESCRIPTION
# Description

-   Ensuring users can use the inbound and outbound matching pages to miss out fare stages where needed, but not entirely.

# Testing instructions

-   Run locally and create a return ticket, using or not using fare stages in all scenarios.

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
