### PR TITLE
feat: Check to find if journey patterns and journey pattern sections exist in TXC

### DIFF
--- a/repos/fdbt-reference-data-service/src/uploaders/txc_uploader/txc_processor.py
+++ b/repos/fdbt-reference-data-service/src/uploaders/txc_uploader/txc_processor.py
@@ -369,11 +369,10 @@ def write_to_database(data_dict, region_code, data_source, key, db_connection, l
                             valid_noc = False
                             break
 
-                        iterate_through_journey_patterns_and_run_insert_queries(
-                            cursor, data_dict, operator_service_id, service
-                        )
-
-                        file_has_useable_data = True
+                        if 'JourneyPattern' in service.get('StandardService') and 'JourneyPatternSections' in data_dict.get('TransXChange'):
+                            if 'JourneyPatternSection' in data_dict.get('TransXChange').get('JourneyPatternSections'):
+                                iterate_through_journey_patterns_and_run_insert_queries(cursor, data_dict, operator_service_id, service)
+                                file_has_useable_data = True
 
             if not file_has_nocs:
                 db_connection.rollback()


### PR DESCRIPTION
# Description

-   We currently dont handle the exceptions thrown if TXC files do not have journey patterns or journey pattern sections. This change ensures we do not continue with the database transaction if this is the case.

# Testing instructions

-   Reference data import.

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
