### PR TITLE
feat: cfd-584 upgrade Grafana version to 8.3.3

### DIFF
--- a/fdbt-aws/cloudformation/service/eu-west-2/fargate.yml
+++ b/fdbt-aws/cloudformation/service/eu-west-2/fargate.yml
@@ -21,7 +21,7 @@ Parameters:
   MonitoringImage:
     Type: String
     Description: The monitoring docker image
-    Default: grafana/grafana:7.0.1
+    Default: grafana/grafana:8.3.3
   MonitoringContainerPort:
     Type: Number
     Default: 3000

--- a/fdbt-aws/grafana/general/business-intelligence.json
+++ b/fdbt-aws/grafana/general/business-intelligence.json
@@ -1,0 +1,419 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 14,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "displayName": "NeTEx created",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expression": "fields @timestamp, @message\n| sort @timestamp desc\n| filter @message like /NeTEx generation complete/\n| stats count() by bin(1d)",
+          "id": "",
+          "logGroupNames": [
+            "/aws/lambda/netex-output-service-prod-NetexConvertor"
+          ],
+          "namespace": "",
+          "queryMode": "Logs",
+          "refId": "A",
+          "region": "default",
+          "statsGroups": [
+            "bin(1d)"
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "NeTEx per day",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transformations": [
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "bin(1d)": {
+                "aggregations": [],
+                "operation": null
+              },
+              "count()": {
+                "aggregations": [],
+                "operation": null
+              }
+            }
+          }
+        }
+      ],
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null,
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 14,
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "expression": "fields @timestamp, @message\n| sort @timestamp desc\n| parse @message \"NeTEx generation complete for type *\" as type\n| filter ispresent(type)\n| stats count() by type",
+          "hide": false,
+          "id": "",
+          "logGroupNames": [
+            "/aws/lambda/netex-output-service-prod-NetexConvertor"
+          ],
+          "namespace": "",
+          "queryMode": "Logs",
+          "refId": "A",
+          "region": "default",
+          "statsGroups": [
+            "type"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "NeTEx created by type",
+      "transformations": [],
+      "type": "bargauge"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 11
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "expression": "fields @timestamp, @message\n| sort @timestamp desc\n| filter @message like /NeTEx generation complete/\n| stats count()",
+          "id": "",
+          "logGroupNames": [
+            "/aws/lambda/netex-output-service-prod-NetexConvertor"
+          ],
+          "namespace": "FDBT/Netex-Validator",
+          "queryMode": "Logs",
+          "refId": "A",
+          "region": "default",
+          "statsGroups": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total NeTEx",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 11
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "expression": "fields @timestamp, @message\n| sort @timestamp desc\n| filter @message like /registration successful/\n| stats count()",
+          "id": "",
+          "logGroupNames": [
+            "fdbt-site-prod"
+          ],
+          "namespace": "FDBT/Netex-Validator",
+          "queryMode": "Logs",
+          "refId": "A",
+          "region": "default",
+          "statsGroups": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total Registrations",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 11
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {},
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "startedTransactions",
+          "namespace": "FDBT/Site",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Started Transactions",
+      "type": "stat"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Business Intelligence",
+  "uid": "LVS6gUfMz",
+  "version": 13
+}

--- a/fdbt-aws/grafana/general/kpi.json
+++ b/fdbt-aws/grafana/general/kpi.json
@@ -15,12 +15,12 @@
     "editable": true,
     "gnetId": null,
     "graphTooltip": 0,
-    "id": 22,
+    "id": 9,
+    "iteration": 1639650892649,
     "links": [],
     "panels": [
         {
-            "datasource": null,
-            "description": "",
+            "datasource": "CloudWatch",
             "fieldConfig": {
                 "defaults": {
                     "custom": {},
@@ -31,9 +31,14 @@
                             {
                                 "color": "green",
                                 "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 200
                             }
                         ]
-                    }
+                    },
+                    "unit": "s"
                 },
                 "overrides": []
             },
@@ -43,7 +48,7 @@
                 "x": 0,
                 "y": 0
             },
