### PR TITLE
feat: Remove TNDS button from multiOperatorServiceList page

### DIFF
--- a/repos/fdbt-site/src/pages/multipleOperatorsServiceList.tsx
+++ b/repos/fdbt-site/src/pages/multipleOperatorsServiceList.tsx
@@ -19,7 +19,7 @@ import {
     TxcSourceAttribute,
 } from '../interfaces';
 import CsrfForm from '../components/CsrfForm';
-import { getAndValidateNoc, getCsrfToken } from '../utils';
+import { getCsrfToken } from '../utils';
 import { redirectTo } from '../utils/apiUtils';
 
 const pageTitle = 'Multiple Operators Service List - Create Fares Data Service';

--- a/repos/fdbt-site/src/pages/multipleOperatorsServiceList.tsx
+++ b/repos/fdbt-site/src/pages/multipleOperatorsServiceList.tsx
@@ -179,7 +179,6 @@ export const getServerSideProps = async (
     let dataSourceAttribute = getSessionAttribute(ctx.req, MULTI_OP_TXC_SOURCE_ATTRIBUTE);
 
     if (!dataSourceAttribute) {
-        const nocCode = getAndValidateNoc(ctx);
         const services = await getAllServicesByNocCode(operatorToUse.nocCode);
         const hasBodsServices = services.some((service) => service.dataSource && service.dataSource === 'bods');
 
@@ -187,7 +186,7 @@ export const getServerSideProps = async (
             if (ctx.res) {
                 redirectTo(ctx.res, '/noServices');
             } else {
-                throw new Error(`No services found for NOC Code: ${nocCode}`);
+                throw new Error(`No services found for NOC Code: ${operatorToUse.nocCode}`);
             }
         }
         // const hasTndsServices = services.some((service) => service.dataSource && service.dataSource === 'tnds');

--- a/repos/fdbt-site/src/pages/multipleOperatorsServiceList.tsx
+++ b/repos/fdbt-site/src/pages/multipleOperatorsServiceList.tsx
@@ -46,12 +46,13 @@ const MultipleOperatorsServiceList = ({
     dataSourceAttribute,
 }: MultipleOperatorsServiceListProps): ReactElement => (
     <FullColumnLayout title={pageTitle} description={pageDescription}>
-        <SwitchDataSource
+        {/* removed as TNDS is being disabled until further notice */}
+        {/* <SwitchDataSource
             dataSourceAttribute={dataSourceAttribute}
             pageUrl="/multipleOperatorsServiceList"
             attributeVersion="multiOperator"
             csrfToken={csrfToken}
-        />
+        /> */}
         <CsrfForm action="/api/multipleOperatorsServiceList" method="post" csrfToken={csrfToken}>
             <>
                 <ErrorSummary errors={errors} />

--- a/repos/fdbt-site/src/pages/multipleOperatorsServiceList.tsx
+++ b/repos/fdbt-site/src/pages/multipleOperatorsServiceList.tsx
@@ -21,7 +21,6 @@ import {
 import CsrfForm from '../components/CsrfForm';
 import { getCsrfToken } from '../utils';
 import { redirectTo } from '../utils/apiUtils';
-import SwitchDataSource from '../components/SwitchDataSource';
 
 const pageTitle = 'Multiple Operators Service List - Create Fares Data Service';
 const pageDescription = 'Multiple Operators Service List selection page of the Create Fares Data Service';

--- a/repos/fdbt-site/tests/pages/__snapshots__/multipleOperatorsServiceList.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/multipleOperatorsServiceList.test.tsx.snap
@@ -5,18 +5,6 @@ exports[`pages multipleOperatorsServiceList should render correctly with bods da
   description="Multiple Operators Service List selection page of the Create Fares Data Service"
   title="Multiple Operators Service List - Create Fares Data Service"
 >
-  <SwitchDataSource
-    attributeVersion="multiOperator"
-    csrfToken=""
-    dataSourceAttribute={
-      Object {
-        "hasBods": true,
-        "hasTnds": false,
-        "source": "bods",
-      }
-    }
-    pageUrl="/multipleOperatorsServiceList"
-  />
   <CsrfForm
     action="/api/multipleOperatorsServiceList"
     csrfToken=""
@@ -158,18 +146,6 @@ exports[`pages multipleOperatorsServiceList should render correctly with errors 
   description="Multiple Operators Service List selection page of the Create Fares Data Service"
   title="Multiple Operators Service List - Create Fares Data Service"
 >
-  <SwitchDataSource
-    attributeVersion="multiOperator"
-    csrfToken=""
-    dataSourceAttribute={
-      Object {
-        "hasBods": false,
-        "hasTnds": true,
-        "source": "tnds",
-      }
-    }
-    pageUrl="/multipleOperatorsServiceList"
-  />
   <CsrfForm
     action="/api/multipleOperatorsServiceList"
     csrfToken=""
@@ -325,18 +301,6 @@ exports[`pages multipleOperatorsServiceList should render correctly with tnds da
   description="Multiple Operators Service List selection page of the Create Fares Data Service"
   title="Multiple Operators Service List - Create Fares Data Service"
 >
-  <SwitchDataSource
-    attributeVersion="multiOperator"
-    csrfToken=""
-    dataSourceAttribute={
-      Object {
-        "hasBods": true,
-        "hasTnds": true,
-        "source": "tnds",
-      }
-    }
-    pageUrl="/multipleOperatorsServiceList"
-  />
   <CsrfForm
     action="/api/multipleOperatorsServiceList"
     csrfToken=""

--- a/repos/fdbt-site/tests/pages/multipleOperatorsServiceList.test.tsx
+++ b/repos/fdbt-site/tests/pages/multipleOperatorsServiceList.test.tsx
@@ -324,7 +324,7 @@ describe('pages', () => {
                 expect(updateSessionAttributeSpy).toBeCalledWith(ctx.req, MULTI_OP_TXC_SOURCE_ATTRIBUTE, {
                     source: 'tnds',
                     hasBods: false,
-                    hasTnds: true,
+                    hasTnds: false,
                 });
             });
         });


### PR DESCRIPTION
## Description

Removing TNDS button from browser as we are not using this functionality 

## Testing instructions

Go through the steps making a multi operator product you should notice that there is no TNDS button when you reach the /multiOperatorsServiceList path/page

<img width="258" alt="Screenshot 2022-10-14 at 15 28 39" src="https://user-images.githubusercontent.com/59929701/195871632-4cbfe0bc-69fa-4983-9d6c-5ded6ff2e563.png">
