### PR TITLE
feat: autogenerate returns from singles

### DIFF
--- a/repos/fdbt-site/src/components/GenerateReturnPopup.tsx
+++ b/repos/fdbt-site/src/components/GenerateReturnPopup.tsx
@@ -1,44 +1,24 @@
 import React, { ReactElement } from 'react';
-import { getPointToPointProductsByLineId } from '../data/auroradb';
 
 interface GenerateSinglePopupPopUpProps {
-    apiUrl: string;
-    lineId: string;
-    nocCode: string;
     cancelActionHandler: React.MouseEventHandler<HTMLButtonElement>;
 }
 
-const canGenerateAReturn = async (noc: string, lineId: string): Promise<boolean> => {
-    const products = await getPointToPointProductsByLineId(noc, lineId);
-    return true;
+const GenerateReturnPopup = ({ cancelActionHandler }: GenerateSinglePopupPopUpProps): ReactElement => {
+    return (
+        <div className="popup">
+            <div className="popup__content">
+                <h1 className="govuk-heading-m">A return cannot be auto-generated for this product.</h1>
+                <span className="govuk-hint" id="delete-hint">
+                    Two singles must be created, one for inbound and one for outbound. They must have the same passenger
+                    type and not be expired.
+                </span>
+                <button className="govuk-button govuk-button--secondary" onClick={cancelActionHandler}>
+                    Close
+                </button>
+            </div>
+        </div>
+    );
 };
 
-const GenerateSinglePopup = async ({ apiUrl, cancelActionHandler, lineId, nocCode }: GenerateSinglePopupPopUpProps): Promise<ReactElement | null> => (
-    <div className="popup">
-        <div className="popup__content">
-            <form>
-                <h1 className="govuk-heading-m"></h1>
-
-                <span className="govuk-hint" id="delete-hint"></span>
-
-                <button className="govuk-button govuk-button--secondary" onClick={cancelActionHandler}>
-                    Cancel
-                </button>
-
-                {await canGenerateAReturn(nocCode, lineId) && (
-                    <button
-                        className="govuk-link govuk-body button-link govuk-!-margin-bottom-0"
-                        formAction={apiUrl}
-                        formMethod="post"
-                        type="submit"
-                        id="generate-return-button"
-                    >
-                        Generate return from singles
-                    </button>
-                )}
-            </form>
-        </div>
-    </div>
-);
-
-export default GenerateSinglePopup;
+export default GenerateReturnPopup;

--- a/repos/fdbt-site/src/components/GenerateReturnPopup.tsx
+++ b/repos/fdbt-site/src/components/GenerateReturnPopup.tsx
@@ -11,7 +11,8 @@ const GenerateReturnPopup = ({ cancelActionHandler }: GenerateSinglePopupPopUpPr
                 <h1 className="govuk-heading-m">A return cannot be auto-generated for this product.</h1>
                 <span className="govuk-hint" id="delete-hint">
                     Two singles must be created, one for inbound and one for outbound. They must have the same passenger
-                    type and not be expired.
+                    type and not be expired. Services with one direction (circular services for example) cannot be used
+                    to generate returns.
                 </span>
                 <button className="govuk-button govuk-button--secondary" onClick={cancelActionHandler}>
                     Close

--- a/repos/fdbt-site/src/components/GenerateReturnPopup.tsx
+++ b/repos/fdbt-site/src/components/GenerateReturnPopup.tsx
@@ -1,0 +1,44 @@
+import React, { ReactElement } from 'react';
+import { getPointToPointProductsByLineId } from '../data/auroradb';
+
+interface GenerateSinglePopupPopUpProps {
+    apiUrl: string;
+    lineId: string;
+    nocCode: string;
+    cancelActionHandler: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+const canGenerateAReturn = async (noc: string, lineId: string): Promise<boolean> => {
+    const products = await getPointToPointProductsByLineId(noc, lineId);
+    return true;
+};
+
+const GenerateSinglePopup = async ({ apiUrl, cancelActionHandler, lineId, nocCode }: GenerateSinglePopupPopUpProps): Promise<ReactElement | null> => (
+    <div className="popup">
+        <div className="popup__content">
+            <form>
+                <h1 className="govuk-heading-m"></h1>
+
+                <span className="govuk-hint" id="delete-hint"></span>
+
+                <button className="govuk-button govuk-button--secondary" onClick={cancelActionHandler}>
+                    Cancel
+                </button>
+
+                {await canGenerateAReturn(nocCode, lineId) && (
+                    <button
+                        className="govuk-link govuk-body button-link govuk-!-margin-bottom-0"
+                        formAction={apiUrl}
+                        formMethod="post"
+                        type="submit"
+                        id="generate-return-button"
+                    >
+                        Generate return from singles
+                    </button>
+                )}
+            </form>
+        </div>
+    </div>
+);
+
+export default GenerateSinglePopup;

--- a/repos/fdbt-site/src/interfaces/index.ts
+++ b/repos/fdbt-site/src/interfaces/index.ts
@@ -604,6 +604,7 @@ export interface ProductDetailsElement {
     name: string;
     content: string[];
     editLink?: string;
+    generateLink?: string;
     id?: string;
 }
 

--- a/repos/fdbt-site/src/interfaces/typeGuards.ts
+++ b/repos/fdbt-site/src/interfaces/typeGuards.ts
@@ -42,8 +42,9 @@ export const isPeriodTicket = (ticket: PeriodTicket | PointToPointTicket): ticke
 export const isMultipleServicesTicket = (ticket: Ticket): ticket is PeriodMultipleServicesTicket | FlatFareTicket =>
     (ticket as PeriodMultipleServicesTicket).selectedServices !== undefined;
 
-export const isPointToPointTicket = (ticket: PeriodTicket | PointToPointTicket | WithIds<Ticket>): ticket is PointToPointTicket =>
-    (ticket as PointToPointTicket).lineName !== undefined;
+export const isPointToPointTicket = (
+    ticket: PeriodTicket | PointToPointTicket | WithIds<Ticket>,
+): ticket is PointToPointTicket => (ticket as PointToPointTicket).lineName !== undefined;
 
 export const isGeoZoneTicket = (ticket: PeriodTicket | PointToPointTicket): ticket is GeoZoneTicket =>
     (ticket as GeoZoneTicket).zoneName !== undefined;

--- a/repos/fdbt-site/src/interfaces/typeGuards.ts
+++ b/repos/fdbt-site/src/interfaces/typeGuards.ts
@@ -1,4 +1,4 @@
-import { FlatFareTicket, PeriodMultipleServicesTicket, Ticket } from 'fdbt-types/matchingJsonTypes';
+import { FlatFareTicket, PeriodMultipleServicesTicket, Ticket, WithIds } from 'fdbt-types/matchingJsonTypes';
 import {
     CarnetProductInfo,
     ErrorInfo,
@@ -42,7 +42,7 @@ export const isPeriodTicket = (ticket: PeriodTicket | PointToPointTicket): ticke
 export const isMultipleServicesTicket = (ticket: Ticket): ticket is PeriodMultipleServicesTicket | FlatFareTicket =>
     (ticket as PeriodMultipleServicesTicket).selectedServices !== undefined;
 
-export const isPointToPointTicket = (ticket: PeriodTicket | PointToPointTicket): ticket is PointToPointTicket =>
+export const isPointToPointTicket = (ticket: PeriodTicket | PointToPointTicket | WithIds<Ticket>): ticket is PointToPointTicket =>
     (ticket as PointToPointTicket).lineName !== undefined;
 
 export const isGeoZoneTicket = (ticket: PeriodTicket | PointToPointTicket): ticket is GeoZoneTicket =>

--- a/repos/fdbt-site/src/pages/api/generateReturn.ts
+++ b/repos/fdbt-site/src/pages/api/generateReturn.ts
@@ -1,0 +1,177 @@
+import { ReturnTicket, SingleTicket, WithIds } from 'fdbt-types/matchingJsonTypes';
+import moment from 'moment';
+import { NextApiResponse } from 'next';
+import {
+    getPointToPointProductsByLineId,
+    getProductById,
+    getProductIdByMatchingJsonLink,
+    getServiceByIdAndDataSource,
+} from '../../data/auroradb';
+import { getProductsMatchingJson } from '../../data/s3';
+import { NextApiRequestWithSession } from '../../interfaces';
+import { isPointToPointTicket } from '../../interfaces/typeGuards';
+import { getAndValidateNoc, redirectTo, redirectToError } from '../../utils/apiUtils';
+import { insertDataToProductsBucketAndProductsTable } from '../../utils/apiUtils/userData';
+import { buildUuid } from '../fareType';
+
+const findTicketsToMakeReturn = async (
+    noc: string,
+    lineId: string,
+    passengerTypeId: number,
+    outboundDirection: string,
+    inboundDirection: string,
+    productId: string,
+): Promise<WithIds<SingleTicket>[]> => {
+    const originalProduct = await getProductById(noc, productId);
+    const originalTicket = await getProductsMatchingJson(originalProduct.matchingJsonLink);
+
+    const products = await getPointToPointProductsByLineId(noc, lineId);
+    const matchingJsonLinks = products.map((product) => product.matchingJsonLink);
+    const tickets = await Promise.all(
+        matchingJsonLinks.map(async (link) => {
+            return await getProductsMatchingJson(link);
+        }),
+    );
+
+    const chosenTickets: WithIds<SingleTicket>[] = [];
+
+    tickets.forEach((ticket) => {
+        let chosenOutboundSingleTicket;
+        let chosenInboundSingleTicket;
+
+        if ((originalTicket as WithIds<SingleTicket>).journeyDirection === outboundDirection) {
+            chosenOutboundSingleTicket = originalTicket;
+        } else {
+            chosenInboundSingleTicket = originalTicket;
+        }
+        let expired = false;
+
+        if (ticket.ticketPeriod.endDate) {
+            const today = moment.utc().startOf('day').valueOf();
+            const endDateAsUnixTime = moment.utc(ticket.ticketPeriod.endDate, 'DD/MM/YYYY').valueOf();
+            if (endDateAsUnixTime < today) {
+                expired = true;
+            }
+        }
+
+        if (!expired) {
+            if (isPointToPointTicket(ticket) && ticket.type === 'single') {
+                if ('journeyDirection' in ticket && ticket.passengerType.id === passengerTypeId) {
+                    if (ticket.journeyDirection === outboundDirection && !chosenOutboundSingleTicket) {
+                        chosenOutboundSingleTicket = ticket;
+                        chosenTickets.push(chosenOutboundSingleTicket);
+                    } else if (ticket.journeyDirection === inboundDirection && !chosenInboundSingleTicket) {
+                        chosenInboundSingleTicket = ticket;
+                        chosenTickets.push(chosenInboundSingleTicket);
+                    }
+                }
+            }
+        }
+    });
+
+    if (chosenTickets.length === 2) {
+        return chosenTickets;
+    }
+
+    return [];
+};
+
+export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
+    try {
+        const { lineId, productId, serviceId, passengerTypeId } = req.query;
+
+        if (
+            typeof lineId !== 'string' ||
+            typeof productId !== 'string' ||
+            typeof serviceId !== 'string' ||
+            typeof passengerTypeId !== 'string'
+        ) {
+            throw new Error('Generate return API called with incorrect parameters.');
+        }
+        const noc = getAndValidateNoc(req, res);
+
+        const service = await getServiceByIdAndDataSource(noc, Number(serviceId), 'bods');
+        const directions = Array.from(
+            service.journeyPatterns.reduce((set, pattern) => {
+                set.add(pattern.direction);
+                return set;
+            }, new Set<string>()),
+        );
+
+        const outboundDirection = directions.find((it) => ['outbound', 'clockwise'].includes(it));
+        const inboundDirection = directions.find((it) => ['inbound', 'antiClockwise'].includes(it));
+
+        if (!outboundDirection || !inboundDirection) {
+            redirectTo(
+                res,
+                `/products/productDetails?productId=${productId}&serviceId=${serviceId}&generateReturn=false`,
+            );
+            return;
+        }
+
+        const result = await findTicketsToMakeReturn(
+            noc,
+            lineId,
+            Number(passengerTypeId),
+            outboundDirection,
+            inboundDirection,
+            productId,
+        );
+
+        if (result.length !== 2) {
+            redirectTo(
+                res,
+                `/products/productDetails?productId=${productId}&serviceId=${serviceId}&generateReturn=false`,
+            );
+            return;
+        } else {
+            // create return
+
+            const outboundTicket = result.find(
+                (ticket) => ticket.journeyDirection === outboundDirection,
+            ) as WithIds<SingleTicket>;
+            const inboundTicket = result.find(
+                (ticket) => ticket.journeyDirection === inboundDirection,
+            ) as WithIds<SingleTicket>;
+
+            const uuid = buildUuid(noc);
+            const returnTicket: WithIds<ReturnTicket> = {
+                type: 'return',
+                passengerType: outboundTicket.passengerType,
+                lineName: outboundTicket.lineName,
+                lineId: outboundTicket.lineId,
+                nocCode: outboundTicket.nocCode,
+                operatorName: outboundTicket.operatorName,
+                serviceDescription: outboundTicket.serviceDescription,
+                email: outboundTicket.email,
+                uuid,
+                timeRestriction: outboundTicket.timeRestriction,
+                ticketPeriod: outboundTicket.ticketPeriod,
+                products: outboundTicket.products,
+                inboundFareZones: inboundTicket.fareZones,
+                outboundFareZones: outboundTicket.fareZones,
+                returnPeriodValidity: {
+                    amount: '1',
+                    typeOfDuration: 'day',
+                },
+                unassignedStops: {
+                    inboundUnassignedStops: [],
+                    outboundUnassignedStops: [],
+                },
+            };
+
+            const newJsonLink = await insertDataToProductsBucketAndProductsTable(returnTicket, noc, uuid, '', 'bods', {
+                req,
+                res,
+            });
+
+            const newProductId = await getProductIdByMatchingJsonLink(noc, newJsonLink);
+
+            redirectTo(res, `/products/productDetails?productId=${newProductId}&serviceId=${serviceId}`);
+            return;
+        }
+    } catch (error) {
+        const message = 'There was a problem generating a return.';
+        redirectToError(res, message, 'api.generateReturn.', error);
+    }
+};

--- a/repos/fdbt-site/src/pages/products/productDetails.tsx
+++ b/repos/fdbt-site/src/pages/products/productDetails.tsx
@@ -38,7 +38,6 @@ interface ProductDetailsProps {
     productId: string;
     serviceId?: string;
     lineId?: string;
-    nocCode: string;
     copiedProduct: boolean;
     passengerTypeId: number;
     isSingle: boolean;
@@ -467,7 +466,6 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
             productId,
             serviceId: typeof serviceId === 'string' ? serviceId : '',
             lineId,
-            nocCode: noc,
             copiedProduct,
             passengerTypeId: ticket.passengerType.id,
             isSingle: ticket.type === 'single',

--- a/repos/fdbt-site/tests/components/GenerateReturnPopup.test.tsx
+++ b/repos/fdbt-site/tests/components/GenerateReturnPopup.test.tsx
@@ -1,0 +1,15 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import GenerateReturnPopup from '../../src/components/GenerateReturnPopup';
+
+describe('GenerateReturnPopup', () => {
+    it('should render the GenerateReturnPopup', () => {
+        const cancelActionHandler = jest.fn();
+        const wrapper = shallow(<GenerateReturnPopup cancelActionHandler={cancelActionHandler} />);
+        expect(wrapper).toMatchSnapshot();
+
+        expect(cancelActionHandler).not.toHaveBeenCalled();
+        wrapper.find('button').simulate('click');
+        expect(cancelActionHandler).toHaveBeenCalled();
+    });
+});

--- a/repos/fdbt-site/tests/components/__snapshots__/GenerateReturnPopup.test.tsx.snap
+++ b/repos/fdbt-site/tests/components/__snapshots__/GenerateReturnPopup.test.tsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GenerateReturnPopup should render the GenerateReturnPopup 1`] = `
+<div
+  className="popup"
+>
+  <div
+    className="popup__content"
+  >
+    <h1
+      className="govuk-heading-m"
+    >
+      A return cannot be auto-generated for this product.
+    </h1>
+    <span
+      className="govuk-hint"
+      id="delete-hint"
+    >
+      Two singles must be created, one for inbound and one for outbound. They must have the same passenger type and not be expired. Services with one direction (circular services for example) cannot be used to generate returns.
+    </span>
+    <button
+      className="govuk-button govuk-button--secondary"
+      onClick={[MockFunction]}
+    >
+      Close
+    </button>
+  </div>
+</div>
+`;

--- a/repos/fdbt-site/tests/pages/api/apiUtils/userData.test.ts
+++ b/repos/fdbt-site/tests/pages/api/apiUtils/userData.test.ts
@@ -204,7 +204,7 @@ describe('userData', () => {
                     [FARE_TYPE_ATTRIBUTE]: { fareType: 'single' },
                     [PRODUCT_DATE_ATTRIBUTE]: {
                         startDate: '2020-12-17T09:30:46.0Z',
-                        endDate: '2020-12-18T09:30:46.0Z',
+                        endDate: '2024-12-18T09:30:46.0Z',
                         dateInput: {
                             startDateDay: '17',
                             startDateMonth: '12',

--- a/repos/fdbt-site/tests/pages/api/csvUpload.test.ts
+++ b/repos/fdbt-site/tests/pages/api/csvUpload.test.ts
@@ -1027,7 +1027,7 @@ describe('csvUpload', () => {
             serviceDescription: 'Worthing - Seaham - Crawley',
             termTime: true,
             ticketPeriod: {
-                endDate: '2020-12-18T09:30:46.0Z',
+                endDate: '2024-12-18T09:30:46.0Z',
                 startDate: '2020-12-17T09:30:46.0Z',
             },
             timeRestriction: {

--- a/repos/fdbt-site/tests/pages/api/generateReturn.test.ts
+++ b/repos/fdbt-site/tests/pages/api/generateReturn.test.ts
@@ -1,0 +1,390 @@
+import {
+    expectedCarnetReturnTicket,
+    expectedFlatFareTicket,
+    expectedSingleTicket,
+    getMockRequestAndResponse,
+    mockRawService,
+} from '../../testData/mockData';
+import generateReturn, { findTicketsToMakeReturn } from '../../../src/pages/api/generateReturn';
+import * as userData from '../../../src/utils/apiUtils/userData';
+import * as index from '../../../src/utils/apiUtils/index';
+import {
+    getProductById,
+    getProductIdByMatchingJsonLink,
+    getServiceByIdAndDataSource,
+} from '../../../src/data/auroradb';
+import { getProductsMatchingJson } from '../../../src/data/s3';
+
+const expectedGeneratedReturn = {
+    type: 'return',
+    passengerType: { id: 9 },
+    lineName: '215',
+    lineId: 'q2gv2ve',
+    nocCode: 'DCCL',
+    operatorName: 'DCC',
+    serviceDescription: 'Worthing - Seaham - Crawley',
+    email: 'test@example.com',
+    uuid: expect.any(String),
+    timeRestriction: { id: 2 },
+    ticketPeriod: { startDate: '2020-12-17T09:30:46.0Z', endDate: '2024-12-18T09:30:46.0Z' },
+    products: [{ salesOfferPackages: [{ id: 1 }, { id: 2 }] }],
+    inboundFareZones: [
+        {
+            name: 'Acomb Green Lane',
+            stops: [
+                {
+                    stopName: 'Yoden Way - Chapel Hill Road',
+                    naptanCode: 'duratdmj',
+                    atcoCode: '13003521G',
+                    localityCode: 'E0045956',
+                    localityName: 'Peterlee',
+                    parentLocalityName: '',
+                    indicator: 'W-bound',
+                    street: 'Yodan Way',
+                    qualifierName: '',
+                },
+            ],
+            prices: [
+                { price: '1.10', fareZones: ['Mattison Way', 'Nursery Drive', 'Holl Bank/Beech Ave'] },
+                {
+                    price: '1.70',
+                    fareZones: [
+                        'Cambridge Street (York)',
+                        'Blossom Street',
+                        'Rail Station (York)',
+                        'Piccadilly (York)',
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'Mattison Way',
+            stops: [
+                {
+                    stopName: 'Yoden Way',
+                    naptanCode: 'duratdmt',
+                    atcoCode: '13003522F',
+                    localityCode: 'E0010183',
+                    localityName: 'Horden',
+                    parentLocalityName: '',
+                    indicator: 'SW-bound',
+                    street: 'Yoden Way',
+                    qualifierName: '',
+                },
+            ],
+            prices: [
+                { price: '1.10', fareZones: ['Nursery Drive', 'Holl Bank/Beech Ave'] },
+                {
+                    price: '1.70',
+                    fareZones: [
+                        'Cambridge Street (York)',
+                        'Blossom Street',
+                        'Rail Station (York)',
+                        'Piccadilly (York)',
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'Holl Bank/Beech Ave',
+            stops: [
+                {
+                    stopName: 'Surtees Rd-Edenhill Rd',
+                    naptanCode: 'durapgdw',
+                    atcoCode: '13003219H',
+                    localityCode: 'E0045956',
+                    localityName: 'Peterlee',
+                    parentLocalityName: '',
+                    indicator: 'NW-bound',
+                    street: 'Surtees Road',
+                    qualifierName: '',
+                },
+            ],
+            prices: [
+                { price: '1.10', fareZones: ['Cambridge Street (York)', 'Blossom Street'] },
+                { price: '1.70', fareZones: ['Rail Station (York)', 'Piccadilly (York)'] },
+            ],
+        },
+        {
+            name: 'Blossom Street',
+            stops: [
+                {
+                    stopName: 'Bus Station',
+                    naptanCode: 'duratdma',
+                    atcoCode: '13003519H',
+                    localityCode: 'E0045956',
+                    localityName: 'Peterlee',
+                    parentLocalityName: '',
+                    indicator: 'H',
+                    street: 'Bede Way',
+                    qualifierName: '',
+                },
+            ],
+            prices: [{ price: '1.00', fareZones: ['Rail Station (York)', 'Piccadilly (York)'] }],
+        },
+        {
+            name: 'Piccadilly (York)',
+            stops: [
+                {
+                    stopName: 'Kell Road',
+                    naptanCode: 'duraptwp',
+                    atcoCode: '13003345D',
+                    localityCode: 'E0010183',
+                    localityName: 'Horden',
+                    parentLocalityName: '',
+                    indicator: 'SE-bound',
+                    street: 'Kell Road',
+                    qualifierName: '',
+                },
+            ],
+            prices: [],
+        },
+    ],
+    outboundFareZones: [
+        {
+            name: 'Acomb Green Lane',
+            stops: [
+                {
+                    stopName: 'Yoden Way - Chapel Hill Road',
+                    naptanCode: 'duratdmj',
+                    atcoCode: '13003521G',
+                    localityCode: 'E0045956',
+                    localityName: 'Peterlee',
+                    parentLocalityName: '',
+                    indicator: 'W-bound',
+                    street: 'Yodan Way',
+                    qualifierName: '',
+                },
+            ],
+            prices: [
+                { price: '1.10', fareZones: ['Mattison Way', 'Nursery Drive', 'Holl Bank/Beech Ave'] },
+                {
+                    price: '1.70',
+                    fareZones: [
+                        'Cambridge Street (York)',
+                        'Blossom Street',
+                        'Rail Station (York)',
+                        'Piccadilly (York)',
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'Mattison Way',
+            stops: [
+                {
+                    stopName: 'Yoden Way',
+                    naptanCode: 'duratdmt',
+                    atcoCode: '13003522F',
+                    localityCode: 'E0010183',
+                    localityName: 'Horden',
+                    parentLocalityName: '',
+                    indicator: 'SW-bound',
+                    street: 'Yoden Way',
+                    qualifierName: '',
+                },
+            ],
+            prices: [
+                { price: '1.10', fareZones: ['Nursery Drive', 'Holl Bank/Beech Ave'] },
+                {
+                    price: '1.70',
+                    fareZones: [
+                        'Cambridge Street (York)',
+                        'Blossom Street',
+                        'Rail Station (York)',
+                        'Piccadilly (York)',
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'Holl Bank/Beech Ave',
+            stops: [
+                {
+                    stopName: 'Surtees Rd-Edenhill Rd',
+                    naptanCode: 'durapgdw',
+                    atcoCode: '13003219H',
+                    localityCode: 'E0045956',
+                    localityName: 'Peterlee',
+                    parentLocalityName: '',
+                    indicator: 'NW-bound',
+                    street: 'Surtees Road',
+                    qualifierName: '',
+                },
+            ],
+            prices: [
+                { price: '1.10', fareZones: ['Cambridge Street (York)', 'Blossom Street'] },
+                { price: '1.70', fareZones: ['Rail Station (York)', 'Piccadilly (York)'] },
+            ],
+        },
+        {
+            name: 'Blossom Street',
+            stops: [
+                {
+                    stopName: 'Bus Station',
+                    naptanCode: 'duratdma',
+                    atcoCode: '13003519H',
+                    localityCode: 'E0045956',
+                    localityName: 'Peterlee',
+                    parentLocalityName: '',
+                    indicator: 'H',
+                    street: 'Bede Way',
+                    qualifierName: '',
+                },
+            ],
+            prices: [{ price: '1.00', fareZones: ['Rail Station (York)', 'Piccadilly (York)'] }],
+        },
+        {
+            name: 'Piccadilly (York)',
+            stops: [
+                {
+                    stopName: 'Kell Road',
+                    naptanCode: 'duraptwp',
+                    atcoCode: '13003345D',
+                    localityCode: 'E0010183',
+                    localityName: 'Horden',
+                    parentLocalityName: '',
+                    indicator: 'SE-bound',
+                    street: 'Kell Road',
+                    qualifierName: '',
+                },
+            ],
+            prices: [],
+        },
+    ],
+    returnPeriodValidity: { amount: '1', typeOfDuration: 'day' },
+    unassignedStops: { inboundUnassignedStops: [], outboundUnassignedStops: [] },
+};
+
+jest.mock('../../../src/data/auroradb');
+jest.mock('../../../src/data/s3');
+
+describe('generateReturn', () => {
+    const noc = 'mynoc';
+    const writeHeadMock = jest.fn();
+    jest.spyOn(index, 'getAndValidateNoc').mockReturnValue(noc);
+    (getProductIdByMatchingJsonLink as jest.Mock).mockResolvedValue('2');
+    (getProductById as jest.Mock).mockResolvedValueOnce('path');
+    (getProductsMatchingJson as jest.Mock).mockResolvedValueOnce(expectedCarnetReturnTicket);
+    const insertDataToProductsBucketAndProductsTableSpy = jest.spyOn(
+        userData,
+        'insertDataToProductsBucketAndProductsTable',
+    );
+
+    insertDataToProductsBucketAndProductsTableSpy.mockImplementationOnce(() => Promise.resolve('pathOne'));
+    const collectInfoForMatchingTicketsSpy = jest.spyOn(userData, 'collectInfoForMatchingTickets');
+    collectInfoForMatchingTicketsSpy.mockImplementationOnce(() =>
+        Promise.resolve({
+            directionToFind: 'outbound',
+            tickets: [
+                {
+                    ...expectedSingleTicket,
+                    journeyDirection: 'outbound',
+                },
+            ],
+            originalTicket: expectedSingleTicket,
+        }),
+    );
+    const redirectToErrorSpy = jest.spyOn(index, 'redirectToError');
+
+    it('should error if a query param is missing', async () => {
+        const { req, res } = getMockRequestAndResponse({
+            cookieValues: {},
+            query: { lineId: '2', productId: '1', serviceId: '3' },
+            mockWriteHeadFn: writeHeadMock,
+        });
+
+        await generateReturn(req, res);
+
+        expect(redirectToErrorSpy).toBeCalledWith(
+            res,
+            'There was a problem generating a return.',
+            'api.generateReturn',
+            new Error('Generate return API called with incorrect parameters.'),
+        );
+    });
+
+    it('should redirect back with generateReturn=false query param if service only has 1 direction', async () => {
+        const mockServiceWithOneDirection = {
+            ...mockRawService,
+            journeyPatterns: [mockRawService.journeyPatterns[0]],
+        };
+        (getServiceByIdAndDataSource as jest.Mock).mockResolvedValueOnce(mockServiceWithOneDirection);
+        const { req, res } = getMockRequestAndResponse({
+            cookieValues: {},
+            query: { lineId: '2', productId: '1', serviceId: '3', passengerTypeId: '4' },
+            mockWriteHeadFn: writeHeadMock,
+        });
+
+        await generateReturn(req, res);
+
+        expect(res.writeHead).toBeCalledWith(302, {
+            Location: '/products/productDetails?productId=1&serviceId=3&generateReturn=false',
+        });
+    });
+
+    it('should create a return if there are two singles which are compatible', async () => {
+        (getServiceByIdAndDataSource as jest.Mock).mockResolvedValueOnce(mockRawService);
+        const { req, res } = getMockRequestAndResponse({
+            cookieValues: {},
+            query: { lineId: '2', productId: '1', serviceId: '3', passengerTypeId: '9' },
+            mockWriteHeadFn: writeHeadMock,
+        });
+
+        await generateReturn(req, res);
+
+        expect(insertDataToProductsBucketAndProductsTableSpy).toBeCalledWith(
+            expectedGeneratedReturn,
+            noc,
+            expect.any(String),
+            '',
+            'bods',
+            {
+                req,
+                res,
+            },
+        );
+
+        expect(res.writeHead).toBeCalledWith(302, {
+            Location: '/products/productDetails?productId=2&serviceId=3',
+        });
+    });
+});
+
+describe('findTicketsToMakeReturn', () => {
+    const singleTicket = expectedSingleTicket;
+    it('returns an empty array if the ticket compared is expired', () => {
+        const ticket = {
+            ...singleTicket,
+            ticketPeriod: {
+                startDate: '2020-12-17T09:30:46.0Z',
+                endDate: '2020-12-18T09:30:46.0Z',
+            },
+        };
+        const result = findTicketsToMakeReturn(2, 'outbound', [ticket], singleTicket);
+        expect(result).toEqual([]);
+    });
+
+    it('returns an empty array if the ticket compared is not a single', () => {
+        const result = findTicketsToMakeReturn(2, 'outbound', [expectedFlatFareTicket], singleTicket);
+        expect(result).toEqual([]);
+    });
+
+    it('returns an empty array if the ticket compared does not share the same passenger type', () => {
+        const ticket = {
+            ...singleTicket,
+            passengerType: { id: 8 },
+        };
+        const result = findTicketsToMakeReturn(2, 'outbound', [ticket], singleTicket);
+        expect(result).toEqual([]);
+    });
+
+    it('returns an empty array if the ticket compared does not have the direction that is being sought', () => {
+        const ticket = {
+            ...singleTicket,
+            journeyDirection: 'inbound',
+        };
+        const result = findTicketsToMakeReturn(2, 'outbound', [ticket], singleTicket);
+        expect(result).toEqual([]);
+    });
+});

--- a/repos/fdbt-site/tests/pages/products/__snapshots__/productDetails.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/products/__snapshots__/productDetails.test.tsx.snap
@@ -538,3 +538,271 @@ exports[`myfares pages productDetails should render correctly for a copied produ
   </dl>
 </TwoThirdsLayout>
 `;
+
+exports[`myfares pages productDetails should render correctly while the cannot generate return popup is open 1`] = `
+<TwoThirdsLayout
+  description="Product Details page of the Create Fares Data Service"
+  errors={Array []}
+  title="Product Details - Create Fares Data Service"
+>
+  <BackButton
+    href="/products/pointToPointProducts?serviceId=1"
+  />
+  <div
+    className="dft-flex"
+  >
+    <h1
+      className="govuk-heading-l"
+      id="product-name"
+    >
+      Carnet Return Test
+    </h1>
+    <button
+      className="govuk-link govuk-body align-top button-link govuk-!-margin-left-2"
+      onClick={[Function]}
+    >
+      Edit
+    </button>
+  </div>
+  <div
+    className="govuk-hint"
+    id="product-status"
+  >
+    Product status: 
+    <strong
+      className="govuk-tag govuk-tag--turquoise"
+    >
+      Active
+    </strong>
+    <strong
+      className="govuk-tag govuk-tag--yellow govuk-!-margin-left-2"
+    >
+      NEEDS ATTENTION
+    </strong>
+  </div>
+  <dl
+    className="govuk-summary-list"
+    key="Service"
+  >
+    <div
+      className="govuk-summary-list__row"
+      key="Service"
+    >
+      <dt
+        className="govuk-summary-list__key"
+      >
+        Service
+      </dt>
+      <dd
+        className="govuk-summary-list__value"
+      >
+        <span
+          key="19 - STAINING - BLACKPOOL via Victoria Hospital (Main Entrance)"
+        >
+          19 - STAINING - BLACKPOOL via Victoria Hospital (Main Entrance)
+        </span>
+      </dd>
+    </div>
+  </dl>
+  <dl
+    className="govuk-summary-list"
+    key="Passenger type"
+  >
+    <div
+      className="govuk-summary-list__row"
+      key="Passenger type"
+    >
+      <dt
+        className="govuk-summary-list__key"
+      >
+        Passenger type
+      </dt>
+      <dd
+        className="govuk-summary-list__value"
+      >
+        <div
+          className="dft-flex dft-flex-justify-space-between"
+        >
+          <span
+            key="Adult Test"
+          >
+            Adult Test
+          </span>
+          <a
+            href="/selectPassengerType"
+          >
+            Edit
+          </a>
+        </div>
+      </dd>
+    </div>
+  </dl>
+  <dl
+    className="govuk-summary-list"
+    key="Time restriction"
+  >
+    <div
+      className="govuk-summary-list__row"
+      key="Time restriction"
+    >
+      <dt
+        className="govuk-summary-list__key"
+      >
+        Time restriction
+      </dt>
+      <dd
+        className="govuk-summary-list__value"
+      >
+        <span
+          key="N/A"
+        >
+          N/A
+        </span>
+      </dd>
+    </div>
+  </dl>
+  <dl
+    className="govuk-summary-list"
+    key="Quantity in bundle"
+  >
+    <div
+      className="govuk-summary-list__row"
+      key="Quantity in bundle"
+    >
+      <dt
+        className="govuk-summary-list__key"
+      >
+        Quantity in bundle
+      </dt>
+      <dd
+        className="govuk-summary-list__value"
+      >
+        <span
+          key="2"
+        >
+          2
+        </span>
+      </dd>
+    </div>
+  </dl>
+  <dl
+    className="govuk-summary-list"
+    key="Carnet expiry"
+  >
+    <div
+      className="govuk-summary-list__row"
+      key="Carnet expiry"
+    >
+      <dt
+        className="govuk-summary-list__key"
+      >
+        Carnet expiry
+      </dt>
+      <dd
+        className="govuk-summary-list__value"
+      >
+        <span
+          key="22 year(s)"
+        >
+          22 year(s)
+        </span>
+      </dd>
+    </div>
+  </dl>
+  <dl
+    className="govuk-summary-list"
+    key="Purchase methods"
+  >
+    <div
+      className="govuk-summary-list__row"
+      key="Purchase methods"
+    >
+      <dt
+        className="govuk-summary-list__key"
+      >
+        Purchase methods
+      </dt>
+      <dd
+        className="govuk-summary-list__value"
+      >
+        <span
+          key="SOP Test 1"
+        >
+          SOP Test 1
+        </span>
+        <span
+          key="SOP Test 2"
+        >
+          SOP Test 2
+        </span>
+      </dd>
+    </div>
+  </dl>
+  <dl
+    className="govuk-summary-list"
+    key="Start date"
+  >
+    <div
+      className="govuk-summary-list__row"
+      key="Start date"
+    >
+      <dt
+        className="govuk-summary-list__key"
+      >
+        Start date
+      </dt>
+      <dd
+        className="govuk-summary-list__value"
+      >
+        <div
+          className="dft-flex dft-flex-justify-space-between"
+        >
+          <span
+            key="18/10/2021"
+          >
+            18/10/2021
+          </span>
+          <a
+            href="/productDateInformation"
+          >
+            Edit
+          </a>
+        </div>
+      </dd>
+    </div>
+  </dl>
+  <dl
+    className="govuk-summary-list"
+    key="End date"
+  >
+    <div
+      className="govuk-summary-list__row"
+      key="End date"
+    >
+      <dt
+        className="govuk-summary-list__key"
+      >
+        End date
+      </dt>
+      <dd
+        className="govuk-summary-list__value"
+      >
+        <div
+          className="dft-flex dft-flex-justify-space-between"
+        >
+          <span
+            key="18/10/2121"
+          >
+            18/10/2121
+          </span>
+          <a
+            href="/productDateInformation"
+          >
+            Edit
+          </a>
+        </div>
+      </dd>
+    </div>
+  </dl>
+</TwoThirdsLayout>
+`;

--- a/repos/fdbt-site/tests/pages/products/productDetails.test.tsx
+++ b/repos/fdbt-site/tests/pages/products/productDetails.test.tsx
@@ -7,6 +7,7 @@ import {
     getProductById,
     getSalesOfferPackageByIdAndNoc,
     getTimeRestrictionByIdAndNoc,
+    getServiceByIdAndDataSource,
 } from '../../../src/data/auroradb';
 import { getProductsMatchingJson } from '../../../src/data/s3';
 import ProductDetails, { getServerSideProps } from '../../../src/pages/products/productDetails';
@@ -19,6 +20,7 @@ import {
     expectedSchemeOperatorTicketAfterGeoZoneAdjustment,
     expectedSingleTicket,
     getMockContext,
+    mockRawService,
 } from '../../testData/mockData';
 
 jest.mock('../../../src/data/auroradb');
@@ -49,6 +51,9 @@ describe('myfares pages', () => {
                     ]}
                     productId="2"
                     copiedProduct={false}
+                    isSingle={false}
+                    cannotGenerateReturn={false}
+                    passengerTypeId={2}
                     csrfToken=""
                 />,
             );
@@ -79,6 +84,41 @@ describe('myfares pages', () => {
                     ]}
                     productId="2"
                     copiedProduct
+                    isSingle={false}
+                    cannotGenerateReturn={false}
+                    passengerTypeId={2}
+                    csrfToken=""
+                />,
+            );
+
+            expect(tree).toMatchSnapshot();
+        });
+        it('should render correctly while the cannot generate return popup is open', () => {
+            const tree = shallow(
+                <ProductDetails
+                    requiresAttention={true}
+                    backHref={'/products/pointToPointProducts?serviceId=1'}
+                    productName={'Carnet Return Test'}
+                    startDate={'18/10/2021'}
+                    endDate={'18/10/2121'}
+                    productDetailsElements={[
+                        {
+                            name: 'Service',
+                            content: ['19 - STAINING - BLACKPOOL via Victoria Hospital (Main Entrance)'],
+                        },
+                        { name: 'Passenger type', content: ['Adult Test'], editLink: '/selectPassengerType' },
+                        { name: 'Time restriction', content: ['N/A'] },
+                        { name: 'Quantity in bundle', content: ['2'] },
+                        { name: 'Carnet expiry', content: ['22 year(s)'] },
+                        { name: 'Purchase methods', content: ['SOP Test 1', 'SOP Test 2'] },
+                        { name: 'Start date', content: ['18/10/2021'], editLink: '/productDateInformation' },
+                        { name: 'End date', content: ['18/10/2121'], editLink: '/productDateInformation' },
+                    ]}
+                    productId="2"
+                    copiedProduct={false}
+                    isSingle
+                    cannotGenerateReturn
+                    passengerTypeId={2}
                     csrfToken=""
                 />,
             );
@@ -115,6 +155,8 @@ describe('myfares pages', () => {
                 inboundDirectionDescription: 'this way',
                 outboundDirectionDescription: 'another way',
             });
+
+            (getServiceByIdAndDataSource as jest.Mock).mockResolvedValue(mockRawService);
         });
 
         it('correctly returns the elements which should be displayed on the page for a school single ticket', async () => {
@@ -126,7 +168,7 @@ describe('myfares pages', () => {
                     backHref: `/products/pointToPointProducts?serviceId=2`,
                     productName: 'Test Passenger Type - Single (school)',
                     startDate: '17/12/2020',
-                    endDate: '18/12/2020',
+                    endDate: '18/12/2024',
                     productDetailsElements: [
                         { name: 'Fare type', id: 'fare-type', content: ['Single'] },
                         { name: 'Service', content: ['Test Line Name - Test Origin to Test Destination'] },
@@ -136,11 +178,15 @@ describe('myfares pages', () => {
                         { name: 'Fare triangle', content: ['You created a fare triangle'], editLink: '/csvUpload' },
                         { name: 'Purchase methods', content: ['SOP 1', 'SOP 2'] },
                         { name: 'Start date', content: ['17/12/2020'], editLink: '/productDateInformation' },
-                        { name: 'End date', content: ['18/12/2020'], editLink: '/productDateInformation' },
+                        { name: 'End date', content: ['18/12/2024'], editLink: '/productDateInformation' },
                     ],
                     productId: '1',
                     serviceId: '2',
                     copiedProduct: false,
+                    cannotGenerateReturn: false,
+                    isSingle: true,
+                    lineId: 'q2gv2ve',
+                    passengerTypeId: 9,
                     csrfToken: '',
                 },
             });
@@ -171,6 +217,10 @@ describe('myfares pages', () => {
                     productId: '1',
                     serviceId: '2',
                     copiedProduct: false,
+                    cannotGenerateReturn: false,
+                    isSingle: false,
+                    passengerTypeId: 9,
+                    lineId: 'q2gv2ve',
                     csrfToken: '',
                 },
             });
@@ -206,6 +256,10 @@ describe('myfares pages', () => {
                     productId: '1',
                     serviceId: '',
                     copiedProduct: false,
+                    cannotGenerateReturn: false,
+                    isSingle: false,
+                    lineId: '',
+                    passengerTypeId: 9,
                     csrfToken: '',
                 },
             });
@@ -237,6 +291,10 @@ describe('myfares pages', () => {
                     productId: '1',
                     serviceId: '',
                     copiedProduct: false,
+                    cannotGenerateReturn: false,
+                    isSingle: false,
+                    lineId: '',
+                    passengerTypeId: 9,
                     csrfToken: '',
                 },
             });
@@ -269,6 +327,10 @@ describe('myfares pages', () => {
                     productId: '1',
                     serviceId: '',
                     copiedProduct: false,
+                    cannotGenerateReturn: false,
+                    isSingle: false,
+                    lineId: '',
+                    passengerTypeId: 9,
                     csrfToken: '',
                 },
             });
@@ -299,6 +361,10 @@ describe('myfares pages', () => {
                     productId: '1',
                     serviceId: '',
                     copiedProduct: false,
+                    cannotGenerateReturn: false,
+                    isSingle: false,
+                    lineId: '',
+                    passengerTypeId: 9,
                     csrfToken: '',
                 },
             });
@@ -330,6 +396,10 @@ describe('myfares pages', () => {
                     productId: '1',
                     serviceId: '',
                     copiedProduct: true,
+                    cannotGenerateReturn: false,
+                    isSingle: false,
+                    lineId: '',
+                    passengerTypeId: 9,
                     csrfToken: '',
                 },
             });

--- a/repos/fdbt-site/tests/testData/mockData.ts
+++ b/repos/fdbt-site/tests/testData/mockData.ts
@@ -1208,7 +1208,7 @@ export const expectedSingleTicket: WithIds<SingleTicket> = {
     timeRestriction: { id: 2 },
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
-        endDate: '2020-12-18T09:30:46.0Z',
+        endDate: '2024-12-18T09:30:46.0Z',
     },
     products: [
         {


### PR DESCRIPTION
## Description

Gives the user the ability to automatically create a return from two eligible singles for the same service, as long as they meet certain criteria.

## Testing instructions

Create two singles which use the same service, same passenger type (id), and have both outbound and inbound directions, and ensure they are not expired. Then find one of them, and click the generate button.