-            "id": 2,
+            "id": 7,
             "options": {
                 "colorMode": "value",
                 "graphMode": "none",
@@ -51,39 +56,41 @@
                 "orientation": "auto",
                 "reduceOptions": {
                     "calcs": [
-                        "sum"
+                        "mean"
                     ],
                     "fields": "",
                     "values": false
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
-                    "dimensions": {},
+                    "dimensions": {
+                        "LoadBalancer": "app/FDBT-Publi-984WV6WVQ5BY/d90fa10cb3799dc0",
+                        "TargetGroup": "targetgroup/fdbt-site-tg-prod/21e1e60f2bf239d0"
+                    },
                     "expression": "",
                     "id": "",
                     "matchExact": true,
-                    "metricName": "startedTransactions",
-                    "namespace": "FDBT/Site",
+                    "metricName": "TargetResponseTime",
+                    "namespace": "AWS/ApplicationELB",
                     "period": "",
                     "refId": "A",
-                    "region": "default",
+                    "region": "eu-west-2",
                     "statistics": [
-                        "Sum"
+                        "Average"
                     ]
                 }
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Started Transactions",
+            "title": "Site ALB response time (Average)",
             "type": "stat"
         },
         {
-            "datasource": null,
-            "description": "",
+            "datasource": "CloudWatch",
             "fieldConfig": {
                 "defaults": {
                     "custom": {},
@@ -94,9 +101,14 @@
                             {
                                 "color": "green",
                                 "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 200
                             }
                         ]
-                    }
+                    },
+                    "unit": "s"
                 },
                 "overrides": []
             },
@@ -106,7 +118,7 @@
                 "x": 8,
                 "y": 0
             },
-            "id": 3,
+            "id": 8,
             "options": {
                 "colorMode": "value",
                 "graphMode": "none",
@@ -114,34 +126,37 @@
                 "orientation": "auto",
                 "reduceOptions": {
                     "calcs": [
-                        "sum"
+                        "mean"
                     ],
                     "fields": "",
                     "values": false
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
-                    "dimensions": {},
+                    "dimensions": {
+                        "LoadBalancer": "app/FDBT-Publi-984WV6WVQ5BY/d90fa10cb3799dc0",
+                        "TargetGroup": "targetgroup/fdbt-site-tg-prod/21e1e60f2bf239d0"
+                    },
                     "expression": "",
                     "id": "",
                     "matchExact": true,
-                    "metricName": "completeTransactions",
-                    "namespace": "FDBT/Site",
+                    "metricName": "TargetResponseTime",
+                    "namespace": "AWS/ApplicationELB",
                     "period": "",
                     "refId": "A",
-                    "region": "default",
+                    "region": "eu-west-2",
                     "statistics": [
-                        "Sum"
+                        "p95"
                     ]
                 }
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Completed Transactions",
+            "title": "Site ALB response time (95th percentile)",
             "type": "stat"
         },
         {
@@ -168,7 +183,7 @@
                 "x": 16,
                 "y": 0
             },
-            "id": 5,
+            "id": 10,
             "options": {
                 "colorMode": "value",
                 "graphMode": "none",
@@ -183,7 +198,67 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
+            "targets": [
+                {
+                    "expression": "fields @timestamp, @message\n| sort @timestamp desc\n| filter @message like /NeTEx generation complete/\n| stats count()",
+                    "id": "",
+                    "logGroupNames": [
+                        "/aws/lambda/netex-output-service-prod-NetexConvertor"
+                    ],
+                    "namespace": "FDBT/Netex-Validator",
+                    "queryMode": "Logs",
+                    "refId": "A",
+                    "region": "default",
+                    "statsGroups": []
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Total NeTEx",
+            "type": "stat"
+        },
+        {
+            "datasource": null,
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 9,
+                "w": 8,
+                "x": 0,
+                "y": 9
+            },
+            "id": 12,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "sum"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
@@ -191,8 +266,8 @@
                     "expression": "",
                     "id": "",
                     "matchExact": true,
-                    "metricName": "netex-valid-${environment}",
-                    "namespace": "FDBT/Netex-Validator",
+                    "metricName": "startedTransactions",
+                    "namespace": "FDBT/Site",
                     "period": "",
                     "refId": "A",
                     "region": "default",
@@ -203,10 +278,11 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Total NeTEx",
+            "title": "Started Transactions",
             "type": "stat"
         }
     ],
+    "refresh": false,
     "schemaVersion": 26,
     "style": "dark",
     "tags": [],
@@ -221,6 +297,7 @@
                 },
                 "datasource": "CloudWatch",
                 "definition": "metrics(FDBT/Netex-Output)",
+                "error": null,
                 "hide": 0,
                 "includeAll": false,
                 "label": null,
@@ -266,5 +343,5 @@
     "timezone": "",
     "title": "KPI",
     "uid": "XE3h8LNGk",
-    "version": 4
+    "version": 5
 }

