### PR TITLE
fix: Setting RDS CPU Alarm to 95%

### DIFF
--- a/fdbt-aws/cloudformation/service/eu-west-2/rds.yml
+++ b/fdbt-aws/cloudformation/service/eu-west-2/rds.yml
@@ -113,14 +113,14 @@ Resources:
   DatabaseMasterCPUAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: Master database CPU utilization is over 80%.
+      AlarmDescription: Master database CPU utilization is over 95%.
       Namespace: AWS/RDS
       MetricName: CPUUtilization
       Unit: Percent
       Statistic: Average
       Period: 300
       EvaluationPeriods: 3
-      Threshold: 80
+      Threshold: 95
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: DBInstanceIdentifier


### PR DESCRIPTION
# Description

Setting RDS CPU Alarm to 95%

# Testing instructions

No nightly false positive alarm firing to Slack

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
