### PR TITLE
fix: Passenger type card ID's

### DIFF
--- a/repos/fdbt-site/src/components/PassengerTypeCard.tsx
+++ b/repos/fdbt-site/src/components/PassengerTypeCard.tsx
@@ -4,15 +4,21 @@ import { getProofDocumentsString, sentenceCaseString } from '../utils';
 
 interface PassengerTypeCardProps {
     contents: FullGroupPassengerType | SinglePassengerType;
+    index: number;
     deleteActionHandler?: (id: number, name: string, isGroup: boolean) => void;
     defaultChecked: boolean;
 }
 
-const PassengerTypeCard = ({ contents, deleteActionHandler, defaultChecked }: PassengerTypeCardProps): ReactElement => {
+const PassengerTypeCard = ({
+    contents,
+    index,
+    deleteActionHandler,
+    defaultChecked,
+}: PassengerTypeCardProps): ReactElement => {
     const { name, id } = contents;
     const isGroup = 'groupPassengerType' in contents;
     return (
-        <div className="card">
+        <div className="card" id={`${isGroup ? 'group-card' : 'passenger-card'}-${index}`}>
             <div className="card__body">
                 {deleteActionHandler ? (
                     <div className="card__actions">

--- a/repos/fdbt-site/src/pages/api/deletePassenger.ts
+++ b/repos/fdbt-site/src/pages/api/deletePassenger.ts
@@ -47,7 +47,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             const passengerDetails = (await getPassengerTypeById(id, nationalOperatorCode)) as SinglePassengerType;
             const { name } = passengerDetails;
             const errorMessage = `You cannot delete ${name} because it is being used in ${productsUsingPassengerType.length} products.`;
-            const errors: ErrorInfo[] = [{ id: '/viewPassengerTypes', errorMessage }];
+            const errors: ErrorInfo[] = [{ id: 'passenger-card-0', errorMessage }];
             updateSessionAttribute(req, VIEW_PASSENGER_TYPE, errors);
             redirectTo(res, `/viewPassengerTypes?cannotDelete=${name}`);
             return;

--- a/repos/fdbt-site/src/pages/selectPassengerType.tsx
+++ b/repos/fdbt-site/src/pages/selectPassengerType.tsx
@@ -66,9 +66,10 @@ const SelectPassengerType = ({
                                 <h3 className="govuk-heading-m">Individuals</h3>
 
                                 <div className="card-row" id="individual-passengers">
-                                    {savedPassengerTypes.map((passengerType) => (
+                                    {savedPassengerTypes.map((passengerType, index) => (
                                         <PassengerTypeCard
                                             defaultChecked={selectedId === passengerType.id}
+                                            index={index}
                                             contents={passengerType}
                                             key={passengerType.id.toString()}
                                         />
@@ -79,9 +80,10 @@ const SelectPassengerType = ({
                                 <div className="card-row">
                                     {savedGroups.length ? (
                                         <>
-                                            {savedGroups.map((passengerTypeGroup) => (
+                                            {savedGroups.map((passengerTypeGroup, index) => (
                                                 <PassengerTypeCard
                                                     contents={passengerTypeGroup}
+                                                    index={index}
                                                     key={passengerTypeGroup.id.toString()}
                                                     defaultChecked={selectedId === passengerTypeGroup.id}
                                                 />

--- a/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
+++ b/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
@@ -163,9 +163,10 @@ const IndividualPassengerTypes = ({
             <h2 className="govuk-heading-l">Individual</h2>
 
             <div className="card-row">
-                {singlePassengerTypes.map((singlePassengerType) => (
+                {singlePassengerTypes.map((singlePassengerType, index) => (
                     <PassengerTypeCard
                         contents={singlePassengerType}
+                        index={index}
                         deleteActionHandler={deleteActionHandler}
                         key={singlePassengerType.id.toString()}
                         defaultChecked={false}
@@ -203,9 +204,10 @@ const PassengerTypeGroups = ({ deleteActionHandler, passengerTypeGroups }: Passe
             <h2 className="govuk-heading-l">Groups</h2>
 
             <div className="card-row">
-                {passengerTypeGroups.map((passengerTypeGroup) => (
+                {passengerTypeGroups.map((passengerTypeGroup, index) => (
                     <PassengerTypeCard
                         contents={passengerTypeGroup}
+                        index={index}
                         deleteActionHandler={deleteActionHandler}
                         key={passengerTypeGroup.id}
                         defaultChecked={false}

--- a/repos/fdbt-site/tests/pages/__snapshots__/selectPassengerType.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/selectPassengerType.test.tsx.snap
@@ -165,6 +165,7 @@ exports[`pages selectPassengerType should render correctly with no saved groups 
               }
             }
             defaultChecked={false}
+            index={0}
             key="3"
           />
           <PassengerTypeCard
@@ -182,6 +183,7 @@ exports[`pages selectPassengerType should render correctly with no saved groups 
               }
             }
             defaultChecked={false}
+            index={1}
             key="2"
           />
         </div>
@@ -308,6 +310,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
               }
             }
             defaultChecked={false}
+            index={0}
             key="3"
           />
           <PassengerTypeCard
@@ -325,6 +328,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
               }
             }
             defaultChecked={false}
+            index={1}
             key="2"
           />
         </div>
@@ -370,6 +374,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
               }
             }
             defaultChecked={true}
+            index={0}
             key="1"
           />
           <PassengerTypeCard
@@ -396,6 +401,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
               }
             }
             defaultChecked={false}
+            index={1}
             key="4"
           />
         </div>
@@ -516,6 +522,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
               }
             }
             defaultChecked={false}
+            index={0}
             key="3"
           />
           <PassengerTypeCard
@@ -533,6 +540,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
               }
             }
             defaultChecked={false}
+            index={1}
             key="2"
           />
         </div>
@@ -578,6 +586,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
               }
             }
             defaultChecked={false}
+            index={0}
             key="1"
           />
           <PassengerTypeCard
@@ -604,6 +613,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
               }
             }
             defaultChecked={false}
+            index={1}
             key="4"
           />
         </div>


### PR DESCRIPTION
## Description

Giving passenger type cards ID's so they can be referenced in errors.

## Testing instructions

Attempt to delete a passenger type that is being used by a product, and then click on the red error you are shown. It should snap the user's focus to the passenger type list.
