### PR TITLE
fix: Remove duplicates from multiple operator list

### DIFF
--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -157,7 +157,7 @@ export const getServicesByNocCodeAndDataSource = async (nocCode: string, source:
     }
 };
 
-export const getServicesGroupedByDescriptionSpy = async (
+export const getServicesGroupedByDescription = async (
     nocCode: string,
     source: string,
 ): Promise<ServiceWithNocCode[]> => {

--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -157,11 +157,11 @@ export const getServicesByNocCodeAndDataSource = async (nocCode: string, source:
     }
 };
 
-export const getServicesGoupedByDescription = async (
+export const getServicesGroupedByDescriptionSpy = async (
     nocCode: string,
     source: string,
 ): Promise<ServiceWithNocCode[]> => {
-    //grouped by service description which combines (lineName, startDate, destination)
+    //grouped by service description which combines (lineName, origin, destination)
     const nocCodeParameter = replaceInternalNocCode(nocCode);
     logger.info('', {
         context: 'data.auroradb',

--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -157,10 +157,11 @@ export const getServicesByNocCodeAndDataSource = async (nocCode: string, source:
     }
 };
 
-export const getServicesByNocCodeAndDataSourceAndDescription = async (
+export const getServicesGoupedByDescription = async (
     nocCode: string,
     source: string,
 ): Promise<ServiceWithNocCode[]> => {
+    //grouped by service description which combines (lineName, startDate, destination)
     const nocCodeParameter = replaceInternalNocCode(nocCode);
     logger.info('', {
         context: 'data.auroradb',

--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -173,7 +173,7 @@ export const getServicesByNocCodeAndDataSourceAndDescription = async (
             SELECT id, lineName, lineId, startDate, serviceDescription, origin, destination, serviceCode
             FROM txcOperatorLine
             WHERE nocCode = ? AND dataSource = ? AND (endDate IS NULL OR CURDATE() <= endDate)
-            group by lineId, serviceDescription
+            group by lineId, origin, destination
             ORDER BY CAST(lineName AS UNSIGNED) = 0, CAST(lineName AS UNSIGNED), LEFT(lineName, 1), MID(lineName, 2), startDate;
         `;
 

--- a/repos/fdbt-site/src/pages/multipleOperatorsServiceList.tsx
+++ b/repos/fdbt-site/src/pages/multipleOperatorsServiceList.tsx
@@ -7,7 +7,7 @@ import { isMultiOperatorInfoWithErrors } from '../interfaces/typeGuards';
 import ErrorSummary from '../components/ErrorSummary';
 import { BaseLayout } from '../layout/Layout';
 
-import { getServiceDataSource, getServicesByNocCodeAndDataSourceAndDescription } from '../data/auroradb';
+import { getServiceDataSource, getServicesGoupedByDescription } from '../data/auroradb';
 import {
     ErrorInfo,
     NextPageContextWithSession,
@@ -369,7 +369,7 @@ export const getServerSideProps = async (
     let multiOperatorData = await Promise.all(
         searchedOperators.map(async (operator): Promise<MultiOperatorInfo> => {
             const dataSource = (await dataSourceAttribute(operator.nocCode)).source;
-            const dbServices = await getServicesByNocCodeAndDataSourceAndDescription(operator.nocCode, dataSource);
+            const dbServices = await getServicesGoupedByDescription(operator.nocCode, dataSource);
 
             return {
                 nocCode: operator.nocCode,

--- a/repos/fdbt-site/src/pages/multipleOperatorsServiceList.tsx
+++ b/repos/fdbt-site/src/pages/multipleOperatorsServiceList.tsx
@@ -7,7 +7,7 @@ import { isMultiOperatorInfoWithErrors } from '../interfaces/typeGuards';
 import ErrorSummary from '../components/ErrorSummary';
 import { BaseLayout } from '../layout/Layout';
 
-import { getServiceDataSource, getServicesGoupedByDescription } from '../data/auroradb';
+import { getServiceDataSource, getServicesGroupedByDescriptionSpy } from '../data/auroradb';
 import {
     ErrorInfo,
     NextPageContextWithSession,
@@ -369,7 +369,7 @@ export const getServerSideProps = async (
     let multiOperatorData = await Promise.all(
         searchedOperators.map(async (operator): Promise<MultiOperatorInfo> => {
             const dataSource = (await dataSourceAttribute(operator.nocCode)).source;
-            const dbServices = await getServicesGoupedByDescription(operator.nocCode, dataSource);
+            const dbServices = await getServicesGroupedByDescriptionSpy(operator.nocCode, dataSource);
 
             return {
                 nocCode: operator.nocCode,

--- a/repos/fdbt-site/src/pages/multipleOperatorsServiceList.tsx
+++ b/repos/fdbt-site/src/pages/multipleOperatorsServiceList.tsx
@@ -7,7 +7,7 @@ import { isMultiOperatorInfoWithErrors } from '../interfaces/typeGuards';
 import ErrorSummary from '../components/ErrorSummary';
 import { BaseLayout } from '../layout/Layout';
 
-import { getServiceDataSource, getServicesGroupedByDescriptionSpy } from '../data/auroradb';
+import { getServiceDataSource, getServicesGroupedByDescription } from '../data/auroradb';
 import {
     ErrorInfo,
     NextPageContextWithSession,
@@ -369,7 +369,7 @@ export const getServerSideProps = async (
     let multiOperatorData = await Promise.all(
         searchedOperators.map(async (operator): Promise<MultiOperatorInfo> => {
             const dataSource = (await dataSourceAttribute(operator.nocCode)).source;
-            const dbServices = await getServicesGroupedByDescriptionSpy(operator.nocCode, dataSource);
+            const dbServices = await getServicesGroupedByDescription(operator.nocCode, dataSource);
 
             return {
                 nocCode: operator.nocCode,

--- a/repos/fdbt-site/tests/pages/multipleOperatorsServiceList.test.tsx
+++ b/repos/fdbt-site/tests/pages/multipleOperatorsServiceList.test.tsx
@@ -99,15 +99,15 @@ describe('pages', () => {
                 ],
             },
         ];
-        const getServicesGoupedByDescriptionSpy = jest.spyOn(aurora, 'getServicesGoupedByDescription');
+        const getServicesGroupedByDescriptionSpySpy = jest.spyOn(aurora, 'getServicesGroupedByDescriptionSpy');
 
         const getServiceDataSourceSpy: jest.SpyInstance<Promise<object[]>> = jest.spyOn(aurora, 'getServiceDataSource');
 
         beforeEach(() => {
             getServiceDataSourceSpy.mockImplementation(() => Promise.resolve(mockDataSource));
 
-            getServicesGoupedByDescriptionSpy.mockImplementationOnce(() => Promise.resolve(mockBlackServices));
-            getServicesGoupedByDescriptionSpy.mockImplementationOnce(() => Promise.resolve(mockLNUDServices));
+            getServicesGroupedByDescriptionSpySpy.mockImplementationOnce(() => Promise.resolve(mockBlackServices));
+            getServicesGroupedByDescriptionSpySpy.mockImplementationOnce(() => Promise.resolve(mockLNUDServices));
         });
 
         afterEach(() => {

--- a/repos/fdbt-site/tests/pages/multipleOperatorsServiceList.test.tsx
+++ b/repos/fdbt-site/tests/pages/multipleOperatorsServiceList.test.tsx
@@ -99,10 +99,7 @@ describe('pages', () => {
                 ],
             },
         ];
-        const getServicesByNocCodeAndDataSourceAndDescriptionSpy = jest.spyOn(
-            aurora,
-            'getServicesByNocCodeAndDataSourceAndDescription',
-        );
+        const getServicesGoupedByDescriptionSpy = jest.spyOn(aurora, 'getServicesGoupedByDescription');
 
         const getServiceDataSourceSpy: jest.SpyInstance<Promise<object[]>> = jest.spyOn(aurora, 'getServiceDataSource');
 
@@ -111,12 +108,8 @@ describe('pages', () => {
             getServiceDataSourceSpy.mockImplementation(() => Promise.resolve(mockDataSource));
 
             // getServicesByNocCodeAndDataSourceSpy.mockImplementation(() => Promise.resolve(mockBlackServices));
-            getServicesByNocCodeAndDataSourceAndDescriptionSpy.mockImplementationOnce(() =>
-                Promise.resolve(mockBlackServices),
-            );
-            getServicesByNocCodeAndDataSourceAndDescriptionSpy.mockImplementationOnce(() =>
-                Promise.resolve(mockLNUDServices),
-            );
+            getServicesGoupedByDescriptionSpy.mockImplementationOnce(() => Promise.resolve(mockBlackServices));
+            getServicesGoupedByDescriptionSpy.mockImplementationOnce(() => Promise.resolve(mockLNUDServices));
         });
 
         afterEach(() => {

--- a/repos/fdbt-site/tests/pages/multipleOperatorsServiceList.test.tsx
+++ b/repos/fdbt-site/tests/pages/multipleOperatorsServiceList.test.tsx
@@ -99,15 +99,15 @@ describe('pages', () => {
                 ],
             },
         ];
-        const getServicesGroupedByDescriptionSpySpy = jest.spyOn(aurora, 'getServicesGroupedByDescriptionSpy');
+        const getServicesGroupedByDescriptionSpy = jest.spyOn(aurora, 'getServicesGroupedByDescription');
 
         const getServiceDataSourceSpy: jest.SpyInstance<Promise<object[]>> = jest.spyOn(aurora, 'getServiceDataSource');
 
         beforeEach(() => {
             getServiceDataSourceSpy.mockImplementation(() => Promise.resolve(mockDataSource));
 
-            getServicesGroupedByDescriptionSpySpy.mockImplementationOnce(() => Promise.resolve(mockBlackServices));
-            getServicesGroupedByDescriptionSpySpy.mockImplementationOnce(() => Promise.resolve(mockLNUDServices));
+            getServicesGroupedByDescriptionSpy.mockImplementationOnce(() => Promise.resolve(mockBlackServices));
+            getServicesGroupedByDescriptionSpy.mockImplementationOnce(() => Promise.resolve(mockLNUDServices));
         });
 
         afterEach(() => {

--- a/repos/fdbt-site/tests/pages/multipleOperatorsServiceList.test.tsx
+++ b/repos/fdbt-site/tests/pages/multipleOperatorsServiceList.test.tsx
@@ -104,10 +104,8 @@ describe('pages', () => {
         const getServiceDataSourceSpy: jest.SpyInstance<Promise<object[]>> = jest.spyOn(aurora, 'getServiceDataSource');
 
         beforeEach(() => {
-            // getServicesByNocCodeAndDataSourceSpy.mockImplementation(() => Promise.resolve(mockServices));
             getServiceDataSourceSpy.mockImplementation(() => Promise.resolve(mockDataSource));
 
-            // getServicesByNocCodeAndDataSourceSpy.mockImplementation(() => Promise.resolve(mockBlackServices));
             getServicesGoupedByDescriptionSpy.mockImplementationOnce(() => Promise.resolve(mockBlackServices));
             getServicesGoupedByDescriptionSpy.mockImplementationOnce(() => Promise.resolve(mockLNUDServices));
         });


### PR DESCRIPTION
## Description

This ticket remove duplicate Services from mulipleOperatorsServiceList
Services with uniq lineId, 

## Testing instructions

Start multi-operator journey and notice /mulipleOperatorsServiceList
