### PR TITLE
fix: cfd-623 allow ftp egress for retrievers

### DIFF
--- a/fdbt-aws/cloudformation/service/eu-west-2/vpc.yml
+++ b/fdbt-aws/cloudformation/service/eu-west-2/vpc.yml
@@ -299,8 +299,8 @@ Resources:
           ToPort: 3306
           SourceSecurityGroupId: !Ref FargateSiteContainerSecurityGroup
       SecurityGroupEgress:
-        - CidrIp: 127.0.0.1/32
-          Description: "Setting egress to local host as unable to delete default rule"
+        - CidrIp: 0.0.0.0/0
+          Description: "to AWS APIs"
           IpProtocol: tcp
           FromPort: 443
           ToPort: 443

--- a/fdbt-aws/cloudformation/service/eu-west-2/vpc.yml
+++ b/fdbt-aws/cloudformation/service/eu-west-2/vpc.yml
@@ -342,6 +342,16 @@ Resources:
           FromPort: 443
           ToPort: 443
           CidrIp: 0.0.0.0/0
+        - Description: "to FTP Control for Retrievers"
+          IpProtocol: tcp
+          FromPort: 21
+          ToPort: 21
+          CidrIp: 0.0.0.0/0
+        - Description: "to FTP Passive for Retrievers"
+          IpProtocol: tcp
+          FromPort: 5000
+          ToPort: 5100
+          CidrIp: 0.0.0.0/0
       VpcId: !Ref VPC
       Tags:
         - Key: Name


### PR DESCRIPTION
# Description

allow ftp egress for retrievers

# Testing instructions

Any Lambda event will trigger the retriever

# Type of change

-   [ ] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