--- a/fdbt-aws/grafana/services/netex-output.json
+++ b/fdbt-aws/grafana/services/netex-output.json
@@ -15,7 +15,8 @@
     "editable": true,
     "gnetId": null,
     "graphTooltip": 0,
-    "id": 19,
+    "id": 10,
+    "iteration": 1639650889237,
     "links": [],
     "panels": [
         {
@@ -58,7 +59,7 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
@@ -121,7 +122,7 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
@@ -180,8 +181,11 @@
             "lines": false,
             "linewidth": 1,
             "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
             "percentage": false,
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "pointradius": 2,
             "points": true,
             "renderer": "flot",
@@ -287,7 +291,7 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
@@ -350,7 +354,7 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
@@ -409,8 +413,11 @@
             "lines": false,
             "linewidth": 1,
             "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
             "percentage": false,
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "pointradius": 2,
             "points": true,
             "renderer": "flot",
@@ -516,7 +523,7 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
@@ -579,7 +586,7 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
@@ -618,6 +625,7 @@
                 },
                 "datasource": "CloudWatch",
                 "definition": "metrics(FDBT/Netex-Output)",
+                "error": null,
                 "hide": 0,
                 "includeAll": false,
                 "label": null,
@@ -644,7 +652,7 @@
         ]
     },
     "time": {
-        "from": "now-90d",
+        "from": "now-7d",
         "to": "now"
     },
     "timepicker": {

--- a/fdbt-aws/grafana/services/reference-data.json
+++ b/fdbt-aws/grafana/services/reference-data.json
@@ -15,7 +15,8 @@
     "editable": true,
     "gnetId": null,
     "graphTooltip": 0,
-    "id": 20,
+    "id": 12,
+    "iteration": 1639650889888,
     "links": [],
     "panels": [
         {
@@ -79,12 +80,12 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
                     "dimensions": {
-                        "FunctionName": "reference-data-service-uploaders-${environment}-XmlUploader"
+                        "FunctionName": "reference-data-service-uploaders-prod-TxcUploader"
                     },
                     "expression": "",
                     "id": "",
@@ -101,7 +102,7 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Successful XML Uploader",
+            "title": "Successful TXC Uploader",
             "type": "stat"
         },
         {
@@ -123,7 +124,7 @@
                             },
                             {
                                 "color": "green",
-                                "value": 5
+                                "value": 4
                             }
                         ]
                     }
@@ -151,7 +152,7 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
@@ -223,12 +224,12 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
                     "dimensions": {
-                        "FunctionName": "reference-data-service-retrievers-${environment}-TndsUnzipper"
+                        "FunctionName": "reference-data-service-retrievers-prod-TxcUnzipper"
                     },
                     "expression": "",
                     "id": "",
