### PR TITLE
fix: fixing tariff name

### DIFF
--- a/fdbt-dev/data/netexData/carnetFlatFare.xml
+++ b/fdbt-dev/data/netexData/carnetFlatFare.xml
@@ -139,7 +139,7 @@
                   <ToDate>2028-12-17T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Weekly Rider</Name>
+              <Name>Tariff for Weekly Rider</Name>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:flat"/>
               <TariffBasis>flat</TariffBasis>

--- a/fdbt-dev/data/netexData/carnetPeriodGeoZone.xml
+++ b/fdbt-dev/data/netexData/carnetPeriodGeoZone.xml
@@ -207,7 +207,7 @@
                   <ToDate>2028-12-17T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Product 1</Name>
+              <Name>Tariff for Product 1</Name>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zonal"/>
               <TariffBasis>zone</TariffBasis>

--- a/fdbt-dev/data/netexData/carnetPeriodMultiService.xml
+++ b/fdbt-dev/data/netexData/carnetPeriodMultiService.xml
@@ -141,7 +141,7 @@
                   <ToDate>2028-12-17T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Test Product 1</Name>
+              <Name>Tariff for Test Product 1</Name>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zonal"/>
               <TariffBasis>zone</TariffBasis>

--- a/fdbt-dev/data/netexData/carnetReturn.xml
+++ b/fdbt-dev/data/netexData/carnetReturn.xml
@@ -351,7 +351,7 @@
                   <ToDate>2028-12-17T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Another product</Name>
+              <Name>Tariff for Another product</Name>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
               <LineRef version="1.0" ref="19"/>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zone_to_zone"/>

--- a/fdbt-dev/data/netexData/carnetSingle.xml
+++ b/fdbt-dev/data/netexData/carnetSingle.xml
@@ -465,7 +465,7 @@
                   <ToDate>2028-12-17T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Product 1</Name>
+              <Name>Tariff for Product 1</Name>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
               <LineRef version="1.0" ref="4"/>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zone_to_zone"/>

--- a/fdbt-dev/data/netexData/flatFare.xml
+++ b/fdbt-dev/data/netexData/flatFare.xml
@@ -139,7 +139,7 @@
                   <ToDate>2028-12-17T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Weekly Rider</Name>
+              <Name>Tariff for Weekly Rider</Name>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:flat"/>
               <TariffBasis>flat</TariffBasis>

--- a/fdbt-dev/data/netexData/flatFareGeoZone.xml
+++ b/fdbt-dev/data/netexData/flatFareGeoZone.xml
@@ -201,7 +201,7 @@
                   <ToDate>2021-10-01T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>JTest00</Name>
+              <Name>Tariff for JTest00</Name>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:flat"/>
               <TariffBasis>flat</TariffBasis>

--- a/fdbt-dev/data/netexData/flatFareGroup.xml
+++ b/fdbt-dev/data/netexData/flatFareGroup.xml
@@ -139,7 +139,7 @@
                   <ToDate>2028-12-17T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Weekly Rider</Name>
+              <Name>Tariff for Weekly Rider</Name>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:flat"/>
               <TariffBasis>flat</TariffBasis>

--- a/fdbt-dev/data/netexData/flatFareWithSopPrices.xml
+++ b/fdbt-dev/data/netexData/flatFareWithSopPrices.xml
@@ -139,7 +139,7 @@
                   <ToDate>2121-07-06T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>test</Name>
+              <Name>Tariff for test</Name>
               <OperatorRef version="1.0" ref="noc:WBTR">noc:135742</OperatorRef>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:flat"/>
               <TariffBasis>flat</TariffBasis>

--- a/fdbt-dev/data/netexData/hybridPeriod.xml
+++ b/fdbt-dev/data/netexData/hybridPeriod.xml
@@ -202,7 +202,7 @@
                   <ToDate>2121-06-30T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Best product one</Name>
+              <Name>Tariff for Best product one</Name>
               <OperatorRef version="1.0" ref="noc:WBTR">noc:135742</OperatorRef>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zonal"/>
               <TariffBasis>zone</TariffBasis>

--- a/fdbt-dev/data/netexData/multiOpGeoZone.xml
+++ b/fdbt-dev/data/netexData/multiOpGeoZone.xml
@@ -256,7 +256,7 @@
                   <ToDate>2028-12-17T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Product 1</Name>
+              <Name>Tariff for Product 1</Name>
               <GroupOfOperatorsRef version="1.0" ref="operators@bus"/>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zonal"/>
               <TariffBasis>zone</TariffBasis>

