### PR TITLE
feat: Rest of other product page UI tests

### DIFF
--- a/repos/fdbt-site/cypress_tests/cypress/support/helpers.ts
+++ b/repos/fdbt-site/cypress_tests/cypress/support/helpers.ts
@@ -268,30 +268,49 @@ export const completeGroupPassengerDetailsPages = (): void => {
 };
 
 export const randomlyDetermineUserType = (): void => {
+    let passengerType;
     cy.get('[class=govuk-radios__input]')
         .its('length')
         .then((length) => {
             const randomNumber = getRandomNumber(0, length - 1);
-            cy.get('[class=govuk-radios__input]').eq(randomNumber).click();
+            cy.get('[class=govuk-radios__input]')
+                .eq(randomNumber)
+                .click()
+                .then(($radio) => {
+                    passengerType = $radio.attr('aria-label');
+                    cy.wrap(passengerType).as('passengerType');
+                });
         });
 
     continueButtonClick();
 };
 
 export const randomlyDeterminePurchaseType = (): void => {
+    let purchaseType: string;
     cy.get('[class=govuk-checkboxes__input]')
         .its('length')
         .then((length) => {
             const randomNumber = getRandomNumber(0, length - 1);
-            cy.get('[class=govuk-checkboxes__input]').eq(randomNumber).click();
+            cy.get('[class=govuk-checkboxes__input]')
+                .eq(randomNumber)
+                .click()
+                .then(($radio) => {
+                    purchaseType = $radio.attr('value');
+                    purchaseType = JSON.parse(purchaseType).name;
+                    cy.get(`[id=price-${randomNumber}]`).then(($radio) => {
+                        purchaseType = `${purchaseType} - £${$radio.attr('value')}`;
+                        cy.wrap(purchaseType).as('purchaseType');
+                    });
+                });
         });
-
     continueButtonClick();
 };
 
 export const randomlyDecideTimeRestrictions = (): void => {
+    let timeRestriction = 'N/A';
     if (getRandomNumber(0, 1) === 0) {
         clickElementById('valid-days-not-required');
+        cy.wrap(timeRestriction).as('timeRestriction');
     } else {
         // click yes button
         clickElementById('valid-days-required');
@@ -305,7 +324,11 @@ export const randomlyDecideTimeRestrictions = (): void => {
                 getElementById('conditional-time-restriction')
                     .find('[class=govuk-radios__input]')
                     .eq(randomNumber)
-                    .click();
+                    .click()
+                    .then(($radio) => {
+                        timeRestriction = $radio.attr('value');
+                        cy.wrap(timeRestriction).as('timeRestriction');
+                    });
             });
     }
 

--- a/repos/fdbt-site/cypress_tests/cypress/support/steps.ts
+++ b/repos/fdbt-site/cypress_tests/cypress/support/steps.ts
@@ -400,6 +400,9 @@ export const editPassengerTypeOtherProductsPage = () => {
     getElementById('fare-type').should('not.be.empty');
     clickElementById('passenger-type-link');
     randomlyDetermineUserType();
+    cy.get('@passengerType').then((passengerType) => {
+        cy.get('[id=passenger-type]').should('have.text', passengerType.toString());
+    });
     clickElementByText('Back');
 };
 
@@ -434,6 +437,9 @@ export const editTimeRestrictionOtherProductsPage = () => {
     getElementById('fare-type').should('not.be.empty');
     clickElementById('time-restriction-link');
     randomlyDecideTimeRestrictions();
+    cy.get('@timeRestriction').then((timeRestriction) => {
+        cy.get('[id=time-restriction]').should('have.text', timeRestriction.toString());
+    });
     clickElementByText('Back');
 };
 
@@ -444,5 +450,8 @@ export const editPurchaseMethodOtherProductsPage = () => {
     getElementById('fare-type').should('not.be.empty');
     clickElementById('purchase-methods-link');
     randomlyDeterminePurchaseType();
+    cy.get('@purchaseType').then((purchaseType) => {
+        cy.get('[id=purchase-methods]').should('have.text', purchaseType.toString());
+    });
     clickElementByText('Back');
 };

--- a/repos/fdbt-site/src/pages/selectPurchaseMethods.tsx
+++ b/repos/fdbt-site/src/pages/selectPurchaseMethods.tsx
@@ -105,7 +105,7 @@ const generateCheckbox = (
                                                 name={`price-${productName}-${offer.id}`}
                                                 data-non-numeric
                                                 type="text"
-                                                id={`price-${productNameIds}-${index}`}
+                                                id={`price-${index}`}
                                                 defaultValue={selectedOffer?.price || defaultPrice}
                                             />
                                         </FormElementWrapper>


### PR DESCRIPTION
## Description

We need some UI tests for when a user edits parts of a ticket specific to non-point to point products, e.g.

- edit passenger type (validation in another ticket)
- edit time restriction (validation in another ticket)
- edit purchase methods (validation in another ticket)

Based on work https://github.com/fares-data-build-tool/create-data/pull/634

## Testing instructions

Run the UI tests and see if it enters the stated in the description
