### PR TITLE
Fix: Deleting Purchase Method breaks products

### DIFF
--- a/repos/fdbt-site/src/components/GlobalSettingsViewPage.tsx
+++ b/repos/fdbt-site/src/components/GlobalSettingsViewPage.tsx
@@ -63,7 +63,7 @@ export const GlobalSettingsViewPage = <T extends Entity>({
         <>
             <div className="card-row">
                 {entities.map((entity) => (
-                    <div className="card" key={entity.id}>
+                    <div className="card" key={entity.id} id={`${entity.id}`}>
                         <div className={'card__body ' + entityDescription.replace(/ /g, '-')}>
                             <div className="card__actions">
                                 <ul className="actions__list">

--- a/repos/fdbt-site/src/components/GlobalSettingsViewPage.tsx
+++ b/repos/fdbt-site/src/components/GlobalSettingsViewPage.tsx
@@ -1,8 +1,10 @@
 import { capitalize } from 'lodash';
 import React, { FunctionComponent, ReactElement, useState } from 'react';
+import { ErrorInfo } from 'src/interfaces';
 import DeleteConfirmationPopup from '../components/DeleteConfirmationPopup';
 import { BaseLayout } from '../layout/Layout';
 import SubNavigation from '../layout/SubNavigation';
+import ErrorSummary from './ErrorSummary';
 
 type Entity = { id: number; name: string };
 
@@ -14,6 +16,7 @@ interface GlobalSettingsViewPageProps<T extends Entity> {
     description: string;
     entityDescription: string;
     CardBody: FunctionComponent<{ entity: T }>;
+    errors?: ErrorInfo[];
 }
 
 export const GlobalSettingsViewPage = <T extends Entity>({
@@ -24,6 +27,7 @@ export const GlobalSettingsViewPage = <T extends Entity>({
     description,
     entityDescription,
     CardBody,
+    errors = [],
 }: GlobalSettingsViewPageProps<T>): ReactElement => {
     const entityUrl = entityDescription
         .split(' ')
@@ -99,6 +103,9 @@ export const GlobalSettingsViewPage = <T extends Entity>({
 
     return (
         <BaseLayout title={title} description={description} showNavigation referer={referer}>
+            <div>
+                <ErrorSummary errors={errors} />
+            </div>
             <div className="govuk-width-container" data-card-count={entities.length}>
                 <div className="govuk-grid-row">
                     <div className="govuk-grid-column-one-quarter">

--- a/repos/fdbt-site/src/constants/attributes.ts
+++ b/repos/fdbt-site/src/constants/attributes.ts
@@ -117,3 +117,5 @@ export const MATCHING_JSON_META_DATA_ATTRIBUTE = 'fdbt-matching-json-meta-data';
 export const RETURN_SERVICE_ATTRIBUTE = 'fdbt-return-service';
 
 export const VIEW_PASSENGER_TYPE = 'fdbt-products-using-passenger-type';
+
+export const VIEW_PURCHASE_METHOD = 'fdbt-products-using-purchase-method';

--- a/repos/fdbt-site/src/pages/api/deletePurchaseMethod.ts
+++ b/repos/fdbt-site/src/pages/api/deletePurchaseMethod.ts
@@ -28,7 +28,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             }),
         );
 
-        let productsUsingPurchaseMethod = [];
+        const productsUsingPurchaseMethod = [];
         for (const ticket of tickets) {
             for (const salesOfferPackage of ticket.products[0].salesOfferPackages) {
                 if (salesOfferPackage.id === id) {

--- a/repos/fdbt-site/src/pages/api/deletePurchaseMethod.ts
+++ b/repos/fdbt-site/src/pages/api/deletePurchaseMethod.ts
@@ -41,7 +41,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             const purchaseDetails = await getSalesOfferPackageByIdAndNoc(id, nocCode);
             const { name } = purchaseDetails;
             const errorMessage = `You cannot delete ${name} because it is being used in ${productsUsingPurchaseMethod.length} products.`;
-            const errors: ErrorInfo[] = [{ id: '/viewPurchaseMethods', errorMessage }];
+            const errors: ErrorInfo[] = [{ id: `${id}`, errorMessage }];
             updateSessionAttribute(req, VIEW_PURCHASE_METHOD, errors);
             redirectTo(res, `/viewPurchaseMethods?cannotDelete=${name}`);
             return;

--- a/repos/fdbt-site/src/pages/api/deletePurchaseMethod.ts
+++ b/repos/fdbt-site/src/pages/api/deletePurchaseMethod.ts
@@ -1,7 +1,14 @@
 import { NextApiResponse } from 'next';
-import { deleteSalesOfferPackageByNocCodeAndName } from '../../data/auroradb';
+import {
+    deleteSalesOfferPackageByNocCodeAndName,
+    getAllProductsByNoc,
+    getSalesOfferPackageByIdAndNoc,
+} from '../../data/auroradb';
 import { redirectToError, redirectTo, getAndValidateNoc } from '../../utils/apiUtils/index';
-import { NextApiRequestWithSession } from '../../interfaces';
+import { ErrorInfo, NextApiRequestWithSession } from '../../interfaces';
+import { getProductsMatchingJson } from 'src/data/s3';
+import { updateSessionAttribute } from 'src/utils/sessions';
+import { VIEW_PURCHASE_METHOD } from 'src/constants/attributes';
 
 export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
     try {
@@ -12,6 +19,34 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             throw new Error('insufficient data provided for delete query');
         }
         const nocCode = getAndValidateNoc(req, res);
+
+        const products = await getAllProductsByNoc(nocCode);
+        const matchingJsonLinks = products.map((product) => product.matchingJsonLink);
+        const tickets = await Promise.all(
+            matchingJsonLinks.map(async (link) => {
+                return await getProductsMatchingJson(link);
+            }),
+        );
+
+        let productsUsingPurchaseMethod = [];
+        for (const ticket of tickets) {
+            for (const salesOfferPackage of ticket.products[0].salesOfferPackages) {
+                if (salesOfferPackage.id === id) {
+                    productsUsingPurchaseMethod.push(ticket);
+                }
+            }
+        }
+
+        if (productsUsingPurchaseMethod.length > 0) {
+            const purchaseDetails = await getSalesOfferPackageByIdAndNoc(id, nocCode);
+            const { name } = purchaseDetails;
+            const errorMessage = `You cannot delete ${name} because it is being used in ${productsUsingPurchaseMethod.length} products.`;
+            const errors: ErrorInfo[] = [{ id: '/viewPurchaseMethods', errorMessage }];
+            updateSessionAttribute(req, VIEW_PURCHASE_METHOD, errors);
+            redirectTo(res, `/viewPurchaseMethods?cannotDelete=${name}`);
+            return;
+        }
+
         await deleteSalesOfferPackageByNocCodeAndName(id, nocCode);
 
         redirectTo(res, '/viewPurchaseMethods');

--- a/repos/fdbt-site/src/pages/viewPurchaseMethods.tsx
+++ b/repos/fdbt-site/src/pages/viewPurchaseMethods.tsx
@@ -2,10 +2,12 @@ import React, { FunctionComponent, ReactElement } from 'react';
 import { FromDb, SalesOfferPackage } from 'fdbt-types/matchingJsonTypes';
 import { GlobalSettingsViewPage } from '../components/GlobalSettingsViewPage';
 import { getSalesOfferPackagesByNocCode } from '../data/auroradb';
-import { NextPageContextWithSession } from '../interfaces';
+import { ErrorInfo, NextPageContextWithSession } from '../interfaces';
 import { formatSOPArray, getAndValidateNoc, getCsrfToken } from '../utils';
 import { extractGlobalSettingsReferer } from '../utils/globalSettings';
 import { sopTicketFormatConverter } from './salesConfirmation';
+import { VIEW_PURCHASE_METHOD } from 'src/constants/attributes';
+import { getSessionAttribute, updateSessionAttribute } from 'src/utils/sessions';
 
 const title = 'Purchase methods';
 const description =
@@ -15,9 +17,15 @@ interface PurchaseMethodProps {
     csrfToken: string;
     purchaseMethods: FromDb<SalesOfferPackage>[];
     referer: string | null;
+    viewPurchaseMethodErrors: ErrorInfo[];
 }
 
-const ViewPurchaseMethods = ({ purchaseMethods, referer, csrfToken }: PurchaseMethodProps): ReactElement => {
+const ViewPurchaseMethods = ({
+    purchaseMethods,
+    referer,
+    csrfToken,
+    viewPurchaseMethodErrors,
+}: PurchaseMethodProps): ReactElement => {
     return (
         <>
             <GlobalSettingsViewPage
@@ -28,6 +36,7 @@ const ViewPurchaseMethods = ({ purchaseMethods, referer, csrfToken }: PurchaseMe
                 title={title}
                 description={description}
                 CardBody={PurchaseMethodCardBody}
+                errors={viewPurchaseMethodErrors}
             />
         </>
     );
@@ -57,12 +66,16 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     const csrfToken = getCsrfToken(ctx);
     const nationalOperatorCode = getAndValidateNoc(ctx);
     const purchaseMethods = await getSalesOfferPackagesByNocCode(nationalOperatorCode);
+    const viewPurchaseMethod = getSessionAttribute(ctx.req, VIEW_PURCHASE_METHOD);
+
+    updateSessionAttribute(ctx.req, VIEW_PURCHASE_METHOD, undefined);
 
     return {
         props: {
             purchaseMethods: purchaseMethods,
             referer: extractGlobalSettingsReferer(ctx),
             csrfToken,
+            viewPurchaseMethodErrors: viewPurchaseMethod || [],
         },
     };
 };

--- a/repos/fdbt-site/src/pages/viewPurchaseMethods.tsx
+++ b/repos/fdbt-site/src/pages/viewPurchaseMethods.tsx
@@ -6,8 +6,8 @@ import { ErrorInfo, NextPageContextWithSession } from '../interfaces';
 import { formatSOPArray, getAndValidateNoc, getCsrfToken } from '../utils';
 import { extractGlobalSettingsReferer } from '../utils/globalSettings';
 import { sopTicketFormatConverter } from './salesConfirmation';
-import { VIEW_PURCHASE_METHOD } from 'src/constants/attributes';
-import { getSessionAttribute, updateSessionAttribute } from 'src/utils/sessions';
+import { VIEW_PURCHASE_METHOD } from '../constants/attributes';
+import { getSessionAttribute, updateSessionAttribute } from '../utils/sessions';
 
 const title = 'Purchase methods';
 const description =

--- a/repos/fdbt-site/src/utils/sessions.ts
+++ b/repos/fdbt-site/src/utils/sessions.ts
@@ -61,6 +61,7 @@ import {
     GS_PURCHASE_METHOD_ATTRIBUTE,
     GS_OPERATOR_DETAILS_ATTRIBUTE,
     VIEW_PASSENGER_TYPE,
+    VIEW_PURCHASE_METHOD,
 } from '../constants/attributes';
 import {
     CompanionInfo,
@@ -202,6 +203,7 @@ export interface SessionAttributeTypes {
     [GS_REFERER]: string;
     [CSV_ZONE_FILE_NAME]: string;
     [VIEW_PASSENGER_TYPE]: ErrorInfo[];
+    [VIEW_PURCHASE_METHOD]: ErrorInfo[];
 }
 
 export type SessionAttribute<T extends string> = T extends keyof SessionAttributeTypes

--- a/repos/fdbt-site/tests/components/__snapshots__/GlobalSettingsViewPage.test.tsx.snap
+++ b/repos/fdbt-site/tests/components/__snapshots__/GlobalSettingsViewPage.test.tsx.snap
@@ -7,6 +7,11 @@ exports[`GlobalSettingsViewPage should render correctly when entities exist 1`] 
   showNavigation={true}
   title="my title"
 >
+  <div>
+    <ErrorSummary
+      errors={Array []}
+    />
+  </div>
   <div
     className="govuk-width-container"
     data-card-count={3}
@@ -37,6 +42,7 @@ exports[`GlobalSettingsViewPage should render correctly when entities exist 1`] 
         >
           <div
             className="card"
+            id="7"
             key="7"
           >
             <div
@@ -82,6 +88,7 @@ exports[`GlobalSettingsViewPage should render correctly when entities exist 1`] 
           </div>
           <div
             className="card"
+            id="17"
             key="17"
           >
             <div
@@ -127,6 +134,7 @@ exports[`GlobalSettingsViewPage should render correctly when entities exist 1`] 
           </div>
           <div
             className="card"
+            id="1"
             key="1"
           >
             <div
@@ -192,6 +200,11 @@ exports[`GlobalSettingsViewPage should render correctly when no entities 1`] = `
   showNavigation={true}
   title="my title"
 >
+  <div>
+    <ErrorSummary
+      errors={Array []}
+    />
+  </div>
   <div
     className="govuk-width-container"
     data-card-count={0}


### PR DESCRIPTION
## Description

Currently we give a warning if the user attempts to delete a purchase method which is used in a product, but if they click delete then we delete it anyway. This causes an error later on.

We should instead just not let the user delete - if possible we should give the number of products the purchase type is connected to, so they can go and edit those products.

## Testing instructions

Case 1:
Make a product and connect it to a purchase method.
Try delete the purchase method.
An error message on the page should appear.

All valid examples:
You cannot delete 123 because it is being used in 3 products.

Case 2:
Make a purchase method alone that is not connected to a product.
Try deleting this.
It should be removed.

Note to add a purchase method navigate to View and manage fares > Operator settings > Purchase Methods
