### PR TITLE
fix: CFD-535 Set reserved concurrency for netex converter

### DIFF
--- a/repos/fdbt-netex-output/serverless.yml
+++ b/repos/fdbt-netex-output/serverless.yml
@@ -78,6 +78,7 @@ functions:
       - s3:
           bucket: matchingDataBucket
           event: s3:ObjectCreated:*
+    reservedConcurrency: 40
     vpc:
       securityGroupIds:
         - Fn::ImportValue: ${self:provider.stage}:ReferenceDataUploaderLambdaSG


### PR DESCRIPTION
# Description

-   Set reserved concurrency for netex converter

# Testing instructions

-   Run a big export and check there are no errors with the DB running out of connections

# Type of change

-   [ ] feat - A new feature
-   [X] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
