### PR TITLE
Story CFDS-37 - PreassignedFareProduct Name

### DIFF
--- a/fdbt-dev/data/netexData/carnetFlatFare.xml
+++ b/fdbt-dev/data/netexData/carnetFlatFare.xml
@@ -212,7 +212,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Weekly_Rider_senior">
-              <Name>Weekly Rider Pass - senior</Name>
+              <Name>Weekly Rider</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@trip@single"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/carnetPeriodGeoZone.xml
+++ b/fdbt-dev/data/netexData/carnetPeriodGeoZone.xml
@@ -548,7 +548,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_adult">
-              <Name>Product 1 Pass - adult</Name>
+              <Name>Product 1</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -571,7 +571,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_adult">
-              <Name>Product 2 Pass - adult</Name>
+              <Name>Product 2</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -594,7 +594,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_adult">
-              <Name>Product 3 Pass - adult</Name>
+              <Name>Product 3</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -617,7 +617,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_adult">
-              <Name>Product 4 Pass - adult</Name>
+              <Name>Product 4</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -640,7 +640,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_adult">
-              <Name>Product 5 Pass - adult</Name>
+              <Name>Product 5</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/carnetPeriodGeoZone.xml
+++ b/fdbt-dev/data/netexData/carnetPeriodGeoZone.xml
@@ -548,7 +548,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_adult">
-              <Name>Product 1 - adult</Name>
+              <Name>Product 1 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -571,7 +571,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_adult">
-              <Name>Product 2 - adult</Name>
+              <Name>Product 2 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -594,7 +594,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_adult">
-              <Name>Product 3 - adult</Name>
+              <Name>Product 3 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -617,7 +617,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_adult">
-              <Name>Product 4 - adult</Name>
+              <Name>Product 4 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -640,7 +640,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_adult">
-              <Name>Product 5 - adult</Name>
+              <Name>Product 5 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/carnetPeriodGeoZone.xml
+++ b/fdbt-dev/data/netexData/carnetPeriodGeoZone.xml
@@ -548,7 +548,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_adult">
-              <Name>Product 1</Name>
+              <Name>Product 1 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -571,7 +571,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_adult">
-              <Name>Product 2</Name>
+              <Name>Product 2 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -594,7 +594,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_adult">
-              <Name>Product 3</Name>
+              <Name>Product 3 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -617,7 +617,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_adult">
-              <Name>Product 4</Name>
+              <Name>Product 4 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -640,7 +640,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_adult">
-              <Name>Product 5</Name>
+              <Name>Product 5 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/carnetPeriodGeoZone.xml
+++ b/fdbt-dev/data/netexData/carnetPeriodGeoZone.xml
@@ -548,7 +548,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_adult">
-              <Name>Product 1 Pass - adult</Name>
+              <Name>Product 1 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -571,7 +571,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_adult">
-              <Name>Product 2 Pass - adult</Name>
+              <Name>Product 2 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -594,7 +594,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_adult">
-              <Name>Product 3 Pass - adult</Name>
+              <Name>Product 3 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -617,7 +617,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_adult">
-              <Name>Product 4 Pass - adult</Name>
+              <Name>Product 4 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -640,7 +640,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_adult">
-              <Name>Product 5 Pass - adult</Name>
+              <Name>Product 5 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/carnetPeriodMultiService.xml
+++ b/fdbt-dev/data/netexData/carnetPeriodMultiService.xml
@@ -418,7 +418,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_1_youngPerson">
-              <Name>Test Product 1 - youngPerson</Name>
+              <Name>Test Product 1 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -441,7 +441,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_2_youngPerson">
-              <Name>Test Product 2 - youngPerson</Name>
+              <Name>Test Product 2 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -464,7 +464,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_3_youngPerson">
-              <Name>Test Product 3 - youngPerson</Name>
+              <Name>Test Product 3 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/carnetPeriodMultiService.xml
+++ b/fdbt-dev/data/netexData/carnetPeriodMultiService.xml
@@ -418,7 +418,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_1_youngPerson">
-              <Name>Test Product 1 Pass - youngPerson</Name>
+              <Name>Test Product 1</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -441,7 +441,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_2_youngPerson">
-              <Name>Test Product 2 Pass - youngPerson</Name>
+              <Name>Test Product 2</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -464,7 +464,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_3_youngPerson">
-              <Name>Test Product 3 Pass - youngPerson</Name>
+              <Name>Test Product 3</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/carnetPeriodMultiService.xml
+++ b/fdbt-dev/data/netexData/carnetPeriodMultiService.xml
@@ -418,7 +418,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_1_youngPerson">
-              <Name>Test Product 1</Name>
+              <Name>Test Product 1 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -441,7 +441,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_2_youngPerson">
-              <Name>Test Product 2</Name>
+              <Name>Test Product 2 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -464,7 +464,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_3_youngPerson">
-              <Name>Test Product 3</Name>
+              <Name>Test Product 3 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/carnetPeriodMultiService.xml
+++ b/fdbt-dev/data/netexData/carnetPeriodMultiService.xml
@@ -418,7 +418,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_1_youngPerson">
-              <Name>Test Product 1 Pass - youngPerson</Name>
+              <Name>Test Product 1 - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -441,7 +441,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_2_youngPerson">
-              <Name>Test Product 2 Pass - youngPerson</Name>
+              <Name>Test Product 2 - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -464,7 +464,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_3_youngPerson">
-              <Name>Test Product 3 Pass - youngPerson</Name>
+              <Name>Test Product 3 - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/flatFare.xml
+++ b/fdbt-dev/data/netexData/flatFare.xml
@@ -202,7 +202,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Weekly_Rider_senior">
-              <Name>Weekly Rider Pass - senior</Name>
+              <Name>Weekly Rider</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@trip@single"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/flatFareGeoZone.xml
+++ b/fdbt-dev/data/netexData/flatFareGeoZone.xml
@@ -293,7 +293,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@JTest00_adult">
-              <Name>JTest00 Pass - adult</Name>
+              <Name>JTest00</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@trip@single"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/flatFareGroup.xml
+++ b/fdbt-dev/data/netexData/flatFareGroup.xml
@@ -315,7 +315,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Weekly_Rider_group">
-              <Name>Weekly Rider Pass - group</Name>
+              <Name>Weekly Rider</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@trip@single"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/flatFareWithSopPrices.xml
+++ b/fdbt-dev/data/netexData/flatFareWithSopPrices.xml
@@ -189,7 +189,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@test_anyone">
-              <Name>test Pass - anyone</Name>
+              <Name>test</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@trip@single"/>
               <OperatorRef version="1.0" ref="noc:WBTR">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/hybridPeriod.xml
