### PR TITLE
fix: cfd-585 - foreign key checks

### DIFF
--- a/repos/exporter/lib/referenceData/tableRenamer.ts
+++ b/repos/exporter/lib/referenceData/tableRenamer.ts
@@ -48,16 +48,23 @@ const tables = [
 export const deleteAndRenameTables = async (connection: Connection): Promise<void> => {
     try {
         await connection.beginTransaction();
+
+        await connection.query('SET FOREIGN_KEY_CHECKS=0');
+
         await connection.query(`DROP TABLE IF EXISTS ${tables.map((table) => `${table}Old`).join(', ')};`);
+
+        await connection.query('SET FOREIGN_KEY_CHECKS=1');
 
         for (const table of tables) {
             await connection.query(`ALTER TABLE ${table} RENAME TO ${table}Old;`);
+
             await connection.query(`ALTER TABLE ${table}New RENAME TO ${table};`);
         }
 
         await connection.commit();
     } catch (error) {
         await connection.rollback();
+
         throw error;
     }
 };

--- a/repos/fdbt-site/tests/pages/products/__snapshots__/otherProducts.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/products/__snapshots__/otherProducts.test.tsx.snap
@@ -298,9 +298,9 @@ exports[`myfares pages otherProducts should render correctly when some non-Point
                 className="govuk-table__cell"
               >
                 <strong
-                  className="govuk-tag govuk-tag--blue dft-table-tag"
+                  className="govuk-tag govuk-tag--turquoise dft-table-tag"
                 >
-                  Pending
+                  Active
                 </strong>
               </td>
               <td
@@ -357,9 +357,9 @@ exports[`myfares pages otherProducts should render correctly when some non-Point
                 className="govuk-table__cell"
               >
                 <strong
-                  className="govuk-tag govuk-tag--blue dft-table-tag"
+                  className="govuk-tag govuk-tag--turquoise dft-table-tag"
                 >
-                  Pending
+                  Active
                 </strong>
               </td>
               <td


### PR DESCRIPTION
# Description

-   We'll disable the foreign key checks before dropping the old tables, then we will re-enable them after the drop is complete.

# Testing instructions

-   Run the lambdas in an environment (e.g. test) where old tables exist.

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
