### PR TITLE
fix: cfd-566 stop altering of the original fare zones array being passed in

### DIFF
--- a/repos/fdbt-netex-output/src/netex-convertor/netexGenerator.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/netexGenerator.ts
@@ -222,10 +222,14 @@ const netexGenerator = async (ticket: Ticket, operatorData: Operator[]): Promise
 
     const updateServiceFrame = (serviceFrame: NetexObject): NetexObject | null => {
         const serviceFrameToUpdate = { ...serviceFrame };
+
         if (isMultiServiceTicket(ticket) || isSchemeOperatorFlatFareTicket(ticket) || isHybridTicket(ticket)) {
             serviceFrameToUpdate.id = `epd:UK:${coreData.operatorIdentifier}:ServiceFrame_UK_PI_NETWORK:${coreData.placeholderGroupOfProductsName}:op`;
+
             const lines = getLinesList(ticket, coreData.url, operatorData);
+
             serviceFrameToUpdate.lines.Line = lines;
+
             serviceFrameToUpdate.groupsOfLines.GroupOfLines = getGroupOfLinesList(
                 coreData.operatorIdentifier,
                 isHybridTicket(ticket),
@@ -234,6 +238,7 @@ const netexGenerator = async (ticket: Ticket, operatorData: Operator[]): Promise
 
             return serviceFrameToUpdate;
         }
+
         delete serviceFrameToUpdate.groupsOfLines;
 
         if ('lineName' in ticket) {
@@ -267,6 +272,7 @@ const netexGenerator = async (ticket: Ticket, operatorData: Operator[]): Promise
 
             return serviceFrameToUpdate;
         }
+
         return null;
     };
 

--- a/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexHelpers.ts
@@ -34,18 +34,21 @@ export const hasDuplicates = (array: string[]): boolean => {
 };
 
 export const getPointToPointScheduledStopPointsList = (fareZones: FareZone[]): ScheduledStopPoints[] => {
-    let stops = getStops(fareZones);
+    // we want a copy because we do not want to alter the fare zones array being passed in
+    const copyOfFareZones = fareZones.map(fz => fz);
+
+    let stops = getStops(copyOfFareZones);
 
     const stopsAtcoCodes = stops.map(s => s.atcoCode);
 
     const hasDuplicateStops = hasDuplicates(stopsAtcoCodes);
 
     if (hasDuplicateStops) {
-        const firstFareStage = fareZones[0];
+        const firstFareStage = copyOfFareZones[0];
 
         const firstStopInFirstFareStage = firstFareStage.stops[0];
 
-        const lastFareStage = fareZones[fareZones.length - 1];
+        const lastFareStage = copyOfFareZones[copyOfFareZones.length - 1];
 
         const lastStopInLastFareStage = lastFareStage.stops[lastFareStage.stops.length - 1];
 
@@ -55,7 +58,7 @@ export const getPointToPointScheduledStopPointsList = (fareZones: FareZone[]): S
         }
     }
 
-    stops = getStops(fareZones);
+    stops = getStops(copyOfFareZones);
 
     return stops.map(stop => ({
         version: 'any',


### PR DESCRIPTION
# Description

-   Stop altering of the original fare zones array being passed in, this was causing the fare zones XML element to be wrong.

# Testing instructions

-   Do an export on test for FSRV and check scheduled stops and farezones (send to Steve for verification)

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
