### PR TITLE
fix: Updated logic for rendering multi operator options

### DIFF
--- a/repos/fdbt-site/src/pages/fareType.tsx
+++ b/repos/fdbt-site/src/pages/fareType.tsx
@@ -34,8 +34,33 @@ export const buildUuid = (noc: string): string => {
 };
 
 const buildRadioProps = (schemeOp: boolean): RadioOption[] => {
+    if (schemeOp) {
+        return [
+            {
+                value: 'period',
+                label: 'Period ticket',
+                hint: 'A ticket valid for a number of days, weeks, months or years',
+            },
+            {
+                value: 'carnetPeriod',
+                label: 'Carnet period ticket',
+                hint: 'A bundle of period tickets, each valid for a number of days, weeks, months or years',
+            },
+            {
+                value: 'flatFare',
+                label: 'Flat fare ticket',
+                hint: 'A fixed fee ticket for a single journey',
+            },
+            {
+                value: 'carnetFlatFare',
+                label: 'Carnet flat fare ticket',
+                hint: 'A bundle of fixed fee tickets, each for a single journey',
+            },
+        ];
+    }
+
     const isDevelopment = process.env.NODE_ENV === 'development';
-    const isTest = process.env.NODE_ENV === 'test';
+    const isTest = process.env.STAGE === 'test';
 
     const radioProps = [
         {
@@ -63,46 +88,21 @@ const buildRadioProps = (schemeOp: boolean): RadioOption[] => {
             label: 'Carnet ticket',
             hint: 'A bundle of pre-paid tickets',
         },
-        // Disabling until a plan for multiop tickets interacting with MyFares is devised
-
         {
             value: 'schoolService',
             label: 'Academic term/year ticket',
             hint: 'A ticket available to pupils in full-time education',
         },
     ];
+
     if (isDevelopment || isTest) {
-        radioProps.push({
+        radioProps.splice(radioProps.length - 1, 0, {
             value: 'multiOperator',
             label: 'Multi-operator',
             hint: 'A ticket that covers more than one operator',
         });
     }
 
-    if (schemeOp) {
-        return [
-            {
-                value: 'period',
-                label: 'Period ticket',
-                hint: 'A ticket valid for a number of days, weeks, months or years',
-            },
-            {
-                value: 'carnetPeriod',
-                label: 'Carnet period ticket',
-                hint: 'A bundle of period tickets, each valid for a number of days, weeks, months or years',
-            },
-            {
-                value: 'flatFare',
-                label: 'Flat fare ticket',
-                hint: 'A fixed fee ticket for a single journey',
-            },
-            {
-                value: 'carnetFlatFare',
-                label: 'Carnet flat fare ticket',
-                hint: 'A bundle of fixed fee tickets, each for a single journey',
-            },
-        ];
-    }
     return radioProps;
 };
 

--- a/repos/fdbt-site/tests/pages/__snapshots__/fareType.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/fareType.test.tsx.snap
@@ -76,11 +76,6 @@ exports[`pages fareType should render correctly 1`] = `
                   "label": "Academic term/year ticket",
                   "value": "schoolService",
                 },
-                Object {
-                  "hint": "A ticket that covers more than one operator",
-                  "label": "Multi-operator",
-                  "value": "multiOperator",
-                },
               ]
             }
           />
@@ -162,6 +157,103 @@ exports[`pages fareType should render correctly for a scheme operator 1`] = `
                   "hint": "A bundle of fixed fee tickets, each for a single journey",
                   "label": "Carnet flat fare ticket",
                   "value": "carnetFlatFare",
+                },
+              ]
+            }
+          />
+        </FormElementWrapper>
+      </fieldset>
+    </div>
+    <input
+      className="govuk-button"
+      id="continue-button"
+      type="submit"
+      value="Continue"
+    />
+  </CsrfForm>
+</TwoThirdsLayout>
+`;
+
+exports[`pages fareType should render correctly on test env 1`] = `
+<TwoThirdsLayout
+  description="Fare Type selection page of the Create Fares Data Service"
+  errors={Array []}
+  title="Fare Type - Create Fares Data Service "
+>
+  <CsrfForm
+    action="/api/fareType"
+    csrfToken=""
+    method="post"
+  >
+    <ErrorSummary
+      errors={Array []}
+    />
+    <div
+      className="govuk-form-group "
+    >
+      <fieldset
+        aria-describedby="fare-type-page-heading"
+        className="govuk-fieldset"
+      >
+        <legend
+          className="govuk-fieldset__legend govuk-fieldset__legend--l"
+        >
+          <h1
+            className="govuk-fieldset__heading"
+            id="fare-type-page-heading"
+          >
+            Select a fare type
+          </h1>
+        </legend>
+        <span
+          className="govuk-hint"
+          id="fare-type-operator-hint"
+        >
+          Blackpool Transport
+        </span>
+        <FormElementWrapper
+          errorClass="govuk-radios--error"
+          errorId="radio-option-single"
+          errors={Array []}
+        >
+          <RadioButtons
+            inputName="fareType"
+            options={
+              Array [
+                Object {
+                  "hint": "A ticket for a point to point journey",
+                  "label": "Single ticket",
+                  "value": "single",
+                },
+                Object {
+                  "hint": "An inbound and outbound ticket for the same service",
+                  "label": "Return ticket",
+                  "value": "return",
+                },
+                Object {
+                  "hint": "A fixed fee ticket for a single journey",
+                  "label": "Flat fare/short hop ticket",
+                  "value": "flatFare",
+                },
+                Object {
+                  "hint": "A ticket valid for a number of days, weeks, months or years",
+                  "label": "Period ticket",
+                  "value": "period",
+                },
+                Object {
+                  "hint": "A bundle of pre-paid tickets",
+                  "label": "Carnet ticket",
+                  "value": "carnet",
+                },
+                Object {
+                  "hint": "A ticket that covers more than one operator",
+                  "label": "Multi-operator",
+                  "value": "multiOperator",
+                },
+                Object {
+                  "hint": "A ticket available to pupils in full-time education",
+                  "label": "Academic term/year ticket",
+                  "value": "schoolService",
                 },
               ]
             }
