### PR TITLE
fix: Deleting products now deletes in S3

### DIFF
--- a/repos/fdbt-site/src/data/s3.ts
+++ b/repos/fdbt-site/src/data/s3.ts
@@ -257,3 +257,16 @@ export const getS3Exports = async (noc: string): Promise<string[]> => {
         }) || []
     );
 };
+
+export const deleteFromS3 = async (key: string, bucketName: string): Promise<void> => {
+    try {
+        logger.info('', {
+            context: 'data.s3',
+            message: `Deleting ${key} in ${bucketName}`,
+        });
+        const bucketParams = { Bucket: bucketName, Key: key };
+        await s3.deleteObject(bucketParams).promise();
+    } catch (error) {
+        throw new Error(`Deletion of ${key} in ${bucketName} unsuccessful: ${(error as Error).stack}`);
+    }
+};

--- a/repos/fdbt-site/src/pages/api/deleteProduct.ts
+++ b/repos/fdbt-site/src/pages/api/deleteProduct.ts
@@ -1,5 +1,5 @@
 import { NextApiResponse } from 'next';
-import { deleteProductByNocCodeAndId } from '../../data/auroradb';
+import { deleteProductByNocCodeAndId, getProductById } from '../../data/auroradb';
 import { redirectToError, redirectTo, getAndValidateNoc } from '../../utils/apiUtils';
 import { NextApiRequestWithSession } from '../../interfaces';
 
@@ -12,6 +12,9 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
         }
 
         const nationalOperatorCode = getAndValidateNoc(req, res);
+
+        const product = await getProductById(nationalOperatorCode, id.toString());
+        const { matchingJsonLink } = product;
 
         await deleteProductByNocCodeAndId(id, nationalOperatorCode);
 

--- a/repos/fdbt-site/src/pages/api/deleteProduct.ts
+++ b/repos/fdbt-site/src/pages/api/deleteProduct.ts
@@ -2,6 +2,8 @@ import { NextApiResponse } from 'next';
 import { deleteProductByNocCodeAndId, getProductById } from '../../data/auroradb';
 import { redirectToError, redirectTo, getAndValidateNoc } from '../../utils/apiUtils';
 import { NextApiRequestWithSession } from '../../interfaces';
+import { deleteFromS3 } from '../../data/s3';
+import { MATCHING_DATA_BUCKET_NAME } from '../../constants';
 
 export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
     try {
@@ -16,6 +18,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
         const product = await getProductById(nationalOperatorCode, id.toString());
         const { matchingJsonLink } = product;
 
+        await deleteFromS3(matchingJsonLink, MATCHING_DATA_BUCKET_NAME);
         await deleteProductByNocCodeAndId(id, nationalOperatorCode);
 
         redirectTo(res, req.headers.referer ?? '/products/services');

--- a/repos/fdbt-site/src/pages/globalSettings.tsx
+++ b/repos/fdbt-site/src/pages/globalSettings.tsx
@@ -64,16 +64,16 @@ const GlobalSettings = ({ globalSettingsCounts, referer }: GlobalSettingsProps):
                             count={globalSettingsCounts.fareDayEndSet}
                         />
                         <SettingOverview
-                            href="/manageOperatorDetails"
-                            name="Operator details"
-                            description="Define your operator contact details - these will be included in your fares data and therefore may be presented to passengers"
-                            count={globalSettingsCounts.operatorDetailsSet}
-                        />
-                        <SettingOverview
                             href="/viewOperatorGroups"
                             name="Operator groups"
                             description="Define your operator groups - these will be used in multi operator tickets"
                             count={globalSettingsCounts.operatorGroupsCount}
+                        />
+                        <SettingOverview
+                            href="/manageOperatorDetails"
+                            name="Operator details"
+                            description="Define your operator contact details - these will be included in your fares data and therefore may be presented to passengers"
+                            count={globalSettingsCounts.operatorDetailsSet}
                         />
                     </div>
                 </div>

--- a/repos/fdbt-site/tests/pages/__snapshots__/globalSettings.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/globalSettings.test.tsx.snap
@@ -57,15 +57,15 @@ exports[`pages globalSettings should render correctly 1`] = `
           name="Fare day end"
         />
         <SettingOverview
+          description="Define your operator groups - these will be used in multi operator tickets"
+          href="/viewOperatorGroups"
+          name="Operator groups"
+        />
+        <SettingOverview
           count={true}
           description="Define your operator contact details - these will be included in your fares data and therefore may be presented to passengers"
           href="/manageOperatorDetails"
           name="Operator details"
-        />
-        <SettingOverview
-          description="Define your operator groups - these will be used in multi operator tickets"
-          href="/viewOperatorGroups"
-          name="Operator groups"
         />
       </div>
     </div>


### PR DESCRIPTION
## Description

Previously when a product was being deleted, it was only being deleted from the DB and the s3 product was being left behind. 

## Testing instructions

Delete a product, and then check the s3 bucket to see if it was removed from there also.
