### PR TITLE
feat: FareZone Types

### DIFF
--- a/fdbt-dev/data/netexData/multiOpGeoZone.xml
+++ b/fdbt-dev/data/netexData/multiOpGeoZone.xml
@@ -207,7 +207,7 @@
                 <ScheduledStopPointRef versionRef="EXTERNAL" ref="naptStop:45019529">Midgley Road Spring Villas, Midgley Road, Mytholmroyd</ScheduledStopPointRef>
               </members>
               <types>
-                <TypeOfZoneRef ref="fxc:fare_zone@operator" version="fxc:v1.0"/>
+                <TypeOfZoneRef ref="fxc:fare_zone@multi_operator" version="fxc:v1.0"/>
               </types>
               <projections>
                 <TopographicProjectionRef versionRef="nptg:EXTERNAL" ref="nptgLocality:N0076467">Park Street, Macclesfield, </TopographicProjectionRef>

--- a/repos/fdbt-netex-output/src/netex-convertor/netexGenerator.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/netexGenerator.ts
@@ -304,6 +304,12 @@ const netexGenerator = async (ticket: Ticket, operatorData: Operator[]): Promise
             networkFareFrameToUpdate.fareZones.FareZone.projections.TopographicProjectionRef = getTopographicProjectionRefList(
                 ticket.stops,
             );
+            if (isMultiOperatorGeoZoneTicket(ticket)) {
+                networkFareFrameToUpdate.fareZones.FareZone.types.TypeOfZoneRef = {
+                    ref: 'fxc:fare_zone@multi_operator',
+                    version: 'fxc:v1.0',
+                };
+            }
 
             return networkFareFrameToUpdate;
         }


### PR DESCRIPTION
## Description

For multioperator geozone NeTEx fles, FareZone must have a specific type

## Testing instructions

Check generated netex for multioperator geozone NeTEx fles should have
```
<types>
<TypeOfZoneRef ref="fxc:fare_zone@multi_operator" version="fxc:v1.0"/>
</types>
```