@@ -275,11 +367,6 @@ exports[`pages fareType should render error messaging when errors are passed to 
                   "hint": "A ticket available to pupils in full-time education",
                   "label": "Academic term/year ticket",
                   "value": "schoolService",
-                },
-                Object {
-                  "hint": "A ticket that covers more than one operator",
-                  "label": "Multi-operator",
-                  "value": "multiOperator",
                 },
               ]
             }

--- a/repos/fdbt-site/tests/pages/fareType.test.tsx
+++ b/repos/fdbt-site/tests/pages/fareType.test.tsx
@@ -24,7 +24,15 @@ describe('pages', () => {
             );
             expect(tree).toMatchSnapshot();
         });
-
+        it('should render correctly on test env', () => {
+            process.env.STAGE = 'test';
+            const tree = shallow(
+                <FareType operatorName="Blackpool Transport" schemeOp={false} errors={[]} csrfToken="" />,
+            );
+            expect(tree).toMatchSnapshot();
+            process.env.STAGE = undefined;
+        });
+        
         it('should render correctly for a scheme operator', () => {
             const tree = shallow(<FareType operatorName="Blackpool Transport" schemeOp errors={[]} csrfToken="" />);
             expect(tree).toMatchSnapshot();

--- a/repos/fdbt-site/tests/pages/fareType.test.tsx
+++ b/repos/fdbt-site/tests/pages/fareType.test.tsx
@@ -32,7 +32,7 @@ describe('pages', () => {
             expect(tree).toMatchSnapshot();
             process.env.STAGE = undefined;
         });
-        
+
         it('should render correctly for a scheme operator', () => {
             const tree = shallow(<FareType operatorName="Blackpool Transport" schemeOp errors={[]} csrfToken="" />);
             expect(tree).toMatchSnapshot();


### PR DESCRIPTION
## Description

Using process.env.STAGE instead of process.env.NODE_ENV because we can't use NODE_ENV cant be used in a .tsx file.

## Testing instructions

Deploy to test and observe the fareType page.
