### PR TITLE
feat: Group of lines

### DIFF
--- a/fdbt-dev/data/netexData/carnetFlatFare.xml
+++ b/fdbt-dev/data/netexData/carnetFlatFare.xml
@@ -161,20 +161,7 @@
                     <TypeOfAccessRightAssignmentRef version="fxc:v1.0" ref="fxc:can_access"/>
                     <ValidityParameterGroupingType>OR</ValidityParameterGroupingType>
                     <validityParameters>
-                      <LineRef version="1.0" ref="PK1146649_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ2_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ4_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ19_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ01_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ02_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ05_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ9_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ014_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ018_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ011_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ003_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ007_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ006_Outbound"/>
+                      <GroupOfLinesRef version="1.0" ref="BLAC@groupOfLines@1"/>
                     </validityParameters>
                   </GenericParameterAssignment>
                 </FareStructureElement>

--- a/fdbt-dev/data/netexData/carnetPeriodMultiService.xml
+++ b/fdbt-dev/data/netexData/carnetPeriodMultiService.xml
@@ -237,20 +237,7 @@
                     <TypeOfAccessRightAssignmentRef version="fxc:v1.0" ref="fxc:can_access"/>
                     <ValidityParameterGroupingType>OR</ValidityParameterGroupingType>
                     <validityParameters>
-                      <LineRef version="1.0" ref="PK1146649_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ2_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ4_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ19_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ01_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ02_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ05_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ9_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ014_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ018_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ011_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ003_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ007_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ006_Outbound"/>
+                      <GroupOfLinesRef version="1.0" ref="BLAC@groupOfLines@1"/>
                     </validityParameters>
                   </GenericParameterAssignment>
                 </FareStructureElement>

--- a/fdbt-dev/data/netexData/flatFare.xml
+++ b/fdbt-dev/data/netexData/flatFare.xml
@@ -151,20 +151,7 @@
                     <TypeOfAccessRightAssignmentRef version="fxc:v1.0" ref="fxc:can_access"/>
                     <ValidityParameterGroupingType>OR</ValidityParameterGroupingType>
                     <validityParameters>
-                      <LineRef version="1.0" ref="PK1146649_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ2_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ4_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ19_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ01_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ02_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ05_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ9_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ014_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ018_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ011_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ003_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ007_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ006_Outbound"/>
+                      <GroupOfLinesRef version="1.0" ref="BLAC@groupOfLines@1"/>
                     </validityParameters>
                   </GenericParameterAssignment>
                 </FareStructureElement>

--- a/fdbt-dev/data/netexData/flatFareGroup.xml
+++ b/fdbt-dev/data/netexData/flatFareGroup.xml
@@ -247,20 +247,7 @@
                     <TypeOfAccessRightAssignmentRef version="fxc:v1.0" ref="fxc:can_access"/>
                     <ValidityParameterGroupingType>OR</ValidityParameterGroupingType>
                     <validityParameters>
-                      <LineRef version="1.0" ref="PK1146649_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ2_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ4_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ19_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ01_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ02_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ05_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ9_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ014_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ018_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ011_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ003_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ007_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ006_Outbound"/>
+                      <GroupOfLinesRef version="1.0" ref="BLAC@groupOfLines@1"/>
                     </validityParameters>
                   </GenericParameterAssignment>
                 </FareStructureElement>

--- a/fdbt-dev/data/netexData/flatFareWithSopPrices.xml
+++ b/fdbt-dev/data/netexData/flatFareWithSopPrices.xml
@@ -151,9 +151,7 @@
                     <TypeOfAccessRightAssignmentRef version="fxc:v1.0" ref="fxc:can_access"/>
                     <ValidityParameterGroupingType>OR</ValidityParameterGroupingType>
                     <validityParameters>
-                      <LineRef version="1.0" ref="lzkklu"/>
-                      <LineRef version="1.0" ref="wido2q"/>
-                      <LineRef version="1.0" ref="TgBKhM"/>
+                      <GroupOfLinesRef version="1.0" ref="WBTR@groupOfLines@1"/>
                     </validityParameters>
                   </GenericParameterAssignment>
                 </FareStructureElement>

--- a/fdbt-dev/data/netexData/multiOpMultiServices.xml
+++ b/fdbt-dev/data/netexData/multiOpMultiServices.xml
@@ -233,26 +233,7 @@
                     <TypeOfAccessRightAssignmentRef version="fxc:v1.0" ref="fxc:can_access"/>
                     <ValidityParameterGroupingType>OR</ValidityParameterGroupingType>
                     <validityParameters>
