### PR TITLE
fix: cfd-545 allow csp all from self

### DIFF
--- a/fdbt-aws/cloudformation/service/us-east-1/lambda.yml
+++ b/fdbt-aws/cloudformation/service/us-east-1/lambda.yml
@@ -46,13 +46,14 @@ Resources:
               headers['strict-transport-security'] = [{key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains; preload'}];
 
               if (!headers['content-security-policy']) {
-                headers['content-security-policy'] = [{key: 'Content-Security-Policy', value: "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'; connect-src 'self'; upgrade-insecure-requests"}];
+                headers['content-security-policy'] = [{key: 'Content-Security-Policy', value: "default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self'; object-src 'self'; connect-src 'self'; upgrade-insecure-requests"}];
               }
 
               headers['x-content-type-options'] = [{key: 'X-Content-Type-Options', value: 'nosniff'}];
               headers['x-frame-options'] = [{key: 'X-Frame-Options', value: 'DENY'}];
               headers['x-xss-protection'] = [{key: 'X-XSS-Protection', value: '1; mode=block'}];
               headers['referrer-policy'] = [{key: 'Referrer-Policy', value: 'same-origin'}];
+              delete headers['x-powered-by'];
 
               callback(null, response);
           };


### PR DESCRIPTION
# Description

fix: cfd-545 allow csp all from self

# Testing instructions

* CloudFormation `fdbt-aws/cloudformation/service/us-east-1/lambda.yml` needs manually deploying. Then `FDBT-Cloudfront` stack updating with the Lambda version ARN (ensure a new version has been created)
* This will affect the CloudFront Error page, so need to break/disable Fargate site to see this error page

# Type of change

-   [ ] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