+++ b/fdbt-dev/data/netexData/hybridPeriod.xml
@@ -324,7 +324,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Best_product_one_anyone">
-              <Name>Best product one Pass - anyone</Name>
+              <Name>Best product one - anyone</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:WBTR">noc:135742</OperatorRef>
@@ -347,7 +347,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Another_great_product_anyone">
-              <Name>Another great product Pass - anyone</Name>
+              <Name>Another great product - anyone</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:WBTR">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/hybridPeriod.xml
+++ b/fdbt-dev/data/netexData/hybridPeriod.xml
@@ -324,7 +324,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Best_product_one_anyone">
-              <Name>Best product one</Name>
+              <Name>Best product one Pass - anyone</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:WBTR">noc:135742</OperatorRef>
@@ -347,7 +347,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Another_great_product_anyone">
-              <Name>Another great product</Name>
+              <Name>Another great product Pass - anyone</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:WBTR">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/hybridPeriod.xml
+++ b/fdbt-dev/data/netexData/hybridPeriod.xml
@@ -324,7 +324,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Best_product_one_anyone">
-              <Name>Best product one Pass - anyone</Name>
+              <Name>Best product one</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:WBTR">noc:135742</OperatorRef>
@@ -347,7 +347,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Another_great_product_anyone">
-              <Name>Another great product Pass - anyone</Name>
+              <Name>Another great product</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:WBTR">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/hybridPeriod.xml
+++ b/fdbt-dev/data/netexData/hybridPeriod.xml
@@ -324,7 +324,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Best_product_one_anyone">
-              <Name>Best product one - anyone</Name>
+              <Name>Best product one Pass - anyone</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:WBTR">noc:135742</OperatorRef>
@@ -347,7 +347,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Another_great_product_anyone">
-              <Name>Another great product - anyone</Name>
+              <Name>Another great product Pass - anyone</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:WBTR">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/multiOpGeoZone.xml
+++ b/fdbt-dev/data/netexData/multiOpGeoZone.xml
@@ -549,7 +549,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_adult">
-              <Name>Product 1 - adult</Name>
+              <Name>Product 1 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -572,7 +572,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_adult">
-              <Name>Product 2 - adult</Name>
+              <Name>Product 2 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -595,7 +595,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_adult">
-              <Name>Product 3 - adult</Name>
+              <Name>Product 3 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -618,7 +618,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_adult">
-              <Name>Product 4 - adult</Name>
+              <Name>Product 4 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -641,7 +641,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_adult">
-              <Name>Product 5 - adult</Name>
+              <Name>Product 5 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/multiOpGeoZone.xml
+++ b/fdbt-dev/data/netexData/multiOpGeoZone.xml
@@ -549,7 +549,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_adult">
-              <Name>Product 1</Name>
+              <Name>Product 1 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -572,7 +572,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_adult">
-              <Name>Product 2</Name>
+              <Name>Product 2 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -595,7 +595,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_adult">
-              <Name>Product 3</Name>
+              <Name>Product 3 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -618,7 +618,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_adult">
-              <Name>Product 4</Name>
+              <Name>Product 4 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -641,7 +641,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_adult">
-              <Name>Product 5</Name>
+              <Name>Product 5 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/multiOpGeoZone.xml
+++ b/fdbt-dev/data/netexData/multiOpGeoZone.xml
@@ -549,7 +549,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_adult">
-              <Name>Product 1 Pass - adult</Name>
+              <Name>Product 1</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -572,7 +572,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_adult">
-              <Name>Product 2 Pass - adult</Name>
+              <Name>Product 2</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -595,7 +595,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_adult">
-              <Name>Product 3 Pass - adult</Name>
+              <Name>Product 3</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -618,7 +618,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_adult">
-              <Name>Product 4 Pass - adult</Name>
+              <Name>Product 4</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -641,7 +641,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_adult">
-              <Name>Product 5 Pass - adult</Name>
+              <Name>Product 5</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/multiOpGeoZone.xml
+++ b/fdbt-dev/data/netexData/multiOpGeoZone.xml
@@ -549,7 +549,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_adult">
-              <Name>Product 1 Pass - adult</Name>
+              <Name>Product 1 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -572,7 +572,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_adult">
-              <Name>Product 2 Pass - adult</Name>
+              <Name>Product 2 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -595,7 +595,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_adult">
-              <Name>Product 3 Pass - adult</Name>
+              <Name>Product 3 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -618,7 +618,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_adult">
-              <Name>Product 4 Pass - adult</Name>
+              <Name>Product 4 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -641,7 +641,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_adult">
-              <Name>Product 5 Pass - adult</Name>
+              <Name>Product 5 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/multiOpMultiServices.xml
+++ b/fdbt-dev/data/netexData/multiOpMultiServices.xml
@@ -429,7 +429,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_1_youngPerson">
-              <Name>Test Product 1 Pass - youngPerson</Name>
+              <Name>Test Product 1</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -452,7 +452,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_2_youngPerson">
-              <Name>Test Product 2 Pass - youngPerson</Name>
+              <Name>Test Product 2</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -475,7 +475,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_3_youngPerson">
-              <Name>Test Product 3 Pass - youngPerson</Name>
+              <Name>Test Product 3</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/multiOpMultiServices.xml
+++ b/fdbt-dev/data/netexData/multiOpMultiServices.xml
@@ -429,7 +429,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_1_youngPerson">
-              <Name>Test Product 1</Name>
+              <Name>Test Product 1 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -452,7 +452,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_2_youngPerson">
-              <Name>Test Product 2</Name>
+              <Name>Test Product 2 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -475,7 +475,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_3_youngPerson">
-              <Name>Test Product 3</Name>
+              <Name>Test Product 3 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/multiOpMultiServices.xml
+++ b/fdbt-dev/data/netexData/multiOpMultiServices.xml
@@ -429,7 +429,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_1_youngPerson">
-              <Name>Test Product 1 - youngPerson</Name>
+              <Name>Test Product 1 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -452,7 +452,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_2_youngPerson">
-              <Name>Test Product 2 - youngPerson</Name>
+              <Name>Test Product 2 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -475,7 +475,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_3_youngPerson">
-              <Name>Test Product 3 - youngPerson</Name>
+              <Name>Test Product 3 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/multiOpMultiServices.xml
+++ b/fdbt-dev/data/netexData/multiOpMultiServices.xml
@@ -429,7 +429,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_1_youngPerson">
-              <Name>Test Product 1 Pass - youngPerson</Name>
+              <Name>Test Product 1 - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -452,7 +452,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_2_youngPerson">
-              <Name>Test Product 2 Pass - youngPerson</Name>
+              <Name>Test Product 2 - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -475,7 +475,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_3_youngPerson">
-              <Name>Test Product 3 Pass - youngPerson</Name>
+              <Name>Test Product 3 - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/periodGeoZone.xml
+++ b/fdbt-dev/data/netexData/periodGeoZone.xml
@@ -529,7 +529,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_adult">
-              <Name>Product 1 - adult</Name>
+              <Name>Product 1 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -552,7 +552,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_adult">
-              <Name>Product 2 - adult</Name>
+              <Name>Product 2 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -575,7 +575,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_adult">
-              <Name>Product 3 - adult</Name>
+              <Name>Product 3 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -598,7 +598,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_adult">
-              <Name>Product 4 - adult</Name>
+              <Name>Product 4 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -621,7 +621,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_adult">
-              <Name>Product 5 - adult</Name>
+              <Name>Product 5 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/periodGeoZone.xml
+++ b/fdbt-dev/data/netexData/periodGeoZone.xml
@@ -529,7 +529,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_adult">
-              <Name>Product 1 Pass - adult</Name>
+              <Name>Product 1 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -552,7 +552,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_adult">
-              <Name>Product 2 Pass - adult</Name>
+              <Name>Product 2 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -575,7 +575,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_adult">
-              <Name>Product 3 Pass - adult</Name>
+              <Name>Product 3 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -598,7 +598,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_adult">
-              <Name>Product 4 Pass - adult</Name>
+              <Name>Product 4 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -621,7 +621,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_adult">
-              <Name>Product 5 Pass - adult</Name>
+              <Name>Product 5 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/periodGeoZone.xml
+++ b/fdbt-dev/data/netexData/periodGeoZone.xml
@@ -529,7 +529,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_adult">
-              <Name>Product 1</Name>
+              <Name>Product 1 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -552,7 +552,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_adult">
-              <Name>Product 2</Name>
+              <Name>Product 2 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -575,7 +575,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_adult">
-              <Name>Product 3</Name>
+              <Name>Product 3 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -598,7 +598,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_adult">
-              <Name>Product 4</Name>
+              <Name>Product 4 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -621,7 +621,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_adult">
-              <Name>Product 5</Name>
+              <Name>Product 5 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/periodGeoZone.xml
+++ b/fdbt-dev/data/netexData/periodGeoZone.xml
@@ -529,7 +529,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_adult">
-              <Name>Product 1 Pass - adult</Name>
+              <Name>Product 1</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -552,7 +552,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_adult">
-              <Name>Product 2 Pass - adult</Name>
+              <Name>Product 2</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -575,7 +575,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_adult">
-              <Name>Product 3 Pass - adult</Name>
+              <Name>Product 3</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -598,7 +598,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_adult">
-              <Name>Product 4 Pass - adult</Name>
+              <Name>Product 4</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -621,7 +621,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_adult">
-              <Name>Product 5 Pass - adult</Name>
+              <Name>Product 5</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/periodGeoZoneGroup.xml
+++ b/fdbt-dev/data/netexData/periodGeoZoneGroup.xml
@@ -559,7 +559,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_group">
-              <Name>Product 1 - group</Name>
+              <Name>Product 1 Pass - group</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -582,7 +582,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_group">
-              <Name>Product 2 - group</Name>
+              <Name>Product 2 Pass - group</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -605,7 +605,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_group">
-              <Name>Product 3 - group</Name>
+              <Name>Product 3 Pass - group</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -628,7 +628,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_group">
-              <Name>Product 4 - group</Name>
+              <Name>Product 4 Pass - group</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -651,7 +651,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_group">
-              <Name>Product 5 - group</Name>
+              <Name>Product 5 Pass - group</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/periodGeoZoneGroup.xml
+++ b/fdbt-dev/data/netexData/periodGeoZoneGroup.xml
@@ -559,7 +559,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_group">
-              <Name>Product 1</Name>
+              <Name>Product 1 Pass - group</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -582,7 +582,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_group">
-              <Name>Product 2</Name>
+              <Name>Product 2 Pass - group</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -605,7 +605,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_group">
-              <Name>Product 3</Name>
+              <Name>Product 3 Pass - group</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -628,7 +628,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_group">
-              <Name>Product 4</Name>
+              <Name>Product 4 Pass - group</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -651,7 +651,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_group">
-              <Name>Product 5</Name>
+              <Name>Product 5 Pass - group</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/periodGeoZoneGroup.xml
+++ b/fdbt-dev/data/netexData/periodGeoZoneGroup.xml
@@ -559,7 +559,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_group">
-              <Name>Product 1 Pass - group</Name>
+              <Name>Product 1 - group</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -582,7 +582,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_group">
-              <Name>Product 2 Pass - group</Name>
+              <Name>Product 2 - group</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -605,7 +605,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_group">
-              <Name>Product 3 Pass - group</Name>
+              <Name>Product 3 - group</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -628,7 +628,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_group">
-              <Name>Product 4 Pass - group</Name>
+              <Name>Product 4 - group</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -651,7 +651,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_group">
-              <Name>Product 5 Pass - group</Name>
+              <Name>Product 5 - group</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/periodGeoZoneGroup.xml
+++ b/fdbt-dev/data/netexData/periodGeoZoneGroup.xml
@@ -559,7 +559,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_group">
-              <Name>Product 1 Pass - group</Name>
+              <Name>Product 1</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -582,7 +582,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_group">
-              <Name>Product 2 Pass - group</Name>
+              <Name>Product 2</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -605,7 +605,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_group">
-              <Name>Product 3 Pass - group</Name>
+              <Name>Product 3</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -628,7 +628,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_group">
-              <Name>Product 4 Pass - group</Name>
+              <Name>Product 4</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -651,7 +651,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_group">
-              <Name>Product 5 Pass - group</Name>
+              <Name>Product 5</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/periodMultiService.xml
+++ b/fdbt-dev/data/netexData/periodMultiService.xml
@@ -405,7 +405,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_1_youngPerson">
-              <Name>Test Product 1</Name>
+              <Name>Test Product 1 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -428,7 +428,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_2_youngPerson">
-              <Name>Test Product 2</Name>
+              <Name>Test Product 2 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -451,7 +451,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_3_youngPerson">
-              <Name>Test Product 3</Name>
+              <Name>Test Product 3 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/periodMultiService.xml
+++ b/fdbt-dev/data/netexData/periodMultiService.xml
@@ -405,7 +405,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_1_youngPerson">
-              <Name>Test Product 1 Pass - youngPerson</Name>
+              <Name>Test Product 1 - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -428,7 +428,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_2_youngPerson">
-              <Name>Test Product 2 Pass - youngPerson</Name>
+              <Name>Test Product 2 - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -451,7 +451,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_3_youngPerson">
-              <Name>Test Product 3 Pass - youngPerson</Name>
+              <Name>Test Product 3 - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/periodMultiService.xml
+++ b/fdbt-dev/data/netexData/periodMultiService.xml
@@ -405,7 +405,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_1_youngPerson">
-              <Name>Test Product 1 - youngPerson</Name>
+              <Name>Test Product 1 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -428,7 +428,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_2_youngPerson">
-              <Name>Test Product 2 - youngPerson</Name>
+              <Name>Test Product 2 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -451,7 +451,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_3_youngPerson">
-              <Name>Test Product 3 - youngPerson</Name>
+              <Name>Test Product 3 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/periodMultiService.xml
+++ b/fdbt-dev/data/netexData/periodMultiService.xml
@@ -405,7 +405,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_1_youngPerson">
-              <Name>Test Product 1 Pass - youngPerson</Name>
+              <Name>Test Product 1</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -428,7 +428,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_2_youngPerson">
-              <Name>Test Product 2 Pass - youngPerson</Name>
+              <Name>Test Product 2</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -451,7 +451,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_3_youngPerson">
-              <Name>Test Product 3 Pass - youngPerson</Name>
+              <Name>Test Product 3</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/schemeCarnetFlatFare.xml
+++ b/fdbt-dev/data/netexData/schemeCarnetFlatFare.xml
@@ -205,7 +205,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@test_adult">
-              <Name>test Pass - adult</Name>
+              <Name>test</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@trip@single"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>