-                      <LineRef version="1.0" ref="AD1146649_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="FD1146649_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="XC1146649_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146639_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="PK133146649_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="PK121146649_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="AD11466334_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="AD1146567_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="AD114878_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="AG245453_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="AA2454563_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="AZ2451113_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="AW245466666_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="SG2423D3_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="AG24D5G3_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="SSSG24453_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="SSSG2321453_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="SSSG24467H_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="SSSG251D67H_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="SDDSG24447H_RJ1_Outbound"/>
+                      <GroupOfLinesRef version="1.0" ref="BLAC@groupOfLines@1"/>
                     </validityParameters>
                   </GenericParameterAssignment>
                 </FareStructureElement>

--- a/fdbt-dev/data/netexData/periodMultiService.xml
+++ b/fdbt-dev/data/netexData/periodMultiService.xml
@@ -227,20 +227,7 @@
                     <TypeOfAccessRightAssignmentRef version="fxc:v1.0" ref="fxc:can_access"/>
                     <ValidityParameterGroupingType>OR</ValidityParameterGroupingType>
                     <validityParameters>
-                      <LineRef version="1.0" ref="PK1146649_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ2_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ4_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ19_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ01_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ02_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ05_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ9_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ014_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ018_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ011_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ003_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ007_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ006_Outbound"/>
+                      <GroupOfLinesRef version="1.0" ref="BLAC@groupOfLines@1"/>
                     </validityParameters>
                   </GenericParameterAssignment>
                 </FareStructureElement>

--- a/fdbt-dev/data/netexData/schemeCarnetFlatFare.xml
+++ b/fdbt-dev/data/netexData/schemeCarnetFlatFare.xml
@@ -169,7 +169,7 @@
                     <TypeOfAccessRightAssignmentRef version="fxc:v1.0" ref="fxc:can_access"/>
                     <ValidityParameterGroupingType>OR</ValidityParameterGroupingType>
                     <validityParameters>
-                      <LineRef version="1.0" ref="ZgvsrC"/>
+                      <GroupOfLinesRef version="1.0" ref="Test_Scheme_Op-SE@groupOfLines@1"/>
                     </validityParameters>
                   </GenericParameterAssignment>
                 </FareStructureElement>

--- a/fdbt-dev/data/netexData/schemeCarnetMultipleServices.xml
+++ b/fdbt-dev/data/netexData/schemeCarnetMultipleServices.xml
@@ -190,9 +190,7 @@
                     <TypeOfAccessRightAssignmentRef version="fxc:v1.0" ref="fxc:can_access"/>
                     <ValidityParameterGroupingType>OR</ValidityParameterGroupingType>
                     <validityParameters>
-                      <LineRef version="1.0" ref="lDJRAS"/>
-                      <LineRef version="1.0" ref="A2EHwY"/>
-                      <LineRef version="1.0" ref="DnmNdy"/>
+                      <GroupOfLinesRef version="1.0" ref="Test_Scheme_Op-SE@groupOfLines@1"/>
                     </validityParameters>
                   </GenericParameterAssignment>
                 </FareStructureElement>

--- a/fdbt-dev/data/netexData/schemeOperatorFlatFare.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorFlatFare.xml
@@ -174,12 +174,7 @@
                     <TypeOfAccessRightAssignmentRef version="fxc:v1.0" ref="fxc:can_access"/>
                     <ValidityParameterGroupingType>OR</ValidityParameterGroupingType>
                     <validityParameters>
-                      <LineRef version="1.0" ref="AD1146649_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="FD1146649_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="XC1146649_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146639_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="PK133146649_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="PK121146649_RJ1_Outbound"/>
+                      <GroupOfLinesRef version="1.0" ref="IW_Buses-Y@groupOfLines@1"/>
                     </validityParameters>
                   </GenericParameterAssignment>
                 </FareStructureElement>

--- a/fdbt-dev/data/netexData/schemeOperatorMultiServices.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorMultiServices.xml
@@ -236,10 +236,7 @@
                     <TypeOfAccessRightAssignmentRef version="fxc:v1.0" ref="fxc:can_access"/>
                     <ValidityParameterGroupingType>OR</ValidityParameterGroupingType>
                     <validityParameters>
