### PR TITLE
fix: Product details page not loading for multiple services with lineId if adding service in return ticket

### DIFF
--- a/repos/fdbt-site/fdbt-types/matchingJsonTypes.ts
+++ b/repos/fdbt-site/fdbt-types/matchingJsonTypes.ts
@@ -27,6 +27,10 @@ export interface SelectedService {
     serviceDescription: string;
 }
 
+export interface AdditionalService extends SelectedService {
+    serviceId: number;
+}
+
 export interface PeriodMultipleServicesTicket extends BasePeriodTicket {
     selectedServices: SelectedService[];
     termTime: boolean;
@@ -226,7 +230,7 @@ export interface ReturnTicket extends BasePointToPointTicket {
     inboundFareZones: FareZone[];
     outboundFareZones: FareZone[];
     returnPeriodValidity?: ReturnPeriodValidity;
-    additionalServices?: SelectedService[];
+    additionalServices?: AdditionalService[];
 }
 
 export interface Product {

--- a/repos/fdbt-site/src/pages/api/returnService.ts
+++ b/repos/fdbt-site/src/pages/api/returnService.ts
@@ -45,6 +45,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                     lineName: service.lineName,
                     lineId: service.lineId,
                     serviceDescription: service.serviceDescription,
+                    serviceId: serviceId,
                 },
             ],
         };

--- a/repos/fdbt-site/src/pages/products/productDetails.tsx
+++ b/repos/fdbt-site/src/pages/products/productDetails.tsx
@@ -8,7 +8,6 @@ import {
     getTimeRestrictionByIdAndNoc,
     getBodsServiceDirectionDescriptionsByNocAndServiceId,
     getServiceByIdAndDataSource,
-    getBodsServiceByNocAndLineId,
 } from '../../data/auroradb';
 import { ProductDetailsElement, NextPageContextWithSession, ProductDateInformation } from '../../interfaces';
 import TwoThirdsLayout from '../../layout/Layout';
@@ -253,7 +252,7 @@ const createProductDetails = async (
 
         const additionalService =
             isReturnTicket(ticket) && ticket.additionalServices && ticket.additionalServices.length > 0
-                ? await getBodsServiceByNocAndLineId(noc, ticket.additionalServices[0].lineId)
+                ? await getBodsServiceByNocAndId(noc, ticket.additionalServices[0].serviceId.toString())
                 : undefined;
 
         productDetailsElements.push({

--- a/repos/fdbt-site/tests/pages/api/returnService.test.ts
+++ b/repos/fdbt-site/tests/pages/api/returnService.test.ts
@@ -85,6 +85,7 @@ describe('returnService', () => {
                         lineName: '17',
                         serviceDescription:
                             '\n\t\t\t\tInterchange Stand B,Seaham - Estate (Hail and Ride) N/B,Westlea\n\t\t\t',
+                        serviceId: 4,
                     },
                 ],
             },

--- a/repos/fdbt-site/tests/testData/mockData.ts
+++ b/repos/fdbt-site/tests/testData/mockData.ts
@@ -1711,6 +1711,7 @@ export const expectedReturnTicketWithAdditionalService: WithIds<ReturnTicket> = 
             serviceCode: 'NW_05_BLAC_12A_1',
             startDate: '13/05/2020',
             serviceDescription: 'Infinity Works, Leeds - Infinity Works, Manchester',
+            serviceId: 1,
         },
     ],
     products: [

--- a/repos/fdbt-types/matchingJsonTypes.ts
+++ b/repos/fdbt-types/matchingJsonTypes.ts
@@ -26,6 +26,9 @@ export interface SelectedService {
     serviceDescription: string;
 }
 
+export interface AdditionalService extends SelectedService {
+    serviceId: number;
+}
 export interface PeriodMultipleServicesTicket extends BasePeriodTicket {
     selectedServices: SelectedService[];
     termTime: boolean;
@@ -224,7 +227,7 @@ export interface ReturnTicket extends BasePointToPointTicket {
     inboundFareZones: FareZone[];
     outboundFareZones: FareZone[];
     returnPeriodValidity?: ReturnPeriodValidity;
-    additionalServices?: SelectedService[];
+    additionalServices?: AdditionalService[];
 }
 
 export interface Product {


### PR DESCRIPTION
## Description

Product details page not loading when the multiple services are associated with the same lineId. The service Id to be used for fetching the service details in additional service for return ticket

## Testing instructions

Create a return ticket and add a service which has the lineId used in another service.