--- a/fdbt-dev/data/netexData/schemeCarnetMultipleServices.xml
+++ b/fdbt-dev/data/netexData/schemeCarnetMultipleServices.xml
@@ -286,7 +286,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@test_child">
-              <Name>test Pass - child</Name>
+              <Name>test - child</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>
@@ -309,7 +309,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Jacob_Ellis_child">
-              <Name>Jacob Ellis Pass - child</Name>
+              <Name>Jacob Ellis - child</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>

--- a/fdbt-dev/data/netexData/schemeCarnetMultipleServices.xml
+++ b/fdbt-dev/data/netexData/schemeCarnetMultipleServices.xml
@@ -286,7 +286,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@test_child">
-              <Name>test Pass - child</Name>
+              <Name>test</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>
@@ -309,7 +309,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Jacob_Ellis_child">
-              <Name>Jacob Ellis Pass - child</Name>
+              <Name>Jacob Ellis</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>

--- a/fdbt-dev/data/netexData/schemeCarnetMultipleServices.xml
+++ b/fdbt-dev/data/netexData/schemeCarnetMultipleServices.xml
@@ -286,7 +286,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@test_child">
-              <Name>test - child</Name>
+              <Name>test Pass - child</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>
@@ -309,7 +309,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Jacob_Ellis_child">
-              <Name>Jacob Ellis - child</Name>
+              <Name>Jacob Ellis Pass - child</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>

