### PR TITLE
fix: cfd-643 fix noc attribute in admin

### DIFF
--- a/repos/fdbt-admin/src/pages/ListUsers.tsx
+++ b/repos/fdbt-admin/src/pages/ListUsers.tsx
@@ -9,14 +9,17 @@ import getCognitoClientAndUserPool from '../utils/cognito';
 const formatAttributes = (attributes: AttributeListType) => {
     return attributes
         .filter((attribute) => ATTRIBUTE_MAP[attribute.Name])
-        .map((attribute) => (
-            <Fragment key={attribute.Name}>
-                <span>
-                    <strong>{ATTRIBUTE_MAP[attribute.Name]}</strong>: {attribute.Value}
-                </span>
-                <br />
-            </Fragment>
-        ));
+        .map(
+            (attribute) =>
+                attribute.Value !== undefined && (
+                    <Fragment key={attribute.Name}>
+                        <span>
+                            <strong>{ATTRIBUTE_MAP[attribute.Name]}</strong>: {attribute.Value.replace(/\|/g, ', ')}
+                        </span>
+                        <br />
+                    </Fragment>
+                ),
+        );
 };
 
 const getAttributeValue = (user: UserType, attributeName: string): string | undefined =>


### PR DESCRIPTION
## Description

User's with a lot of NOCs break the page width as the attribute is returned without spaces and cannot be broken up by the browser. So replace the `|` with `, ` so the browser can break it up and wrap it into the column of the list table

This change need manual deployments through `amplify publish` this will be picked up as part of the DNS migration work as that already contains a step to deploy to Admin

## Testing instructions

List users in Admin
