### PR TITLE
fix: Deleting Time Restrictions Breaks Products

### DIFF
--- a/repos/fdbt-site/src/constants/attributes.ts
+++ b/repos/fdbt-site/src/constants/attributes.ts
@@ -123,3 +123,5 @@ export const VIEW_PASSENGER_TYPE = 'fdbt-products-using-passenger-type';
 export const VIEW_PURCHASE_METHOD = 'fdbt-products-using-purchase-method';
 
 export const MANAGE_OPERATOR_GROUP_ERRORS_ATTRIBUTE = 'fdbt-manage-operator-group-errors';
+
+export const VIEW_TIME_RESTRICTION = 'fdbt-products-using-time-restriction';

--- a/repos/fdbt-site/src/pages/api/deletePassenger.ts
+++ b/repos/fdbt-site/src/pages/api/deletePassenger.ts
@@ -46,7 +46,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
         if (productsUsingPassengerType.length > 0) {
             const passengerDetails = (await getPassengerTypeById(id, nationalOperatorCode)) as SinglePassengerType;
             const { name } = passengerDetails;
-            const errorMessage = `You cannot delete ${name} because it is being used in ${productsUsingPassengerType.length} products.`;
+            const errorMessage = `You cannot delete ${name} because it is being used in ${productsUsingPassengerType.length} product(s).`;
             const errors: ErrorInfo[] = [{ id: 'passenger-card-0', errorMessage }];
             updateSessionAttribute(req, VIEW_PASSENGER_TYPE, errors);
             redirectTo(res, `/viewPassengerTypes?cannotDelete=${name}`);

--- a/repos/fdbt-site/src/pages/api/deletePurchaseMethod.ts
+++ b/repos/fdbt-site/src/pages/api/deletePurchaseMethod.ts
@@ -40,7 +40,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
         if (productsUsingPurchaseMethod.length > 0) {
             const purchaseDetails = await getSalesOfferPackageByIdAndNoc(id, nocCode);
             const { name } = purchaseDetails;
-            const errorMessage = `You cannot delete ${name} because it is being used in ${productsUsingPurchaseMethod.length} products.`;
+            const errorMessage = `You cannot delete ${name} because it is being used in ${productsUsingPurchaseMethod.length} product(s).`;
             const errors: ErrorInfo[] = [{ id: `${id}`, errorMessage }];
             updateSessionAttribute(req, VIEW_PURCHASE_METHOD, errors);
             redirectTo(res, `/viewPurchaseMethods?cannotDelete=${name}`);

--- a/repos/fdbt-site/src/pages/api/deleteTimeRestriction.ts
+++ b/repos/fdbt-site/src/pages/api/deleteTimeRestriction.ts
@@ -1,7 +1,14 @@
 import { NextApiResponse } from 'next';
-import { deleteTimeRestrictionByIdAndNocCode } from '../../data/auroradb';
+import {
+    deleteTimeRestrictionByIdAndNocCode,
+    getAllProductsByNoc,
+    getTimeRestrictionByIdAndNoc,
+} from '../../data/auroradb';
 import { redirectToError, redirectTo, getAndValidateNoc } from '../../utils/apiUtils/index';
-import { NextApiRequestWithSession } from '../../interfaces';
+import { ErrorInfo, NextApiRequestWithSession } from '../../interfaces';
+import { getProductsMatchingJson } from '../../data/s3';
+import { updateSessionAttribute } from '../../utils/sessions';
+import { VIEW_TIME_RESTRICTION } from '../../constants/attributes';
 
 export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
     try {
@@ -10,6 +17,26 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
         const id = Number(query?.id);
 
         const nationalOperatorCode = getAndValidateNoc(req, res);
+
+        const products = await getAllProductsByNoc(nationalOperatorCode);
+        const matchingJsonLinks = products.map((product) => product.matchingJsonLink);
+        const tickets = await Promise.all(
+            matchingJsonLinks.map(async (link) => {
+                return await getProductsMatchingJson(link);
+            }),
+        );
+
+        const productsUsingTimeRestrictions = tickets.filter((t) => t.timeRestriction?.id === id);
+
+        if (productsUsingTimeRestrictions.length > 0) {
+            const timeRestrictionDetails = await getTimeRestrictionByIdAndNoc(id, nationalOperatorCode);
+            const { name } = timeRestrictionDetails;
+            const errorMessage = `You cannot delete ${name} because it is being used in ${productsUsingTimeRestrictions.length} product(s).`;
+            const errors: ErrorInfo[] = [{ id: `${id}`, errorMessage }];
+            updateSessionAttribute(req, VIEW_TIME_RESTRICTION, errors);
+            redirectTo(res, `/viewTimeRestrictions?cannotDelete=${name}`);
+            return;
+        }
 
         await deleteTimeRestrictionByIdAndNocCode(id, nationalOperatorCode);
 

--- a/repos/fdbt-site/src/utils/sessions.ts
+++ b/repos/fdbt-site/src/utils/sessions.ts
@@ -63,6 +63,7 @@ import {
     VIEW_PASSENGER_TYPE,
     VIEW_PURCHASE_METHOD,
     MANAGE_OPERATOR_GROUP_ERRORS_ATTRIBUTE,
+    VIEW_TIME_RESTRICTION,
 } from '../constants/attributes';
 import {
     CompanionInfo,
@@ -207,6 +208,7 @@ export interface SessionAttributeTypes {
     [CSV_ZONE_FILE_NAME]: string;
     [VIEW_PASSENGER_TYPE]: ErrorInfo[];
     [VIEW_PURCHASE_METHOD]: ErrorInfo[];
+    [VIEW_TIME_RESTRICTION]: ErrorInfo[];
 }
 
 export type SessionAttribute<T extends string> = T extends keyof SessionAttributeTypes


### PR DESCRIPTION
## Description
Currently we give a warning if the user attempts to delete a time restriction which is used in a product, but if they click delete then we delete it anyway. This causes an error later on.

We should instead just not let the user delete - if possible we should give the number of products the purchase type is connected to, so they can go and edit those products.

## Testing instructions
Case 1:
Make a product and connect it to a time restriction.
Try delete the time restriction.
An error message on the page should appear.

All valid examples:
You cannot delete 123 because it is being used in 3 product(s).

Case 2:
Make a time restriction alone that is not connected to a product.
Try deleting this.
It should be removed.

Note to add a time restriction navigate to View and manage fares > Operator settings > Time Restrictions