### PR TITLE
feat: cfd-528 turn off export at the end of user journey

### DIFF
--- a/repos/fdbt-site/src/pages/api/salesConfirmation.ts
+++ b/repos/fdbt-site/src/pages/api/salesConfirmation.ts
@@ -105,13 +105,16 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                 // if my fares or export isn't enabled we want to trigger the export lambda for a single
                 await triggerExport({ noc, paths: [filePath] });
             }
+
             if ((ticketType === 'geoZone' || dataFormat !== 'tnds') && exportEnabled) {
                 redirectTo(res, '/productCreated');
                 return;
             }
+
             redirectTo(res, '/thankyou');
             return;
         }
+
         return;
     } catch (error) {
         const message = 'There was a problem processing the information needed for the user data to be put in s3:';

--- a/repos/fdbt-site/src/utils/apiUtils/userData.ts
+++ b/repos/fdbt-site/src/utils/apiUtils/userData.ts
@@ -646,11 +646,14 @@ export const insertDataToProductsBucketAndProductsTable = async (
     dataFormat: 'tnds' | 'bods' | undefined,
 ): Promise<string> => {
     const filePath = await putUserDataInProductsBucket(userDataJson, uuid, nocCode);
+
     if (saveProductsEnabled && (ticketType === 'geoZone' || dataFormat !== 'tnds')) {
         const { startDate, endDate } = userDataJson.ticketPeriod;
         const dateTime = moment().toDate();
         const lineId = 'lineId' in userDataJson ? userDataJson.lineId : undefined;
+
         await insertProducts(nocCode, filePath, dateTime, userDataJson.type, lineId, startDate, endDate);
     }
+
     return filePath;
 };


### PR DESCRIPTION
# Description

-   Turn off export at the end of the user journey
-   Stop emails from sending for anything in the `exports` or `zips` folders on s3.

# Testing instructions

-   Go through the user journey and see if netex gets generated.

# Type of change

-   [ ] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
