### PR TITLE
feat: cfd-547 - show passenger type name on fare confirmation page

### DIFF
--- a/repos/fdbt-site/src/pages/fareConfirmation.tsx
+++ b/repos/fdbt-site/src/pages/fareConfirmation.tsx
@@ -14,16 +14,17 @@ import {
     TermTimeAttribute,
     FullTimeRestrictionAttribute,
     ConfirmationElement,
-    PassengerType,
     SchoolFareTypeAttribute,
     CompanionInfo,
+    SinglePassengerType,
 } from '../interfaces';
 import TwoThirdsLayout from '../layout/Layout';
 import CsrfForm from '../components/CsrfForm';
 import ConfirmationTable from '../components/ConfirmationTable';
 import { getSessionAttribute } from '../utils/sessions';
 import { isPassengerTypeAttributeWithErrors, isFareType } from '../interfaces/typeGuards';
-import { getCsrfToken, sentenceCaseString } from '../utils';
+import { getAndValidateNoc, getCsrfToken, sentenceCaseString } from '../utils';
+import { getPassengerTypeById } from '../../src/data/auroradb';
 
 const title = 'Fare Confirmation - Create Fares Data Service';
 const description = 'Fare Confirmation page of the Create Fares Data Service';
@@ -31,7 +32,7 @@ const description = 'Fare Confirmation page of the Create Fares Data Service';
 interface FareConfirmationProps {
     fareType: string;
     carnet: boolean;
-    passengerType: PassengerType;
+    passengerType: SinglePassengerType;
     groupPassengerInfo: CompanionInfo[];
     schoolFareType: string;
     termTime: string;
@@ -43,7 +44,7 @@ interface FareConfirmationProps {
 export const buildFareConfirmationElements = (
     fareType: string,
     carnet: boolean,
-    passengerType: PassengerType,
+    passengerType: SinglePassengerType,
     groupPassengerInfo: CompanionInfo[],
     schoolFareType: string,
     termTime: string,
@@ -58,7 +59,7 @@ export const buildFareConfirmationElements = (
         },
         {
             name: 'Passenger type',
-            content: sentenceCaseString(passengerType.passengerType),
+            content: sentenceCaseString(passengerType.name),
             href: 'selectPassengerType',
         },
     ];
@@ -71,7 +72,7 @@ export const buildFareConfirmationElements = (
         });
     }
 