@@ -245,7 +246,7 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Successful TNDS Unzipper",
+            "title": "Successful TXC Unzipper",
             "type": "stat"
         },
         {
@@ -295,12 +296,12 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
                     "dimensions": {
-                        "FunctionName": "reference-data-service-retrievers-${environment}-TndsRetriever"
+                        "FunctionName": "reference-data-service-retrievers-prod-TxcRetriever"
                     },
                     "expression": "",
                     "id": "",
@@ -317,7 +318,7 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Successful TNDS Retriever",
+            "title": "Successful TXC Retriever",
             "type": "stat"
         },
         {
@@ -367,7 +368,7 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
@@ -439,7 +440,7 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
@@ -521,12 +522,12 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
                     "dimensions": {
-                        "FunctionName": "reference-data-service-uploaders-${environment}-XmlUploader"
+                        "FunctionName": "reference-data-service-uploaders-prod-TxcUploader"
                     },
                     "expression": "",
                     "id": "",
@@ -543,7 +544,7 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Errors XML Uploader",
+            "title": "Errors TXC Uploader",
             "type": "stat"
         },
         {
@@ -589,7 +590,7 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
@@ -657,12 +658,12 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
                     "dimensions": {
-                        "FunctionName": "reference-data-service-retrievers-${environment}-TndsUnzipper"
+                        "FunctionName": "reference-data-service-retrievers-prod-TxcUnzipper"
                     },
                     "expression": "",
                     "id": "",
@@ -679,7 +680,7 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Errors TNDS Unzipper",
+            "title": "Errors TXC Unzipper",
             "type": "stat"
         },
         {
@@ -725,12 +726,12 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
                     "dimensions": {
-                        "FunctionName": "reference-data-service-retrievers-${environment}-TndsRetriever"
+                        "FunctionName": "reference-data-service-retrievers-prod-TxcRetriever"
                     },
                     "expression": "",
                     "id": "",
@@ -747,7 +748,7 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Errors TNDS Retriever",
+            "title": "Errors TXC Retriever",
             "type": "stat"
         },
         {
@@ -793,7 +794,7 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
@@ -861,7 +862,7 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
@@ -943,12 +944,12 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
                     "dimensions": {
-                        "FunctionName": "reference-data-service-uploaders-${environment}-XmlUploader"
+                        "FunctionName": "reference-data-service-uploaders-prod-TxcUploader"
                     },
                     "expression": "",
                     "id": "",
@@ -965,7 +966,7 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Throttled XML Uploader",
+            "title": "Throttled TXC Uploader",
             "type": "stat"
         },
         {
@@ -1011,7 +1012,7 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
@@ -1079,12 +1080,12 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
                     "dimensions": {
-                        "FunctionName": "reference-data-service-retrievers-${environment}-TndsUnzipper"
+                        "FunctionName": "reference-data-service-retrievers-prod-TxcUnzipper"
                     },
                     "expression": "",
                     "id": "",
@@ -1101,7 +1102,7 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Throttled TNDS Unzipper",
+            "title": "Throttled TXC Unzipper",
             "type": "stat"
         },
         {
@@ -1147,12 +1148,12 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
                     "dimensions": {
-                        "FunctionName": "reference-data-service-retrievers-${environment}-TndsRetriever"
+                        "FunctionName": "reference-data-service-retrievers-prod-TxcRetriever"
                     },
                     "expression": "",
                     "id": "",
@@ -1169,7 +1170,7 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Throttled TNDS Retriever",
+            "title": "Throttled TXC Retriever",
             "type": "stat"
         },
         {
@@ -1215,7 +1216,7 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
@@ -1283,7 +1284,7 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
@@ -1323,6 +1324,7 @@
                 },
                 "datasource": "CloudWatch",
                 "definition": "metrics(FDBT/Netex-Output)",
+                "error": null,
                 "hide": 0,
                 "includeAll": false,
                 "label": null,
@@ -1368,5 +1370,5 @@
     "timezone": "",
     "title": "Reference Data",
     "uid": "0ob5s07Gz",
-    "version": 7
+    "version": 3
 }

--- a/fdbt-aws/grafana/services/site.json
+++ b/fdbt-aws/grafana/services/site.json
@@ -15,7 +15,7 @@
     "editable": true,
     "gnetId": null,
     "graphTooltip": 0,
