### PR TITLE
feat: CompositeFrame ValidBetween

### DIFF
--- a/fdbt-dev/data/netexData/carnetFlatFare.xml
+++ b/fdbt-dev/data/netexData/carnetFlatFare.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_LINE_FARE_OFFER:Pass@BLAC_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for Blackpool Transport</Name>
       <Description>Flat fare ticket for Blackpool Transport</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/carnetPeriodGeoZone.xml
+++ b/fdbt-dev/data/netexData/carnetPeriodGeoZone.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_NETWORK_FARE_OFFER:Pass@BLAC_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for Blackpool Transport</Name>
       <Description>Period ticket for Blackpool Transport</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/carnetPeriodMultiService.xml
+++ b/fdbt-dev/data/netexData/carnetPeriodMultiService.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_LINE_FARE_OFFER:Pass@BLAC_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for Blackpool Transport</Name>
       <Description>Period ticket for Blackpool Transport</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/carnetReturn.xml
+++ b/fdbt-dev/data/netexData/carnetReturn.xml
@@ -28,6 +28,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_LINE_FARE_OFFER:Trip@PK1146649_RJ1_123456:op" dataSourceRef="op:operator" responsibilitySetRef="tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for PK1146649_RJ1_123456</Name>
       <Description>BLAC PK1146649_RJ1_123456 is accessible as a return trip fare. Prices are given zone to zone, where each zone is a linear group of stops, i.e. fare stage.</Description>
       <TypeOfFrameRef ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP" version="fxc:v1.0"/>

--- a/fdbt-dev/data/netexData/carnetSingle.xml
+++ b/fdbt-dev/data/netexData/carnetSingle.xml
@@ -28,6 +28,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_LINE_FARE_OFFER:Trip@PK1146649_RJ1_1234567:op" dataSourceRef="op:operator" responsibilitySetRef="tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for PK1146649_RJ1_1234567</Name>
       <Description>BLAC PK1146649_RJ1_1234567 is accessible as a single trip fare. Prices are given zone to zone, where each zone is a linear group of stops, i.e. fare stage.</Description>
       <TypeOfFrameRef ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP" version="fxc:v1.0"/>

--- a/fdbt-dev/data/netexData/flatFare.xml
+++ b/fdbt-dev/data/netexData/flatFare.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_LINE_FARE_OFFER:Pass@BLAC_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for Blackpool Transport</Name>
       <Description>Flat fare ticket for Blackpool Transport</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/flatFareGeoZone.xml
+++ b/fdbt-dev/data/netexData/flatFareGeoZone.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_NETWORK_FARE_OFFER:Pass@BLAC_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2021-08-05T00:00:00.000Z</FromDate>
+        <ToDate>2021-10-01T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for Test Operator</Name>
       <Description>Flat fare ticket for Test Operator</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/flatFareGroup.xml
+++ b/fdbt-dev/data/netexData/flatFareGroup.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_LINE_FARE_OFFER:Pass@BLAC_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for Blackpool Transport</Name>
       <Description>Flat fare ticket for Blackpool Transport</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/flatFareWithSopPrices.xml
+++ b/fdbt-dev/data/netexData/flatFareWithSopPrices.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:WBTR:CompositeFrame_UK_PI_LINE_FARE_OFFER:Pass@WBTR_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2021-07-06T00:00:00.000Z</FromDate>
+        <ToDate>2121-07-06T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for Test Operator</Name>
       <Description>Flat fare ticket for Test Operator</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/hybridPeriod.xml
+++ b/fdbt-dev/data/netexData/hybridPeriod.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:WBTR:CompositeFrame_UK_PI_LINE_FARE_OFFER:Pass@WBTR_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2010-03-04T00:00:00.000Z</FromDate>
+        <ToDate>2121-06-30T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for Test Operator</Name>
       <Description>Period ticket for Test Operator</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/multiOpGeoZone.xml
+++ b/fdbt-dev/data/netexData/multiOpGeoZone.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_NETWORK_FARE_OFFER:Pass@BLAC_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for Blackpool Transport</Name>
       <Description>Period ticket for Blackpool Transport</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/multiOpMultiServices.xml
+++ b/fdbt-dev/data/netexData/multiOpMultiServices.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_LINE_FARE_OFFER:Pass@BLAC_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for Blackpool Transport</Name>
       <Description>Period ticket for Blackpool Transport</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/periodGeoZone.xml
