### PR TITLE
fix: cfd-621 restricting database and bastion egress rules

### DIFF
--- a/fdbt-aws/cloudformation/service/eu-west-2/vpc.yml
+++ b/fdbt-aws/cloudformation/service/eu-west-2/vpc.yml
@@ -298,6 +298,12 @@ Resources:
           FromPort: 3306
           ToPort: 3306
           SourceSecurityGroupId: !Ref FargateSiteContainerSecurityGroup
+      SecurityGroupEgress:
+        - CidrIp: 127.0.0.1/32
+          Description: "Setting egress to local host as unable to delete default rule"
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
       Tags:
         - Key: Name
           Value: !Sub ${ProductName}-db-sg-${Stage}
@@ -307,9 +313,24 @@ Resources:
     Properties:
       GroupDescription: Access to the Bastion
       VpcId: !Ref VPC
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
       Tags:
         - Key: Name
           Value: !Sub ${ProductName}-bastion-sg-${Stage}
+
+  BastionSecurityGroupEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      Description: "Database SG"
+      DestinationSecurityGroupId: !Ref DatabaseSecurityGroup
+      FromPort: 3306
+      GroupId: !Ref BastionSecurityGroup
+      IpProtocol: tcp
+      ToPort: 3306
 
   UploaderSecurityGroup:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
# Description

fix: cfd-621 restricting database and bastion egress rules

# Testing instructions

-   Add testing instructions if required

# Type of change

-   [ ] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