--- a/fdbt-dev/data/netexData/multiOpMultiServices.xml
+++ b/fdbt-dev/data/netexData/multiOpMultiServices.xml
@@ -175,7 +175,7 @@
                   <ToDate>2028-12-17T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Test Product 1</Name>
+              <Name>Tariff for Test Product 1</Name>
               <GroupOfOperatorsRef version="1.0" ref="operators@bus"/>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zonal"/>
               <TariffBasis>zone</TariffBasis>

--- a/fdbt-dev/data/netexData/periodGeoZone.xml
+++ b/fdbt-dev/data/netexData/periodGeoZone.xml
@@ -207,7 +207,7 @@
                   <ToDate>2028-12-17T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Product 1</Name>
+              <Name>Tariff for Product 1</Name>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zonal"/>
               <TariffBasis>zone</TariffBasis>

--- a/fdbt-dev/data/netexData/periodGeoZoneGroup.xml
+++ b/fdbt-dev/data/netexData/periodGeoZoneGroup.xml
@@ -207,7 +207,7 @@
                   <ToDate>2028-12-17T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Product 1</Name>
+              <Name>Tariff for Product 1</Name>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zonal"/>
               <TariffBasis>zone</TariffBasis>

--- a/fdbt-dev/data/netexData/periodMultiService.xml
+++ b/fdbt-dev/data/netexData/periodMultiService.xml
@@ -141,7 +141,7 @@
                   <ToDate>2028-12-17T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Test Product 1</Name>
+              <Name>Tariff for Test Product 1</Name>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zonal"/>
               <TariffBasis>zone</TariffBasis>

--- a/fdbt-dev/data/netexData/periodPointToPoint.xml
+++ b/fdbt-dev/data/netexData/periodPointToPoint.xml
@@ -1068,7 +1068,7 @@
                   <ToDate>2022-02-02T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Period Point to Point</Name>
+              <Name>Tariff for Period Point to Point</Name>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
               <LineRef version="1.0" ref="2"/>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zone_to_zone"/>

--- a/fdbt-dev/data/netexData/return.xml
+++ b/fdbt-dev/data/netexData/return.xml
@@ -350,7 +350,7 @@
                   <FromDate>2010-12-17T00:00:00.000Z</FromDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Another product</Name>
+              <Name>Tariff for Another product</Name>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
               <LineRef version="1.0" ref="19"/>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zone_to_zone"/>

--- a/fdbt-dev/data/netexData/returnCircular.xml
+++ b/fdbt-dev/data/netexData/returnCircular.xml
@@ -261,7 +261,7 @@
                   <ToDate>2028-12-17T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Another product</Name>
+              <Name>Tariff for Another product</Name>
               <OperatorRef version="1.0" ref="noc:WBTR">noc:135742</OperatorRef>
               <LineRef version="1.0" ref="709"/>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zone_to_zone"/>

--- a/fdbt-dev/data/netexData/returnCircularGroup.xml
+++ b/fdbt-dev/data/netexData/returnCircularGroup.xml
@@ -261,7 +261,7 @@
                   <ToDate>2028-12-17T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Another product</Name>
+              <Name>Tariff for Another product</Name>
               <OperatorRef version="1.0" ref="noc:WBTR">noc:135742</OperatorRef>
               <LineRef version="1.0" ref="709"/>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zone_to_zone"/>

--- a/fdbt-dev/data/netexData/schemeCarnetFlatFare.xml
+++ b/fdbt-dev/data/netexData/schemeCarnetFlatFare.xml
@@ -147,7 +147,7 @@
                   <ToDate>2121-06-25T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>test</Name>
+              <Name>Tariff for test</Name>
               <GroupOfOperatorsRef version="1.0" ref="operators@bus"/>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:flat"/>
               <TariffBasis>flat</TariffBasis>

--- a/fdbt-dev/data/netexData/schemeCarnetMultipleServices.xml
+++ b/fdbt-dev/data/netexData/schemeCarnetMultipleServices.xml
@@ -163,7 +163,7 @@
                   <ToDate>2121-09-02T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>test</Name>
+              <Name>Tariff for test</Name>
               <GroupOfOperatorsRef version="1.0" ref="operators@bus"/>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zonal"/>
               <TariffBasis>zone</TariffBasis>

--- a/fdbt-dev/data/netexData/schemeCarnetPeriod.xml
+++ b/fdbt-dev/data/netexData/schemeCarnetPeriod.xml
@@ -209,7 +209,7 @@
                   <ToDate>2121-06-25T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>jakes</Name>