+++ b/fdbt-dev/data/netexData/periodGeoZone.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_NETWORK_FARE_OFFER:Pass@BLAC_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for Blackpool Transport</Name>
       <Description>Period ticket for Blackpool Transport</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/periodGeoZoneGroup.xml
+++ b/fdbt-dev/data/netexData/periodGeoZoneGroup.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_NETWORK_FARE_OFFER:Pass@BLAC_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for Blackpool Transport</Name>
       <Description>Period ticket for Blackpool Transport</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/periodMultiService.xml
+++ b/fdbt-dev/data/netexData/periodMultiService.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_LINE_FARE_OFFER:Pass@BLAC_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for Blackpool Transport</Name>
       <Description>Period ticket for Blackpool Transport</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/periodPointToPoint.xml
+++ b/fdbt-dev/data/netexData/periodPointToPoint.xml
@@ -30,6 +30,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_LINE_FARE_OFFER:Pass@BLAC_products:op" dataSourceRef="op:operator" responsibilitySetRef="tariffs">
+      <ValidBetween>
+        <FromDate>2011-01-01T00:00:00.000Z</FromDate>
+        <ToDate>2022-02-02T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for Blackpool Transport</Name>
       <Description>Period ticket for Blackpool Transport</Description>
       <TypeOfFrameRef ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP" version="fxc:v1.0"/>

--- a/fdbt-dev/data/netexData/return.xml
+++ b/fdbt-dev/data/netexData/return.xml
@@ -28,6 +28,9 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_LINE_FARE_OFFER:Trip@PK1146649_RJ1_1234:op" dataSourceRef="op:operator" responsibilitySetRef="tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+      </ValidBetween>
       <Name>Fares for PK1146649_RJ1_1234</Name>
       <Description>BLAC PK1146649_RJ1_1234 is accessible as a return trip fare. Prices are given zone to zone, where each zone is a linear group of stops, i.e. fare stage.</Description>
       <TypeOfFrameRef ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP" version="fxc:v1.0"/>

--- a/fdbt-dev/data/netexData/returnCircular.xml
+++ b/fdbt-dev/data/netexData/returnCircular.xml
@@ -28,6 +28,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:WBTR:CompositeFrame_UK_PI_LINE_FARE_OFFER:Trip@PK1146649_RJ1_Outbound:op" dataSourceRef="op:operator" responsibilitySetRef="tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for PK1146649_RJ1_Outbound</Name>
       <Description>WBTR PK1146649_RJ1_Outbound is accessible as a return trip fare. Prices are given zone to zone, where each zone is a linear group of stops, i.e. fare stage.</Description>
       <TypeOfFrameRef ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP" version="fxc:v1.0"/>

--- a/fdbt-dev/data/netexData/returnCircularGroup.xml
+++ b/fdbt-dev/data/netexData/returnCircularGroup.xml
@@ -28,6 +28,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:WBTR:CompositeFrame_UK_PI_LINE_FARE_OFFER:Trip@PK1146649_RJ1_Outbound:op" dataSourceRef="op:operator" responsibilitySetRef="tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for PK1146649_RJ1_Outbound</Name>
       <Description>WBTR PK1146649_RJ1_Outbound is accessible as a return trip fare. Prices are given zone to zone, where each zone is a linear group of stops, i.e. fare stage.</Description>
       <TypeOfFrameRef ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP" version="fxc:v1.0"/>

--- a/fdbt-dev/data/netexData/returnWithExtraService.xml
+++ b/fdbt-dev/data/netexData/returnWithExtraService.xml
@@ -28,6 +28,9 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_LINE_FARE_OFFER:Trip@PK1146649_RJ1_12345:op" dataSourceRef="op:operator" responsibilitySetRef="tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+      </ValidBetween>
       <Name>Fares for PK1146649_RJ1_12345</Name>
       <Description>BLAC PK1146649_RJ1_12345 is accessible as a return trip fare. Prices are given zone to zone, where each zone is a linear group of stops, i.e. fare stage.</Description>
       <TypeOfFrameRef ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP" version="fxc:v1.0"/>