--- a/fdbt-dev/data/netexData/schemeCarnetMultipleServices.xml
+++ b/fdbt-dev/data/netexData/schemeCarnetMultipleServices.xml
@@ -286,7 +286,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@test_child">
-              <Name>test</Name>
+              <Name>test Pass - child</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>
@@ -309,7 +309,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Jacob_Ellis_child">
-              <Name>Jacob Ellis</Name>
+              <Name>Jacob Ellis Pass - child</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>

--- a/fdbt-dev/data/netexData/schemeCarnetPeriod.xml
+++ b/fdbt-dev/data/netexData/schemeCarnetPeriod.xml
@@ -285,7 +285,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@jakes_anyone">
-              <Name>jakes - anyone</Name>
+              <Name>jakes Pass - anyone</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>

--- a/fdbt-dev/data/netexData/schemeCarnetPeriod.xml
+++ b/fdbt-dev/data/netexData/schemeCarnetPeriod.xml
@@ -285,7 +285,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@jakes_anyone">
-              <Name>jakes Pass - anyone</Name>
+              <Name>jakes - anyone</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>

--- a/fdbt-dev/data/netexData/schemeCarnetPeriod.xml
+++ b/fdbt-dev/data/netexData/schemeCarnetPeriod.xml
@@ -285,7 +285,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@jakes_anyone">
-              <Name>jakes</Name>
+              <Name>jakes Pass - anyone</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>

