### PR TITLE
fix: cfd-597 connection does not need closing

### DIFF
--- a/repos/fdbt-reference-data-service/src/uploaders/txc_uploader/main.py
+++ b/repos/fdbt-reference-data-service/src/uploaders/txc_uploader/main.py
@@ -44,8 +44,6 @@ def lambda_handler(event, context):
         )
         raise e
     finally:
-        db_connection.close()
-
         if os.path.exists(file_path):
             logger.info(f"Removing File: {file_path}")
             os.remove(file_path)


### PR DESCRIPTION
# Description

Gets automatically closed

# Testing instructions

Nightly uploaders complete, need to trigger retrievers to then trigger Uploaders via S3 actions

# Type of change

-   [ ] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