--- a/fdbt-dev/data/netexData/schemeCarnetFlatFare.xml
+++ b/fdbt-dev/data/netexData/schemeCarnetFlatFare.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:Test_Scheme_Op-SE:CompositeFrame_UK_PI_LINE_FARE_OFFER:Pass@Test_Scheme_Op-SE_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2021-06-25T00:00:00.000Z</FromDate>
+        <ToDate>2121-06-25T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for Test Scheme Op</Name>
       <Description>Flat fare ticket for Test Scheme Op</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/schemeCarnetMultipleServices.xml
+++ b/fdbt-dev/data/netexData/schemeCarnetMultipleServices.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:Test_Scheme_Op-SE:CompositeFrame_UK_PI_LINE_FARE_OFFER:Pass@Test_Scheme_Op-SE_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2021-09-02T00:00:00.000Z</FromDate>
+        <ToDate>2121-09-02T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for Test Scheme Op</Name>
       <Description>Period ticket for Test Scheme Op</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/schemeCarnetPeriod.xml
+++ b/fdbt-dev/data/netexData/schemeCarnetPeriod.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:Test_Scheme_Op-SE:CompositeFrame_UK_PI_NETWORK_FARE_OFFER:Pass@Test_Scheme_Op-SE_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2021-06-25T00:00:00.000Z</FromDate>
+        <ToDate>2121-06-25T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for Test Scheme Op</Name>
       <Description>Period ticket for Test Scheme Op</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/schemeOperatorFlatFare.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorFlatFare.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:IW_Buses-Y:CompositeFrame_UK_PI_LINE_FARE_OFFER:Pass@IW_Buses-Y_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for IW Buses</Name>
       <Description>Flat fare ticket for IW Buses</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/schemeOperatorGeoZone.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorGeoZone.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:IW_Buses-Y:CompositeFrame_UK_PI_NETWORK_FARE_OFFER:Pass@IW_Buses-Y_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for IW Buses</Name>
       <Description>Period ticket for IW Buses</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/schemeOperatorMultiServices.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorMultiServices.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:Test_Scheme_Op-SE:CompositeFrame_UK_PI_LINE_FARE_OFFER:Pass@Test_Scheme_Op-SE_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2011-01-01T00:00:00.000Z</FromDate>
+        <ToDate>2022-02-02T23:59:00.000Z</ToDate>
+      </ValidBetween>
       <Name>Fares for Test Scheme Op</Name>
       <Description>Period ticket for Test Scheme Op</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/schoolPeriodMultiService.xml
+++ b/fdbt-dev/data/netexData/schoolPeriodMultiService.xml
@@ -29,6 +29,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_LINE_FARE_OFFER:Pass@BLAC_products:op" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for Blackpool Transport</Name>
       <Description>Period ticket for Blackpool Transport</Description>
       <TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP"/>

--- a/fdbt-dev/data/netexData/single.xml
+++ b/fdbt-dev/data/netexData/single.xml
@@ -28,6 +28,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_LINE_FARE_OFFER:Trip@PK1146649_RJ1_123:op" dataSourceRef="op:operator" responsibilitySetRef="tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for PK1146649_RJ1_123</Name>
       <Description>BLAC PK1146649_RJ1_123 is accessible as a single trip fare. Prices are given zone to zone, where each zone is a linear group of stops, i.e. fare stage.</Description>
       <TypeOfFrameRef ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP" version="fxc:v1.0"/>

--- a/fdbt-dev/data/netexData/singleGroup.xml
+++ b/fdbt-dev/data/netexData/singleGroup.xml
@@ -28,6 +28,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_LINE_FARE_OFFER:Trip@PK1146649_RJ1_Outbound:op" dataSourceRef="op:operator" responsibilitySetRef="tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for PK1146649_RJ1_Outbound</Name>
       <Description>BLAC PK1146649_RJ1_Outbound is accessible as a single trip fare. Prices are given zone to zone, where each zone is a linear group of stops, i.e. fare stage.</Description>
       <TypeOfFrameRef ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP" version="fxc:v1.0"/>

--- a/fdbt-dev/data/netexData/singleGroupMultipleAdults.xml
+++ b/fdbt-dev/data/netexData/singleGroupMultipleAdults.xml
@@ -28,6 +28,10 @@
   </PublicationRequest>
   <dataObjects>
     <CompositeFrame version="1.0" id="epd:UK:BLAC:CompositeFrame_UK_PI_LINE_FARE_OFFER:Trip@PK1146649_RJ1_Outbound:op" dataSourceRef="op:operator" responsibilitySetRef="tariffs">