--- a/fdbt-dev/data/netexData/schemeCarnetPeriod.xml
+++ b/fdbt-dev/data/netexData/schemeCarnetPeriod.xml
@@ -285,7 +285,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@jakes_anyone">
-              <Name>jakes Pass - anyone</Name>
+              <Name>jakes</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>

--- a/fdbt-dev/data/netexData/schemeOperatorFlatFare.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorFlatFare.xml
@@ -217,7 +217,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Weekly_Rider_senior">
-              <Name>Weekly Rider Pass - senior</Name>
+              <Name>Weekly Rider</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@trip@single"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>

--- a/fdbt-dev/data/netexData/schemeOperatorGeoZone.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorGeoZone.xml
@@ -555,7 +555,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_adult">
-              <Name>Product 1 Pass - adult</Name>
+              <Name>Product 1 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>
@@ -578,7 +578,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_adult">
-              <Name>Product 2 Pass - adult</Name>
+              <Name>Product 2 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>
@@ -601,7 +601,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_adult">
-              <Name>Product 3 Pass - adult</Name>
+              <Name>Product 3 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>
@@ -624,7 +624,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_adult">
-              <Name>Product 4 Pass - adult</Name>
+              <Name>Product 4 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>
@@ -647,7 +647,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_adult">
-              <Name>Product 5 Pass - adult</Name>
+              <Name>Product 5 - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>

