### PR TITLE
feat: Edit passenger type for products

### DIFF
--- a/repos/fdbt-site/src/pages/api/selectPassengerType.ts
+++ b/repos/fdbt-site/src/pages/api/selectPassengerType.ts
@@ -34,7 +34,6 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
         const matchingJsonMetaData = getSessionAttribute(req, MATCHING_JSON_META_DATA_ATTRIBUTE);
 
         if (ticket && matchingJsonMetaData && (dbIndividual || dbGroup)) {
-            console.log('HERE')
             // edit mode
             const updatedTicket = {
                 ...ticket,

--- a/repos/fdbt-site/src/pages/api/selectPassengerType.ts
+++ b/repos/fdbt-site/src/pages/api/selectPassengerType.ts
@@ -4,12 +4,15 @@ import {
     FARE_TYPE_ATTRIBUTE,
     GROUP_PASSENGER_INFO_ATTRIBUTE,
     GROUP_SIZE_ATTRIBUTE,
+    MATCHING_JSON_ATTRIBUTE,
+    MATCHING_JSON_META_DATA_ATTRIBUTE,
     PASSENGER_TYPE_ATTRIBUTE,
 } from '../../constants/attributes';
 import { convertToFullPassengerType, getGroupPassengerTypeById, getPassengerTypeById } from '../../data/auroradb';
 import { FareType, NextApiRequestWithSession } from '../../interfaces';
 import { getSessionAttribute, updateSessionAttribute } from '../../utils/sessions';
 import { redirectTo, redirectToError, getAndValidateNoc } from '../../utils/apiUtils/index';
+import { putUserDataInProductsBucketWithFilePath } from '../../utils/apiUtils/userData';
 
 export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
     try {
@@ -26,6 +29,32 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
 
         const dbIndividual = await getPassengerTypeById(selectedPassengerType, nocCode);
         const dbGroup = await getGroupPassengerTypeById(selectedPassengerType, nocCode);
+
+        const ticket = getSessionAttribute(req, MATCHING_JSON_ATTRIBUTE);
+        const matchingJsonMetaData = getSessionAttribute(req, MATCHING_JSON_META_DATA_ATTRIBUTE);
+
+        if (ticket && matchingJsonMetaData && (dbIndividual || dbGroup)) {
+            console.log('HERE')
+            // edit mode
+            const updatedTicket = {
+                ...ticket,
+                passengerType: { id: selectedPassengerType },
+            };
+
+            // put the now updated matching json into s3
+            // overriding the existing object
+            await putUserDataInProductsBucketWithFilePath(updatedTicket, matchingJsonMetaData.matchingJsonLink);
+
+            updateSessionAttribute(req, PASSENGER_TYPE_ATTRIBUTE, undefined);
+
+            redirectTo(
+                res,
+                `/products/productDetails?productId=${matchingJsonMetaData?.productId}${
+                    matchingJsonMetaData.serviceId ? `&serviceId=${matchingJsonMetaData?.serviceId}` : ''
+                }`,
+            );
+            return;
+        }
 
         if (dbGroup) {
             const fullGroup = await convertToFullPassengerType(dbGroup, nocCode);

--- a/repos/fdbt-site/tests/pages/api/selectPassengerType.test.ts
+++ b/repos/fdbt-site/tests/pages/api/selectPassengerType.test.ts
@@ -178,7 +178,6 @@ describe('selectPassengerType', () => {
     });
 
     it('should update the passenger type when in edit mode and redirect back to products/productDetails', async () => {
-
         getPassengerTypeByIdSpy.mockImplementation().mockResolvedValue(individualDatabaseResult);
         getGroupPassengerTypeByIdSpy.mockImplementation().mockResolvedValue(groupDbResult);
 

--- a/repos/fdbt-site/tests/pages/products/productDetails.test.tsx
+++ b/repos/fdbt-site/tests/pages/products/productDetails.test.tsx
@@ -98,7 +98,7 @@ describe('myfares pages', () => {
                         { name: 'Fare type', id: 'fare-type', content: ['Single'] },
                         { name: 'Service', content: ['Test Line Name - Test Origin to Test Destination'] },
                         { name: 'Journey direction', content: ['Inbound - this way'] },
-                        { name: 'Passenger type', content: ['Test Passenger Type'] },
+                        { name: 'Passenger type', content: ['Test Passenger Type'], editLink: '/selectPassengerType' },
                         { name: 'Only valid during term time', content: ['Yes'] },
                         { name: 'Fare triangle', content: ['You created a fare triangle'], editLink: '/csvUpload' },
                         { name: 'Purchase methods', content: ['SOP 1', 'SOP 2'] },
@@ -122,7 +122,7 @@ describe('myfares pages', () => {
                     productDetailsElements: [
                         { name: 'Fare type', id: 'fare-type', content: ['Period'] },
                         { name: 'Service', content: ['Test Line Name - Test Origin to Test Destination'] },
-                        { name: 'Passenger type', content: ['Test Passenger Type'] },
+                        { name: 'Passenger type', content: ['Test Passenger Type'], editLink: '/selectPassengerType' },
                         { name: 'Time restriction', content: ['Test Time Restriction'] },
                         { name: 'Fare triangle', content: ['You created a fare triangle'], editLink: '/csvUpload' },
                         { name: 'Period duration', content: ['7 weeks'] },
@@ -152,7 +152,7 @@ describe('myfares pages', () => {
                     endDate: '18/12/2020',
                     productDetailsElements: [
                         { name: 'Fare type', id: 'fare-type', content: ['Return'] },
-                        { name: 'Passenger type', content: ['Test Passenger Type'] },
+                        { name: 'Passenger type', content: ['Test Passenger Type'], editLink: '/selectPassengerType' },
                         { name: 'Time restriction', content: ['Test Time Restriction'] },
                         { name: 'Fare triangle', content: ['You created a fare triangle'], editLink: '/csvUpload' },
                         { name: 'Quantity in bundle', content: ['10'] },
@@ -181,7 +181,7 @@ describe('myfares pages', () => {
                     productDetailsElements: [
                         { name: 'Fare type', id: 'fare-type', content: ['Period'] },
                         { name: 'Zone', content: ['Green Lane Shops'] },
-                        { name: 'Passenger type', content: ['Test Passenger Type'] },
+                        { name: 'Passenger type', content: ['Test Passenger Type'], editLink: '/selectPassengerType' },
                         { name: 'Time restriction', content: ['Test Time Restriction'] },
                         { name: 'Period duration', content: ['5 weeks'] },
                         { name: 'Product expiry', content: ['24 hr'] },
@@ -208,7 +208,7 @@ describe('myfares pages', () => {
                     productDetailsElements: [
                         { name: 'Fare type', id: 'fare-type', content: ['Multi operator'] },
                         { name: 'Zone', content: ['Green Lane Shops'] },
-                        { name: 'Passenger type', content: ['Test Passenger Type'] },
+                        { name: 'Passenger type', content: ['Test Passenger Type'], editLink: '/selectPassengerType' },
                         { name: 'Time restriction', content: ['Test Time Restriction'] },
                         { name: 'Multi Operator Group', content: ['TEST, MCTR, WBTR, BLAC'] },
                         { name: 'Period duration', content: ['5 weeks'] },
@@ -234,7 +234,7 @@ describe('myfares pages', () => {
                     endDate: '18/12/2020',
                     productDetailsElements: [
                         { name: 'Fare type', id: 'fare-type', content: ['Flat fare'] },
-                        { name: 'Passenger type', content: ['Test Passenger Type'] },
+                        { name: 'Passenger type', content: ['Test Passenger Type'], editLink: '/selectPassengerType' },
                         { name: 'Time restriction', content: ['Test Time Restriction'] },
                         { name: 'WBTR Services', content: ['343, 444, 543'] },
                         { name: 'BLAC Services', content: ['100, 101, 102'] },
@@ -261,7 +261,7 @@ describe('myfares pages', () => {
                     productDetailsElements: [
                         { name: 'Fare type', id: 'fare-type', content: ['Period'] },
                         { name: 'Zone', content: ['Green Lane Shops'] },
-                        { name: 'Passenger type', content: ['Test Passenger Type'] },
+                        { name: 'Passenger type', content: ['Test Passenger Type'], editLink: '/selectPassengerType' },
                         { name: 'Time restriction', content: ['Test Time Restriction'] },
                         { name: 'Multi Operator Group', content: ['MCTR, WBTR, BLAC'] },
                         { name: 'Period duration', content: ['5 weeks'] },


### PR DESCRIPTION
## Description

To allow users to edit a passenger type without having to delete and recreate the product.

## Testing instructions

Run locally and edit a passenger type via My Fares.
