### PR TITLE
fix: Added an hour check for when the user can cancel

### DIFF
--- a/fdbt-aws/cloudformation/service/eu-west-2/iam.yml
+++ b/fdbt-aws/cloudformation/service/eu-west-2/iam.yml
@@ -195,6 +195,7 @@ Resources:
                   - !Sub arn:aws:s3:::fdbt-matching-data-${Stage}
                   - !Sub arn:aws:s3:::fdbt-products-data-${Stage}
                   - !Sub arn:aws:s3:::fdbt-netex-data-${Stage}
+                  - !Sub arn:aws:s3:::fdbt-unvalidated-netex-data-${Stage}
               - Effect: Allow
                 Action:
                   - "s3:PutObject"

--- a/repos/fdbt-site/src/data/s3.ts
+++ b/repos/fdbt-site/src/data/s3.ts
@@ -244,6 +244,22 @@ export const getS3FolderCount = async (bucketName: string, path: string): Promis
     return (response.CommonPrefixes?.length ?? 0) + (response.Contents?.length ?? 0);
 };
 
+export const getFileCreationDate = async (bucketName: string, path: string): Promise<Date | undefined> => {
+    const response = await s3
+        .listObjectsV2({
+            Bucket: bucketName,
+            Prefix: path,
+            Delimiter: '/',
+        })
+        .promise();
+
+    if (!response.Contents || !(response.Contents?.length > 0)) {
+        return undefined;
+    }
+
+    return response.Contents[0].LastModified;
+};
+
 export const getS3Exports = async (noc: string): Promise<string[]> => {
     const response = await s3
         .listObjectsV2({

--- a/repos/fdbt-site/tests/pages/products/__snapshots__/exports.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/products/__snapshots__/exports.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`pages confirmRegistration should render correctly without data when operator has no products 1`] = `
+exports[`pages exports should render correctly without data when operator has no products 1`] = `
 <Fragment>
   <BaseLayout
     description="View and access your settings in one place."
@@ -73,7 +73,7 @@ exports[`pages confirmRegistration should render correctly without data when ope
 </Fragment>
 `;
 
-exports[`pages confirmRegistration should render the export button correctly when operator has products 1`] = `
+exports[`pages exports should render the export button correctly when operator has products 1`] = `
 <Fragment>
   <BaseLayout
     description="View and access your settings in one place."

--- a/repos/fdbt-site/tests/pages/products/exports.test.tsx
+++ b/repos/fdbt-site/tests/pages/products/exports.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import Exports from '../../../src/pages/products/exports';
+import Exports, { exportStartedOverAnHourAgo } from '../../../src/pages/products/exports';
 
 describe('pages', () => {
-    describe('confirmRegistration', () => {
+    describe('exports', () => {
         it('should render correctly without data when operator has no products', () => {
             const tree = shallow(<Exports csrf={''} operatorHasProducts={false} />);
             expect(tree).toMatchSnapshot();
@@ -12,6 +12,32 @@ describe('pages', () => {
         it('should render the export button correctly when operator has products', () => {
             const tree = shallow(<Exports csrf={''} operatorHasProducts={true} />);
             expect(tree).toMatchSnapshot();
+        });
+    });
+
+    describe('exportStartedOverAnHourAgo', () => {
+        it('returns true if the export started over an hour ago', () => {
+            const testExport = {
+                name: 'test',
+                matchingDataCount: 2,
+                netexCount: 3,
+                exportStarted: new Date('2022-06-17T03:24:00'),
+            };
+            const result = exportStartedOverAnHourAgo(testExport);
+
+            expect(result).toBeTruthy();
+        });
+
+        it('returns false if the export started less than an hour ago', () => {
+            const testExport = {
+                name: 'test',
+                matchingDataCount: 2,
+                netexCount: 3,
+                exportStarted: new Date(),
+            };
+            const result = exportStartedOverAnHourAgo(testExport);
+
+            expect(result).toBeFalsy();
         });
     });
 });


### PR DESCRIPTION
## Description

Stopping the user from cancelling the export until an hour has passed.

## Testing instructions

Run an export on test, wait until it has finished and then delete one of the .xml files from the netex s3 bucket relating to that export. An hour later, the cancel button should appear.