--- a/fdbt-dev/data/netexData/schemeOperatorGeoZone.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorGeoZone.xml
@@ -555,7 +555,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_adult">
-              <Name>Product 1 - adult</Name>
+              <Name>Product 1 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>
@@ -578,7 +578,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_adult">
-              <Name>Product 2 - adult</Name>
+              <Name>Product 2 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>
@@ -601,7 +601,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_adult">
-              <Name>Product 3 - adult</Name>
+              <Name>Product 3 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>
@@ -624,7 +624,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_adult">
-              <Name>Product 4 - adult</Name>
+              <Name>Product 4 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>
@@ -647,7 +647,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_adult">
-              <Name>Product 5 - adult</Name>
+              <Name>Product 5 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>

--- a/fdbt-dev/data/netexData/schemeOperatorGeoZone.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorGeoZone.xml
@@ -555,7 +555,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_adult">
-              <Name>Product 1</Name>
+              <Name>Product 1 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>
@@ -578,7 +578,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_adult">
-              <Name>Product 2</Name>
+              <Name>Product 2 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>
@@ -601,7 +601,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_adult">
-              <Name>Product 3</Name>
+              <Name>Product 3 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>
@@ -624,7 +624,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_adult">
-              <Name>Product 4</Name>
+              <Name>Product 4 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>
@@ -647,7 +647,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_adult">
-              <Name>Product 5</Name>
+              <Name>Product 5 Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>

