### PR TITLE
fix: cfd-597 only close the db connection once

### DIFF
--- a/repos/fdbt-reference-data-service/src/uploaders/txc_uploader/main.py
+++ b/repos/fdbt-reference-data-service/src/uploaders/txc_uploader/main.py
@@ -44,6 +44,8 @@ def lambda_handler(event, context):
         )
         raise e
     finally:
+        db_connection.close()
+
         if os.path.exists(file_path):
             logger.info(f"Removing File: {file_path}")
             os.remove(file_path)

--- a/repos/fdbt-reference-data-service/src/uploaders/txc_uploader/txc_processor.py
+++ b/repos/fdbt-reference-data-service/src/uploaders/txc_uploader/txc_processor.py
@@ -483,9 +483,6 @@ def write_to_database(
         )
         raise e
 
-    finally:
-        db_connection.close()
-
 
 def download_from_s3_and_write_to_db(
     s3, cloudwatch, bucket, key, file_path, db_connection, logger


### PR DESCRIPTION
# Description

fix: cfd-597 only close the db connection once

# Testing instructions

"Already closed" errors seen in test not seen again

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
