### PR TITLE
fix/CFDS-47: Fixed the direction for the inbound matching

### DIFF
--- a/repos/fdbt-site/src/pages/inboundMatching.tsx
+++ b/repos/fdbt-site/src/pages/inboundMatching.tsx
@@ -54,7 +54,7 @@ const InboundMatching = ({
 export const getServerSideProps = async (ctx: NextPageContextWithSession): Promise<{ props: InboundMatchingProps }> => {
     const matchingAttribute = getSessionAttribute(ctx.req, INBOUND_MATCHING_ATTRIBUTE);
     const unusedStage = !!ctx.query.unusedStage;
-    return { props: { ...(await getMatchingProps(ctx, matchingAttribute)).props, unusedStage } };
+    return { props: { ...(await getMatchingProps(ctx, matchingAttribute, true)).props, unusedStage } };
 };
 
 export default InboundMatching;

--- a/repos/fdbt-site/src/utils/apiUtils/matching.ts
+++ b/repos/fdbt-site/src/utils/apiUtils/matching.ts
@@ -167,6 +167,7 @@ export const removeDuplicateAdjacentStops = (stops: string[]): string[] => {
 export const getMatchingProps = async (
     ctx: NextPageContextWithSession,
     matchingAttribute: MatchingWithErrors | object | undefined,
+    isInbound?: boolean,
 ): Promise<{ props: MatchingProps }> => {
     const serviceAttribute = getSessionAttribute(ctx.req, SERVICE_ATTRIBUTE);
     const directionAttribute = getRequiredSessionAttribute(ctx.req, DIRECTION_ATTRIBUTE);
@@ -184,8 +185,9 @@ export const getMatchingProps = async (
     const service = await getServiceByIdAndDataSource(nocCode, serviceAttribute.id, dataSource);
     const userFareStages = await getUserFareStages(operatorAttribute.uuid);
 
+    const direction = isInbound ? directionAttribute.inboundDirection : directionAttribute.direction;
     // find journey patterns for direction (inbound or outbound)
-    const journeyPatterns = service.journeyPatterns.filter((it) => it.direction === directionAttribute.direction);
+    const journeyPatterns = service.journeyPatterns.filter((it) => it.direction === direction);
 
     // get an unordered list of stop points from journey patterns, then removing any duplicates on stopPointRef and sequence number
     const stops = journeyPatterns


### PR DESCRIPTION
## Description

Fixed the direction in the inbound matching

## Testing instructions

Create a return ticket and select the service (which has both inbound and outbound). The inbound page should be showing the stops for inbound direction only.