-    "id": 21,
+    "id": 13,
     "links": [],
     "panels": [
         {
@@ -61,7 +61,7 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
@@ -123,7 +123,7 @@
                 },
                 "textMode": "auto"
             },
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "targets": [
                 {
                     "alias": "",
@@ -181,8 +181,11 @@
             "lines": true,
             "linewidth": 1,
             "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
             "percentage": false,
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "pointradius": 2,
             "points": false,
             "renderer": "flot",
@@ -283,8 +286,11 @@
             "lines": true,
             "linewidth": 1,
             "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
             "percentage": false,
-            "pluginVersion": "7.1.5",
+            "pluginVersion": "7.3.5",
             "pointradius": 2,
             "points": false,
             "renderer": "flot",

--- a/fdbt-aws/grafana/services/txc-retrieval.json
+++ b/fdbt-aws/grafana/services/txc-retrieval.json
@@ -1,0 +1,1518 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 15,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 13,
+      "panels": [],
+      "title": "BODS",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 28,
+      "options": {
+        "content": "# File Level\n\nData relevant to the file as a whole         ",
+        "mode": "markdown"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {},
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "",
+          "namespace": "",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Average"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 4
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "bods"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "FilesProcessedWithData",
+          "namespace": "FDBT/Reference-Data-Uploaders",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "BODS - Files Processed with Data",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 4,
+        "y": 4
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "bods"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "FilesProcessedNoData",
+          "namespace": "FDBT/Reference-Data-Uploaders",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "BODS - Files Processed with no Useable Data",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 8,
+        "y": 4
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "bods"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "NoNOCsInFile",
+          "namespace": "FDBT/Reference-Data-Uploaders",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "BODS - Files Processed with no NOCs",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 12,
+        "y": 4
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "bods"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "InvalidNoc",
+          "namespace": "FDBT/Reference-Data-Uploaders",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "BODS - Files Processed with Invalid NOCs",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 16,
+        "y": 4
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "bods"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "NoOperatorData",
+          "namespace": "FDBT/Reference-Data-Uploaders",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "BODS - Files Processed with No Operator Data",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 11
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "bods"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "NoServiceDataInFile",
+          "namespace": "FDBT/Reference-Data-Uploaders",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "BODS - Files Processed with No Service Data",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 4,
+        "y": 11
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "bods"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "NoLineDataInFile",
+          "namespace": "FDBT/Reference-Data-Uploaders",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "BODS - Files Processed with No Line Data",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 8,
+        "y": 11
+      },
+      "id": 39,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "bods"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "TxcFilesCopied",
+          "namespace": "FDBT/Reference-Data-Retrievers",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "BODS - Total Files Retrieved",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 29,
+      "options": {
+        "content": "# Operator Level\n\nData relevant to operators within a file since a single TXC file can contain multiple operators        ",
+        "mode": "markdown"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {},
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "",
+          "namespace": "",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Average"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 21
+      },
+      "id": 26,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "bods"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "NoNoc",
+          "namespace": "FDBT/Reference-Data-Uploaders",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "BODS - Operators with No NOC",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 4,
+        "y": 21
+      },
+      "id": 30,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "bods"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "InvalidNoc",
+          "namespace": "FDBT/Reference-Data-Uploaders",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "BODS - Operators with Invalid NOCs",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 16,
+      "panels": [],
+      "title": "TNDS",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 31,
+      "options": {
+        "content": "# File Level\n\nData relevant to the file as a whole         ",
+        "mode": "markdown"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {},
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "",
+          "namespace": "",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Average"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 32
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "tnds"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "FilesProcessedWithData",
+          "namespace": "FDBT/Reference-Data-Uploaders",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "TNDS - Files Processed with Data",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 4,
+        "y": 32
+      },
+      "id": 17,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "tnds"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "FilesProcessedNoData",
+          "namespace": "FDBT/Reference-Data-Uploaders",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "TNDS - Files Processed with no Useable Data",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 8,
+        "y": 32
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "tnds"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "NoNOCsInFile",
+          "namespace": "FDBT/Reference-Data-Uploaders",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "TNDS - Files Processed with no NOCs",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 12,
+        "y": 32
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "tnds"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "InvalidNoc",
+          "namespace": "FDBT/Reference-Data-Uploaders",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "TNDS - Files Processed with Invalid NOCs",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 16,
+        "y": 32
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "tnds"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "NoOperatorData",
+          "namespace": "FDBT/Reference-Data-Uploaders",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "TNDS - Files Processed with No Operator Data",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 39
+      },
+      "id": 32,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "tnds"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "NoServiceDataInFile",
+          "namespace": "FDBT/Reference-Data-Uploaders",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "TNDS - Files Processed with No Service Data",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 4,
+        "y": 39
+      },
+      "id": 33,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "tnds"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "NoLineDataInFile",
+          "namespace": "FDBT/Reference-Data-Uploaders",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "TNDS - Files Processed with No Line Data",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 8,
+        "y": 39
+      },
+      "id": 40,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "tnds"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "TxcFilesCopied",
+          "namespace": "FDBT/Reference-Data-Retrievers",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "TNDS - Total Files Retrieved",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "id": 34,
+      "options": {
+        "content": "# Operator Level\n\nData relevant to operators within a file since a single TXC file can contain multiple operators        ",
+        "mode": "markdown"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {},
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "",
+          "namespace": "",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Average"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 49
+      },
+      "id": 37,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "tnds"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "NoNoc",
+          "namespace": "FDBT/Reference-Data-Uploaders",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "TNDS - Operators with No NOC",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 4,
+        "y": 49
+      },
+      "id": 38,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "alias": "",
+          "dimensions": {
+            "By Data Source": "tnds"
+          },
+          "expression": "",
+          "id": "",
+          "matchExact": true,
+          "metricName": "InvalidNoc",
+          "namespace": "FDBT/Reference-Data-Uploaders",
+          "period": "",
+          "refId": "A",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "TNDS - Operators with Invalid NOCs",
+      "type": "stat"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "TXC Retrieval",
+  "uid": "EVWFOK8Mz",
+  "version": 2
+}


### PR DESCRIPTION
# Description

Upgrades Grafana to latest version at time of PR which is 8.3.3
Includes a backup of all of the dashboards, however they will be persisted as they're stored in AWS EFS and attached to the running instance

# Testing instructions

Ensure Grafana is up, version can be seen at the bottom of the login page

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [x] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
