### PR TITLE
fix: cfd-493 Point to Point Period should not have "No Expiry" option

### DIFF
--- a/repos/fdbt-site/src/pages/pointToPointPeriodProduct.tsx
+++ b/repos/fdbt-site/src/pages/pointToPointPeriodProduct.tsx
@@ -101,7 +101,6 @@ const ProductDetails = ({
                                         unitName="durationUnits"
                                         unitId="product-details-expiry-unit"
                                         errors={errors}
-                                        carnet
                                     />
                                 </>
                             </FormGroupWrapper>

--- a/repos/fdbt-site/tests/pages/__snapshots__/pointToPointPeriodProduct.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/pointToPointPeriodProduct.test.tsx.snap
@@ -105,7 +105,6 @@ exports[`pages pointToPointPeriodProduct should render correctly on first load 1
             errors={Array []}
           />
           <ExpirySelector
-            carnet={true}
             defaultDuration=""
             errors={Array []}
             hintId="product-expiry-hint"
@@ -307,7 +306,6 @@ exports[`pages pointToPointPeriodProduct should render error messaging when erro
             }
           />
           <ExpirySelector
-            carnet={true}
             defaultDuration=""
             errors={
               Array [


### PR DESCRIPTION
## Description

Point to Point Period should not have "No Expiry" option in dropdown

Boolean attributes in JSX default to true, which when `carnet` is passed to the `ExpirySelector` results in the `CarnetExpiryUnit` being used, which contains "No Expiry" not the `ExpiryUnit` which doesn't

## Testing instructions

User journey: Create a product > period ticket > point to point > follow the journey until -> Enter your period product details -> Period duration -> Confirm duration dropdown does not have "No Expiry"