+              <Name>Tariff for jakes</Name>
               <OperatorRef version="1.0" ref="noc:Test_Scheme_Op-SE">noc:Test Scheme Op-SE-opId</OperatorRef>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zonal"/>
               <TariffBasis>zone</TariffBasis>

--- a/fdbt-dev/data/netexData/schemeOperatorFlatFare.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorFlatFare.xml
@@ -162,7 +162,7 @@
                   <ToDate>2028-12-17T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Weekly Rider</Name>
+              <Name>Tariff for Weekly Rider</Name>
               <GroupOfOperatorsRef version="1.0" ref="operators@bus"/>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:flat"/>
               <TariffBasis>flat</TariffBasis>

--- a/fdbt-dev/data/netexData/schemeOperatorGeoZone.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorGeoZone.xml
@@ -245,7 +245,7 @@
                   <ToDate>2028-12-17T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Product 1</Name>
+              <Name>Tariff for Product 1</Name>
               <OperatorRef version="1.0" ref="noc:IW_Buses-Y">noc:IW Buses-Y-opId</OperatorRef>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zonal"/>
               <TariffBasis>zone</TariffBasis>

--- a/fdbt-dev/data/netexData/schemeOperatorMultiServices.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorMultiServices.xml
@@ -163,7 +163,7 @@
                   <ToDate>2022-02-02T23:59:00.000Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Week Rider</Name>
+              <Name>Tariff for Week Rider</Name>
               <GroupOfOperatorsRef version="1.0" ref="operators@bus"/>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zonal"/>
               <TariffBasis>zone</TariffBasis>

--- a/fdbt-dev/data/netexData/schoolPeriodMultiService.xml
+++ b/fdbt-dev/data/netexData/schoolPeriodMultiService.xml
@@ -145,7 +145,7 @@
                   <Name>Term Time Usage Only</Name>
                 </ValidityCondition>
               </validityConditions>
-              <Name>Test Product 4</Name>
+              <Name>Tariff for Test Product 4</Name>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zonal"/>
               <TariffBasis>zone</TariffBasis>

--- a/fdbt-dev/data/netexData/single.xml
+++ b/fdbt-dev/data/netexData/single.xml
@@ -465,7 +465,7 @@
                   <ToDate>2028-12-17T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>adult - single</Name>
+              <Name>Tariff for adult - single</Name>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
               <LineRef version="1.0" ref="4"/>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zone_to_zone"/>

--- a/fdbt-dev/data/netexData/singleGroup.xml
+++ b/fdbt-dev/data/netexData/singleGroup.xml
@@ -465,7 +465,7 @@
                   <ToDate>2028-12-17T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Super product</Name>
+              <Name>Tariff for Super product</Name>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
               <LineRef version="1.0" ref="4"/>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zone_to_zone"/>

--- a/fdbt-dev/data/netexData/singleGroupMultipleAdults.xml
+++ b/fdbt-dev/data/netexData/singleGroupMultipleAdults.xml
@@ -465,7 +465,7 @@
                   <ToDate>2028-12-17T23:59:59.999Z</ToDate>
                 </ValidBetween>
               </validityConditions>
-              <Name>Best product</Name>
+              <Name>Tariff for Best product</Name>
               <OperatorRef version="1.0" ref="noc:BLAC">noc:135742</OperatorRef>
               <LineRef version="1.0" ref="4"/>
               <TypeOfTariffRef version="fxc:v1.0" ref="fxc:zone_to_zone"/>

--- a/repos/fdbt-netex-output/src/netex-convertor/netexGenerator.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/netexGenerator.ts
@@ -330,7 +330,7 @@ const netexGenerator = async (ticket: Ticket, operatorData: Operator[]): Promise
         tariff.id = coreData.lineIdName
             ? `Tariff@${coreData.ticketType}@${coreData.lineIdName}`
             : `op:Tariff@${coreData.placeholderGroupOfProductsName}`;
-        tariff.Name.$t = coreData.productNameForPlainText;
+        tariff.Name.$t = `Tariff for ${coreData.productNameForPlainText}`;
 
         const fareStructuresElements = getFareStructuresElements(
             ticket,


### PR DESCRIPTION
## Description

Tariff name wasnt being properly altered - it was only happening inside the Preassigned Fare Product.

## Testing instructions

Generate some netex, and observe that the name of the Tariff is 'Tariff for <product-name>' instead of only '<product-name>'.
