### PR TITLE
fix: cfd-397 remove lambda schedule

### DIFF
--- a/repos/fdbt-reference-data-service/src/retrievers/serverless.yml
+++ b/repos/fdbt-reference-data-service/src/retrievers/serverless.yml
@@ -182,10 +182,6 @@ functions:
             XML_BUCKET_NAME: fdbt-txc-ref-data-${self:provider.stage}
             RDS_HOST:
                 Fn::ImportValue: ${self:provider.stage}:RdsClusterInternalEndpoint
-        events:
-            - schedule:
-                  rate: ${self:custom.txcRetrieverSchedule.${self:provider.stage}, cron(15 2 * * ? *)}
-                  enabled: ${self:custom.enableSchedule.${self:provider.stage}, false}
         vpc:
             securityGroupIds:
                 - Fn::ImportValue: ${self:provider.stage}:ReferenceDataUploaderLambdaSG


### PR DESCRIPTION
# Description

Now that the Lambda invokes itself, we only need one schedule otherwise
we'll end up with three executions and a race condition in the
clearing down and data uploads

# Testing instructions

- N/A

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