+      <ValidBetween>
+        <FromDate>2010-12-17T00:00:00.000Z</FromDate>
+        <ToDate>2028-12-17T23:59:59.999Z</ToDate>
+      </ValidBetween>
       <Name>Fares for PK1146649_RJ1_Outbound</Name>
       <Description>BLAC PK1146649_RJ1_Outbound is accessible as a single trip fare. Prices are given zone to zone, where each zone is a linear group of stops, i.e. fare stage.</Description>
       <TypeOfFrameRef ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP" version="fxc:v1.0"/>

--- a/repos/fdbt-netex-output/src/netex-convertor/netexGenerator.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/netexGenerator.ts
@@ -17,6 +17,7 @@ import {
     Ticket,
     assertNever,
     isReturnTicket,
+    ValidBetween,
 } from '../types';
 import {
     getGeoZoneFareTable,
@@ -138,6 +139,15 @@ const netexGenerator = async (ticket: Ticket, operatorData: Operator[]): Promise
         const compositeFrameToUpdate = { ...compositeFrame };
         const { nocCode } = baseOperatorInfo as Operator;
         const { lineIdName, ticketType } = coreData;
+
+        let validBetween: ValidBetween = {
+            FromDate: { $t: ticket.ticketPeriod.startDate },
+        };
+        if (ticket.ticketPeriod.endDate) {
+            validBetween = { ...validBetween, ToDate: { $t: ticket.ticketPeriod.endDate } };
+        }
+
+        compositeFrameToUpdate.ValidBetween = validBetween;
 
         if (isPointToPointTicket(ticket)) {
             compositeFrameToUpdate.id = `epd:UK:${nocCode}:CompositeFrame_UK_PI_LINE_FARE_OFFER:Trip@${coreData.lineIdName}:op`;

--- a/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexTemplate.xml
+++ b/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexTemplate.xml
@@ -31,6 +31,10 @@
     <!-- =============== RESULTS =========== -->
     <dataObjects>
 		<CompositeFrame version="1.0" id="" dataSourceRef="op:src" responsibilitySetRef="op:tariffs">
+            <ValidBetween>
+                <FromDate>2019-05-01T00:00:00</FromDate>
+                <ToDate>2022-12-31T12:00:00</ToDate>
+            </ValidBetween>
             <Name></Name>
             <Description></Description>
 			<TypeOfFrameRef version="fxc:v1.0" ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP" />

--- a/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexTemplate.xml
+++ b/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexTemplate.xml
@@ -30,6 +30,10 @@
 	<!-- =============== RESULTS =========== -->
 	<dataObjects>
 		<CompositeFrame version="1.0" id="operator@Products@Trip@Line_1" dataSourceRef="op:operator" responsibilitySetRef="tariffs">
+		 <ValidBetween>
+        <FromDate>2019-05-01T00:00:00</FromDate>
+        <ToDate>2022-12-31T12:00:00</ToDate>
+      </ValidBetween>
 			<Name></Name>
 			<Description></Description>
 			<TypeOfFrameRef ref="fxc:UK:DFT:TypeOfFrame_UK_PI_LINE_FARE_OFFER:FXCP" version="fxc:v1.0" />

--- a/repos/fdbt-netex-output/src/types/index.ts
+++ b/repos/fdbt-netex-output/src/types/index.ts
@@ -447,6 +447,11 @@ export type {
     GeoZoneTicket,
 };
 
+export interface ValidBetween {
+    FromDate: object;
+    ToDate?: object;
+}
+
 export const assertNever = (never: never): never => {
     throw new Error(`This should never happen!! ${never}`);
 };


### PR DESCRIPTION
## Description
All files produced should have a date range included within the main CompositeFrame (see screenshot)
These dates should be the dates defined for the product by the user (ToDate only where appropriate)  and should only be included within in the first CompositeFrame (e.g. not the metadata frame) 

## Testing instructions

Check generated netex to see if it looks like this format under the first composite frame for each file:
 ```
     <ValidBetween>
                <FromDate>2017-01-01T00:00:00</FromDate>
                <ToDate>2020-12-31T12:00:00</ToDate>
            </ValidBetween>

```