-                      <LineRef version="1.0" ref="Mon1JJ"/>
-                      <LineRef version="1.0" ref="rLjpBT"/>
-                      <LineRef version="1.0" ref="M0L2FP"/>
-                      <LineRef version="1.0" ref="BptR81"/>
+                      <GroupOfLinesRef version="1.0" ref="Test_Scheme_Op-SE@groupOfLines@1"/>
                     </validityParameters>
                   </GenericParameterAssignment>
                 </FareStructureElement>

--- a/fdbt-dev/data/netexData/schoolPeriodMultiService.xml
+++ b/fdbt-dev/data/netexData/schoolPeriodMultiService.xml
@@ -230,20 +230,7 @@
                     <TypeOfAccessRightAssignmentRef version="fxc:v1.0" ref="fxc:can_access"/>
                     <ValidityParameterGroupingType>OR</ValidityParameterGroupingType>
                     <validityParameters>
-                      <LineRef version="1.0" ref="PK1146649_RJ1_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ2_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ4_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ19_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ01_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ02_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ05_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ9_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ014_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ018_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ011_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ003_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ007_Outbound"/>
-                      <LineRef version="1.0" ref="PK1146649_RJ006_Outbound"/>
+                      <GroupOfLinesRef version="1.0" ref="BLAC@groupOfLines@1"/>
                     </validityParameters>
                   </GenericParameterAssignment>
                 </FareStructureElement>

--- a/repos/fdbt-netex-output/src/netex-convertor/sharedHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/sharedHelpers.ts
@@ -451,14 +451,24 @@ export const getFareStructuresElements = (
 
         if ('productDuration' in product) {
             return [
-                getPeriodAvailabilityElement(availabilityElementId, validityParametersObject, hasTimeRestriction, groupOfLinesRef),
+                getPeriodAvailabilityElement(
+                    availabilityElementId,
+                    validityParametersObject,
+                    hasTimeRestriction,
+                    groupOfLinesRef,
+                ),
                 getDurationElement(ticket, product),
                 getPeriodConditionsElement(ticket, product),
             ];
         }
 
         return [
-            getPeriodAvailabilityElement(availabilityElementId, validityParametersObject, hasTimeRestriction, groupOfLinesRef),
+            getPeriodAvailabilityElement(
+                availabilityElementId,
+                validityParametersObject,
+                hasTimeRestriction,
+                groupOfLinesRef,
+            ),
             getPeriodConditionsElement(ticket, product),
         ];
     });

--- a/repos/fdbt-netex-output/src/netex-convertor/sharedHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/sharedHelpers.ts
@@ -422,7 +422,9 @@ export const getFareStructuresElements = (
             };
         } else if (isMultiServiceTicket(ticket) || isSchemeOperatorFlatFareTicket(ticket)) {
             availabilityElementId = `Tariff@${product.productName}@access_lines`;
-            validityParametersObject = { LineRef: getLineRefList(ticket) };
+            validityParametersObject = groupOfLinesRef
+                ? { GroupOfLinesRef: { version: '1.0', ref: groupOfLinesRef } }
+                : { LineRef: getLineRefList(ticket) };
         }
 
         if (isHybridTicket(ticket) && isProductDetails(product)) {
@@ -449,14 +451,14 @@ export const getFareStructuresElements = (
 
         if ('productDuration' in product) {
             return [
-                getPeriodAvailabilityElement(availabilityElementId, validityParametersObject, hasTimeRestriction),
+                getPeriodAvailabilityElement(availabilityElementId, validityParametersObject, hasTimeRestriction, groupOfLinesRef),
                 getDurationElement(ticket, product),
                 getPeriodConditionsElement(ticket, product),
             ];
         }
 
         return [
-            getPeriodAvailabilityElement(availabilityElementId, validityParametersObject, hasTimeRestriction),
+            getPeriodAvailabilityElement(availabilityElementId, validityParametersObject, hasTimeRestriction, groupOfLinesRef),
             getPeriodConditionsElement(ticket, product),
         ];
     });


### PR DESCRIPTION
## Description

Where multiple Lines are included in a file, these should be combined into a GroupOfLines to be referenced more efficiently elsewhere. 

## Testing instructions

Check generated netex to see if group of line where there are multiple line references 

Ticket types with multiple lines (flat fare, period multi service, etc) all need to be creating a group of lines, and then referencing it in the tariff.