--- a/fdbt-dev/data/netexData/schemeOperatorGeoZone.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorGeoZone.xml
@@ -555,7 +555,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_1_adult">
-              <Name>Product 1 Pass - adult</Name>
+              <Name>Product 1</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>
@@ -578,7 +578,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_2_adult">
-              <Name>Product 2 Pass - adult</Name>
+              <Name>Product 2</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>
@@ -601,7 +601,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_3_adult">
-              <Name>Product 3 Pass - adult</Name>
+              <Name>Product 3</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>
@@ -624,7 +624,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_4_adult">
-              <Name>Product 4 Pass - adult</Name>
+              <Name>Product 4</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>
@@ -647,7 +647,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Product_5_adult">
-              <Name>Product 5 Pass - adult</Name>
+              <Name>Product 5</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>

--- a/fdbt-dev/data/netexData/schemeOperatorMultiServices.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorMultiServices.xml
@@ -334,7 +334,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Week_Rider_adult">
-              <Name>Week Rider - adult</Name>
+              <Name>Week Rider Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>
@@ -357,7 +357,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Month_Rider_adult">
-              <Name>Month Rider - adult</Name>
+              <Name>Month Rider Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>

--- a/fdbt-dev/data/netexData/schemeOperatorMultiServices.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorMultiServices.xml
@@ -334,7 +334,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Week_Rider_adult">
-              <Name>Week Rider</Name>
+              <Name>Week Rider Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>
@@ -357,7 +357,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Month_Rider_adult">
-              <Name>Month Rider</Name>
+              <Name>Month Rider Pass - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>

--- a/fdbt-dev/data/netexData/schemeOperatorMultiServices.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorMultiServices.xml
@@ -334,7 +334,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Week_Rider_adult">
-              <Name>Week Rider Pass - adult</Name>
+              <Name>Week Rider</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>
@@ -357,7 +357,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Month_Rider_adult">
-              <Name>Month Rider Pass - adult</Name>
+              <Name>Month Rider</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>

--- a/fdbt-dev/data/netexData/schemeOperatorMultiServices.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorMultiServices.xml
@@ -334,7 +334,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Week_Rider_adult">
-              <Name>Week Rider Pass - adult</Name>
+              <Name>Week Rider - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>
@@ -357,7 +357,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Month_Rider_adult">
-              <Name>Month Rider Pass - adult</Name>
+              <Name>Month Rider - adult</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>

--- a/fdbt-dev/data/netexData/schoolPeriodMultiService.xml
+++ b/fdbt-dev/data/netexData/schoolPeriodMultiService.xml
@@ -465,7 +465,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_4_youngPerson">
-              <Name>Test Product 4</Name>
+              <Name>Test Product 4 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -488,7 +488,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_1_youngPerson">
-              <Name>Test Product 1</Name>
+              <Name>Test Product 1 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -511,7 +511,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_2_youngPerson">
-              <Name>Test Product 2</Name>
+              <Name>Test Product 2 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -534,7 +534,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_3_youngPerson">
-              <Name>Test Product 3</Name>
+              <Name>Test Product 3 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/schoolPeriodMultiService.xml
+++ b/fdbt-dev/data/netexData/schoolPeriodMultiService.xml
@@ -465,7 +465,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_4_youngPerson">
-              <Name>Test Product 4 Pass - youngPerson</Name>
+              <Name>Test Product 4 - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -488,7 +488,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_1_youngPerson">
-              <Name>Test Product 1 Pass - youngPerson</Name>
+              <Name>Test Product 1 - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -511,7 +511,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_2_youngPerson">
-              <Name>Test Product 2 Pass - youngPerson</Name>
+              <Name>Test Product 2 - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -534,7 +534,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_3_youngPerson">
-              <Name>Test Product 3 Pass - youngPerson</Name>
+              <Name>Test Product 3 - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/schoolPeriodMultiService.xml
+++ b/fdbt-dev/data/netexData/schoolPeriodMultiService.xml
@@ -465,7 +465,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_4_youngPerson">
-              <Name>Test Product 4 - youngPerson</Name>
+              <Name>Test Product 4 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -488,7 +488,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_1_youngPerson">
-              <Name>Test Product 1 - youngPerson</Name>
+              <Name>Test Product 1 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -511,7 +511,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_2_youngPerson">
-              <Name>Test Product 2 - youngPerson</Name>
+              <Name>Test Product 2 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -534,7 +534,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_3_youngPerson">
-              <Name>Test Product 3 - youngPerson</Name>
+              <Name>Test Product 3 Pass - youngPerson</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/fdbt-dev/data/netexData/schoolPeriodMultiService.xml
+++ b/fdbt-dev/data/netexData/schoolPeriodMultiService.xml
@@ -465,7 +465,7 @@
           </tariffs>
           <fareProducts>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_4_youngPerson">
