### PR TITLE
fix: Added remove all function

### DIFF
--- a/repos/fdbt-netex-output/src/netex-convertor/handler.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/handler.ts
@@ -6,7 +6,7 @@ import * as s3 from '../data/s3';
 import { isPointToPointTicket, isSchemeOperatorTicket, isSingleTicket, Ticket } from '../types/index';
 import netexGenerator from './netexGenerator';
 import { Operator } from '../../src/types/index';
-import { getProductType } from './sharedHelpers';
+import { getProductType, replaceAll } from './sharedHelpers';
 import { SchemeOperatorTicket } from 'fdbt-types/matchingJsonTypes';
 import { fileNameExistsAlready } from '../data/s3';
 import { v4 as uuidv4 } from 'uuid';
@@ -69,7 +69,8 @@ export const generateFileName = (ticket: Ticket): string => {
     const productType = getProductType(ticket);
     const lineOrNetworkFare = getLineOrNetworkFare(productType);
     const nocOrSchemeName = isSchemeOperatorTicket(ticket) ? getSchemeNocIdentifier(ticket) : ticket.nocCode;
-    const productName = ticket.products[0].productName.replace(' ', '-').replace('/', '-');
+    const productNameWithoutWhiteSpace = replaceAll(ticket.products[0].productName, ' ', '-');
+    const productNameWithoutSlashes = replaceAll(productNameWithoutWhiteSpace, '/', '-');
     const creationDate = new Date(Date.now()).toISOString().split('T')[0];
     const startDate = ticket.ticketPeriod.startDate.split('T')[0];
 
@@ -89,7 +90,7 @@ export const generateFileName = (ticket: Ticket): string => {
 
     return `FX-PI-01_UK_${nocOrSchemeName}_${lineOrNetworkFare}_${
         pointToPointInsert ? pointToPointInsert : ''
-    }${productName}_${creationDate}_${startDate}_${uuid}`;
+    }${productNameWithoutSlashes}_${creationDate}_${startDate}_${uuid}`;
 };
 
 export const getFinalNetexName = async (fileName: string): Promise<string> => {

--- a/repos/fdbt-netex-output/src/netex-convertor/sharedHelpers.test.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/sharedHelpers.test.ts
@@ -1,6 +1,6 @@
 import { FullTimeRestriction, GeoZoneTicket } from '../types';
 import * as sharedHelpers from './sharedHelpers';
-import { getTimeRestrictions, getEarliestTime, getProductType } from './sharedHelpers';
+import { getTimeRestrictions, getEarliestTime, getProductType, replaceAll } from './sharedHelpers';
 import {
     periodGeoZoneTicket,
     periodMultipleServicesTicket,
@@ -536,6 +536,18 @@ describe('Shared Helpers', () => {
             const result = getProductType(ticket);
 
             expect(result).toEqual(expectedResult);
+        });
+    });
+
+    describe('replaceAll', () => {
+        it('removes all instances of a character from a string', () => {
+            const result = replaceAll('example/filename/with/slashes', '/', '-');
+            expect(result).toEqual('example-filename-with-slashes');
+        });
+
+        it('leaves the string the same if it contains none of the string its looking to remove', () => {
+            const result = replaceAll('example/filename/with/slashes', '-', '/');
+            expect(result).toEqual('example/filename/with/slashes');
         });
     });
 });

--- a/repos/fdbt-netex-output/src/netex-convertor/sharedHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/sharedHelpers.ts
@@ -51,6 +51,10 @@ export interface NetexObject {
     [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
+export const replaceAll = (input: string, toRemove: string, replacement: string): string => {
+    return input.split(toRemove).join(replacement);
+};
+
 export const getCleanWebsite = (nocWebsite: string): string => {
     if (nocWebsite !== null) {
         const splitWebsite = nocWebsite.split('#');


### PR DESCRIPTION
## Description

The formatting on netex file names was using remove, which only removes the first instance of a character instead of all instances. The new function will remove all instances of a character from the string.


## Testing instructions

n/a.
