### PR TITLE
fix: cfd-604 adding security headers to admin

### DIFF
--- a/repos/fdbt-admin/customHttp.yml
+++ b/repos/fdbt-admin/customHttp.yml
@@ -1,0 +1,15 @@
+customHeaders:
+  - pattern: "**/*"
+    headers:
+      - key: "Strict-Transport-Security"
+        value: "max-age=31536000; includeSubDomains"
+      - key: "Content-Security-Policy"
+        value: default-src 'self'; img-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; object-src 'none'; connect-src 'self' https://*.amazonaws.com; upgrade-insecure-requests
+      - key: "X-Frame-Options"
+        value: "DENY"
+      - key: "X-XSS-Protection"
+        value: "1; mode=block"
+      - key: " X-Content-Type-Options"
+        value: "nosniff"
+      - key: "Referrer-Policy"
+        value: "same-origin"


### PR DESCRIPTION
# Description

fix: cfd-604 adding security headers to admin

# Testing instructions

Needs to be manually deployed in the Amplify Console due to outstanding `amplify` cli issue of not adding headers to existing deployments https://github.com/aws-amplify/amplify-console/issues/1317

# Type of change

-   [ ] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