-    if (passengerType.passengerType === 'group' && groupPassengerInfo.length > 0) {
+    if (passengerType.passengerType.passengerType === 'group' && groupPassengerInfo.length > 0) {
         groupPassengerInfo.forEach((passenger) => {
             const href = 'selectPassengerType';
             if (passenger.ageRangeMin || passenger.ageRangeMax) {
@@ -107,11 +108,13 @@ export const buildFareConfirmationElements = (
         });
     } else {
         const href = 'selectPassengerType';
-        if (passengerType.ageRangeMin || passengerType.ageRangeMax) {
+        if (passengerType.passengerType.ageRangeMin || passengerType.passengerType.ageRangeMax) {
             confirmationElements.push({
                 name: 'Passenger information - age range',
-                content: `Minimum age: ${passengerType.ageRangeMin ? passengerType.ageRangeMin : 'N/A'} Maximum age: ${
-                    passengerType.ageRangeMax ? passengerType.ageRangeMax : 'N/A'
+                content: `Minimum age: ${
+                    passengerType.passengerType.ageRangeMin ? passengerType.passengerType.ageRangeMin : 'N/A'
+                } Maximum age: ${
+                    passengerType.passengerType.ageRangeMax ? passengerType.passengerType.ageRangeMax : 'N/A'
                 }`,
                 href,
             });
@@ -123,10 +126,12 @@ export const buildFareConfirmationElements = (
             });
         }
 
-        if (passengerType.proofDocuments && passengerType.proofDocuments.length > 0) {
+        if (passengerType.passengerType.proofDocuments && passengerType.passengerType.proofDocuments.length > 0) {
             confirmationElements.push({
                 name: 'Passenger information - proof documents',
-                content: passengerType.proofDocuments.map((proofDoc) => sentenceCaseString(proofDoc)).join(', '),
+                content: passengerType.passengerType.proofDocuments
+                    .map((proofDoc) => sentenceCaseString(proofDoc))
+                    .join(', '),
                 href,
             });
         } else {
@@ -213,14 +218,18 @@ const FareConfirmation = ({
                         newTimeRestrictionCreated,
                     )}
                 />
+
                 <input type="submit" value="Continue" id="continue-button" className="govuk-button" />
             </>
         </CsrfForm>
     </TwoThirdsLayout>
 );
 
-export const getServerSideProps = (ctx: NextPageContextWithSession): { props: FareConfirmationProps } => {
+export const getServerSideProps = async (
+    ctx: NextPageContextWithSession,
+): Promise<{ props: FareConfirmationProps }> => {
     const csrfToken = getCsrfToken(ctx);
+    const noc = getAndValidateNoc(ctx);
     const fareTypeAttribute = getSessionAttribute(ctx.req, FARE_TYPE_ATTRIBUTE);
     const carnetAttribute = getSessionAttribute(ctx.req, CARNET_FARE_TYPE_ATTRIBUTE);
     const carnet = !!carnetAttribute;
@@ -231,7 +240,9 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Fa
         ctx.req,
         FULL_TIME_RESTRICTIONS_ATTRIBUTE,
     ) as FullTimeRestrictionAttribute;
+
     const newTimeRestrictionCreated = (ctx.query?.createdTimeRestriction as string) || '';
+
     if (
         !passengerTypeAttribute ||
         isPassengerTypeAttributeWithErrors(passengerTypeAttribute) ||
@@ -243,11 +254,19 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Fa
 
     const groupPassengerInfo = getSessionAttribute(ctx.req, GROUP_PASSENGER_INFO_ATTRIBUTE) || [];
 
+    const passengerType = await getPassengerTypeById(passengerTypeAttribute.id, noc);
+
+    if (passengerType === undefined) {
+        throw new Error(
+            `Could not find a passenger type with id ${passengerTypeAttribute.id} for the noc ${noc} in the database!`,
+        );
+    }
+
     return {
         props: {
             fareType: fareTypeAttribute.fareType,
             carnet,
-            passengerType: passengerTypeAttribute,
+            passengerType: passengerType,
             schoolFareType: schoolFareTypeAttribute?.schoolFareType || '',
             groupPassengerInfo,
             termTime: termTimeAttribute?.termTime.toString() || '',

--- a/repos/fdbt-site/tests/pages/__snapshots__/fareConfirmation.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/fareConfirmation.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`pages fareConfirmation should render correctly for a carnet ticket 1`] 
             "name": "Carnet type",
           },
           Object {
-            "content": "Adult",
+            "content": "Adults",
             "href": "selectPassengerType",
             "name": "Passenger type",
           },
@@ -98,7 +98,7 @@ exports[`pages fareConfirmation should render correctly for a ticket with a prem
             "name": "Fare type",
           },
           Object {
-            "content": "Adult",
+            "content": "Adults",
             "href": "selectPassengerType",
             "name": "Passenger type",
           },
@@ -171,7 +171,7 @@ exports[`pages fareConfirmation should render correctly for group tickets 1`] = 
             "name": "Fare type",
           },
           Object {
-            "content": "Group",
+            "content": "Family group",
             "href": "selectPassengerType",
             "name": "Passenger type",
           },
@@ -254,7 +254,7 @@ exports[`pages fareConfirmation should render correctly for non school single ti
             "name": "Fare type",
           },
           Object {
-            "content": "Adult",
+            "content": "Adults",
             "href": "selectPassengerType",
             "name": "Passenger type",
           },
@@ -322,7 +322,7 @@ exports[`pages fareConfirmation should render correctly for school tickets 1`] =
             "name": "Fare type",
           },
           Object {
-            "content": "School pupil",
+            "content": "School",
             "href": "selectPassengerType",
             "name": "Passenger type",
           },

--- a/repos/fdbt-site/tests/pages/fareConfirmation.test.tsx
+++ b/repos/fdbt-site/tests/pages/fareConfirmation.test.tsx
@@ -11,12 +11,16 @@ describe('pages', () => {
                     carnet={false}
                     passengerType={{
                         id: 2,
-                        passengerType: 'adult',
-                        ageRange: 'yes',
-                        ageRangeMin: '18',
-                        ageRangeMax: '100',
-                        proof: 'yes',
-                        proofDocuments: ['membership card'],
+                        name: 'Adults',
+                        passengerType: {
+                            id: 2,
+                            passengerType: 'adult',
+                            ageRange: 'yes',
+                            ageRangeMin: '18',
+                            ageRangeMax: '100',
+                            proof: 'yes',
+                            proofDocuments: ['membership card'],
+                        },
                     }}
                     groupPassengerInfo={[]}
                     schoolFareType=""
@@ -49,12 +53,16 @@ describe('pages', () => {
                     carnet
                     passengerType={{
                         id: 2,
-                        passengerType: 'adult',
-                        ageRange: 'yes',
-                        ageRangeMin: '18',
-                        ageRangeMax: '100',
-                        proof: 'yes',
-                        proofDocuments: ['membership card'],
+                        name: 'Adults',
+                        passengerType: {
+                            id: 2,
+                            passengerType: 'adult',
+                            ageRange: 'yes',
+                            ageRangeMin: '18',
+                            ageRangeMax: '100',
+                            proof: 'yes',
+                            proofDocuments: ['membership card'],
+                        },
                     }}
                     groupPassengerInfo={[]}
                     schoolFareType=""
@@ -87,12 +95,16 @@ describe('pages', () => {
                     carnet={false}
                     passengerType={{
                         id: 2,
-                        passengerType: 'adult',
-                        ageRange: 'yes',
-                        ageRangeMin: '18',
-                        ageRangeMax: '100',
-                        proof: 'yes',
-                        proofDocuments: ['membership card'],
+                        name: 'Adults',
+                        passengerType: {
+                            id: 2,
+                            passengerType: 'adult',
+                            ageRange: 'yes',
+                            ageRangeMin: '18',
+                            ageRangeMax: '100',
+                            proof: 'yes',
+                            proofDocuments: ['membership card'],
+                        },
                     }}
                     groupPassengerInfo={[]}
                     schoolFareType=""
@@ -125,7 +137,11 @@ describe('pages', () => {
                     carnet={false}
                     passengerType={{
                         id: 4,
-                        passengerType: 'group',
+                        name: 'family group',
+                        passengerType: {
+                            id: 4,
+                            passengerType: 'group',
+                        },
                     }}
                     groupPassengerInfo={[
                         {
@@ -179,11 +195,15 @@ describe('pages', () => {
                     carnet={false}
                     passengerType={{
                         id: 2,
-                        passengerType: 'schoolPupil',
-                        ageRange: 'yes',
-                        ageRangeMax: '18',
-                        proof: 'yes',
-                        proofDocuments: ['Student Card'],
+                        name: 'school',
+                        passengerType: {
+                            id: 2,
+                            passengerType: 'schoolPupil',
+                            ageRange: 'yes',
+                            ageRangeMax: '18',
+                            proof: 'yes',
+                            proofDocuments: ['Student Card'],
+                        },
                     }}
                     groupPassengerInfo={[]}
                     schoolFareType="single"
@@ -203,12 +223,16 @@ describe('pages', () => {
                     false,
                     {
                         id: 2,
-                        passengerType: 'adult',
-                        ageRange: 'yes',
-                        ageRangeMin: '18',
-                        ageRangeMax: '100',
-                        proof: 'yes',
-                        proofDocuments: ['membership card'],
+                        name: 'Adults',
+                        passengerType: {
+                            id: 2,
+                            passengerType: 'adult',
+                            ageRange: 'yes',
+                            ageRangeMin: '18',
+                            ageRangeMax: '100',
+                            proof: 'yes',
+                            proofDocuments: ['membership card'],
+                        },
                     },
                     [],
                     '',
@@ -231,7 +255,7 @@ describe('pages', () => {
                 );
                 expect(result).toStrictEqual([
                     { content: 'Return', href: 'fareType', name: 'Fare type' },
-                    { content: 'Adult', href: 'selectPassengerType', name: 'Passenger type' },
+                    { content: 'Adults', href: 'selectPassengerType', name: 'Passenger type' },
                     {
                         content: 'Minimum age: 18 Maximum age: 100',
                         href: 'selectPassengerType',
@@ -266,12 +290,16 @@ describe('pages', () => {
                     false,
                     {
                         id: 2,
-                        passengerType: 'adult',
-                        ageRange: 'yes',
-                        ageRangeMin: '18',
-                        ageRangeMax: '100',
-                        proof: 'yes',
-                        proofDocuments: ['membership card'],
+                        name: 'Adults',
+                        passengerType: {
+                            id: 2,
+                            passengerType: 'adult',
+                            ageRange: 'yes',
+                            ageRangeMin: '18',
+                            ageRangeMax: '100',
+                            proof: 'yes',
+                            proofDocuments: ['membership card'],
+                        },
                     },
                     [],
                     '',
@@ -292,9 +320,10 @@ describe('pages', () => {
                     ],
                     'Time restriction',
                 );
+
                 expect(result).toStrictEqual([
                     { content: 'Return', href: 'fareType', name: 'Fare type' },
-                    { content: 'Adult', href: 'selectPassengerType', name: 'Passenger type' },
+                    { content: 'Adults', href: 'selectPassengerType', name: 'Passenger type' },
                     {
                         content: 'Minimum age: 18 Maximum age: 100',
                         href: 'selectPassengerType',
@@ -334,11 +363,15 @@ describe('pages', () => {
                     false,
                     {
                         id: 2,
-                        passengerType: 'schoolPupil',
-                        ageRange: 'yes',
-                        ageRangeMax: '18',
-                        proof: 'yes',
-                        proofDocuments: ['Student Card'],
+                        name: 'School pupil',
+                        passengerType: {
+                            id: 2,
+                            passengerType: 'schoolPupil',
+                            ageRange: 'yes',
+                            ageRangeMax: '18',
+                            proof: 'yes',
+                            proofDocuments: ['Student Card'],
+                        },
                     },
                     [],
                     'single',


### PR DESCRIPTION
# Description

-   Show passenger type name on fare confirmation page

# Testing instructions

-   On `/fareConfirmation` page, check and make sure the passenger type name is shown, not the underlying enum type.

# Type of change

-   [ ] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
