### PR TITLE
fix: Removing deletion for matching bucket

### DIFF
--- a/fdbt-aws/cloudformation/service/eu-west-2/iam.yml
+++ b/fdbt-aws/cloudformation/service/eu-west-2/iam.yml
@@ -176,7 +176,6 @@ Resources:
                 Action:
                   - "s3:DeleteObject"
                 Resource:
-                  - !Sub arn:aws:s3:::fdbt-matching-data-${Stage}/*
                   - !Sub arn:aws:s3:::fdbt-products-data-${Stage}/*
               - Effect: Allow
                 Action:

--- a/repos/fdbt-site/src/pages/api/deleteProduct.ts
+++ b/repos/fdbt-site/src/pages/api/deleteProduct.ts
@@ -3,7 +3,7 @@ import { deleteProductByNocCodeAndId, getProductById } from '../../data/auroradb
 import { redirectToError, redirectTo, getAndValidateNoc } from '../../utils/apiUtils';
 import { NextApiRequestWithSession } from '../../interfaces';
 import { deleteFromS3 } from '../../data/s3';
-import { MATCHING_DATA_BUCKET_NAME, PRODUCTS_DATA_BUCKET_NAME } from '../../constants';
+import { PRODUCTS_DATA_BUCKET_NAME } from '../../constants';
 
 export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
     try {
@@ -18,7 +18,6 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
         const product = await getProductById(nationalOperatorCode, id.toString());
         const { matchingJsonLink } = product;
 
-        await deleteFromS3(matchingJsonLink, MATCHING_DATA_BUCKET_NAME);
         await deleteFromS3(matchingJsonLink, PRODUCTS_DATA_BUCKET_NAME);
         await deleteProductByNocCodeAndId(id, nationalOperatorCode);
 


### PR DESCRIPTION
## Description

We cannot delete from the matching bucket for a product as we dont know the name of the export associated.

## Testing instructions

N/A