-              <Name>Test Product 4 Pass - youngPerson</Name>
+              <Name>Test Product 4</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -488,7 +488,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_1_youngPerson">
-              <Name>Test Product 1 Pass - youngPerson</Name>
+              <Name>Test Product 1</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -511,7 +511,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_2_youngPerson">
-              <Name>Test Product 2 Pass - youngPerson</Name>
+              <Name>Test Product 2</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
@@ -534,7 +534,7 @@
               <ProductType>periodPass</ProductType>
             </PreassignedFareProduct>
             <PreassignedFareProduct version="1.0" id="op:Pass@Test_Product_3_youngPerson">
-              <Name>Test Product 3 Pass - youngPerson</Name>
+              <Name>Test Product 3</Name>
               <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>

--- a/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
@@ -570,7 +570,7 @@ export const getPreassignedFareProducts = (
             version: '1.0',
             id: `op:Pass@${product.productName}_${passengerType}`,
             Name: {
-                $t: product.productName
+                $t: product.productName,
             },
             ChargingMomentType: {
                 $t: 'beforeTravel',

--- a/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
@@ -570,7 +570,7 @@ export const getPreassignedFareProducts = (
             version: '1.0',
             id: `op:Pass@${product.productName}_${passengerType}`,
             Name: {
-                $t: `${product.productName} Pass - ${passengerType}`,
+                $t: product.productName
             },
             ChargingMomentType: {
                 $t: 'beforeTravel',

--- a/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
@@ -570,7 +570,9 @@ export const getPreassignedFareProducts = (
             version: '1.0',
             id: `op:Pass@${product.productName}_${passengerType}`,
             Name: {
-                $t: isFlatFareType(userPeriodTicket) ? product.productName : `${product.productName} - ${passengerType}`,
+                $t: isFlatFareType(userPeriodTicket)
+                    ? product.productName
+                    : `${product.productName} - ${passengerType}`,
             },
             ChargingMomentType: {
                 $t: 'beforeTravel',

--- a/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
@@ -572,7 +572,7 @@ export const getPreassignedFareProducts = (
             Name: {
                 $t: isFlatFareType(userPeriodTicket)
                     ? product.productName
-                    : `${product.productName} - ${passengerType}`,
+                    : `${product.productName} Pass - ${passengerType}`,
             },
             ChargingMomentType: {
                 $t: 'beforeTravel',

--- a/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
@@ -570,7 +570,7 @@ export const getPreassignedFareProducts = (
             version: '1.0',
             id: `op:Pass@${product.productName}_${passengerType}`,
             Name: {
-                $t: product.productName,
+                $t: isFlatFareType(userPeriodTicket) ? product.productName : `${product.productName} Pass - ${passengerType}`,
             },
             ChargingMomentType: {
                 $t: 'beforeTravel',

--- a/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
@@ -572,7 +572,7 @@ export const getPreassignedFareProducts = (
             Name: {
                 $t: isFlatFareType(userPeriodTicket)
                     ? product.productName
-                    : `${product.productName} Pass - ${passengerType}`,
+                    : `${product.productName} - ${passengerType}`,
             },
             ChargingMomentType: {
                 $t: 'beforeTravel',

--- a/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
@@ -570,7 +570,7 @@ export const getPreassignedFareProducts = (
             version: '1.0',
             id: `op:Pass@${product.productName}_${passengerType}`,
             Name: {
-                $t: isFlatFareType(userPeriodTicket) ? product.productName : `${product.productName} Pass - ${passengerType}`,
+                $t: isFlatFareType(userPeriodTicket) ? product.productName : `${product.productName} - ${passengerType}`,
             },
             ChargingMomentType: {
                 $t: 'beforeTravel',


### PR DESCRIPTION
## Description
[CFDS-37](https://deliverybackbone.ema.kpmg.com/pdstudio86/browse/CFDS-37)

Currently flat fare user journey uses period ticket naming convention: {productName} Pass - {passengerType}

For flat fare ticket(any variation): Name under PreassignedFareProduct should be the same as pointToPoint ticket - productNameForPlainText

For period ticket (any variation): Name should be '{productName} - {passengerType}' e.g. remove the word Pass

## Testing instructions

Run the tests and code review
