### PR TITLE
Removed the timezone for reset password test case

### DIFF
--- a/repos/fdbt-site/tests/pages/resetPassword.test.tsx
+++ b/repos/fdbt-site/tests/pages/resetPassword.test.tsx
@@ -6,7 +6,7 @@ import { USER_ATTRIBUTE } from '../../src/constants/attributes';
 
 describe('resetPassword', () => {
     // gets the time value in seconds and adds one hour
-    const expiryDate = Math.floor(new Date(2018, 12, 28).getTime() / 1000) + 3600;
+    const expiryDate = new Date(Date.UTC(2018, 12, 28)).getTime() / 1000 + 3600;
     const mockErrors = [
         {
             errorMessage: 'Passwords do not match',


### PR DESCRIPTION
## Description

PR is to remove the timezone constraint for the test cases.

## Testing instructions

Change directory in the terminal to fdbt-netex-output directory via command:
`cd repos/fdbt-netex-output`

Execute the unit test:
`npm run test`
