### PR TITLE
fix: Correcting other products edit services

### DIFF
--- a/repos/fdbt-site/cypress_tests/cypress/support/helpers.ts
+++ b/repos/fdbt-site/cypress_tests/cypress/support/helpers.ts
@@ -358,7 +358,7 @@ export const clickAllCheckboxes = (): string[] => {
 export const getAllCheckboxesData = (): void => {
     const input: string[] = [];
     cy.get('[class=govuk-checkboxes__input]').each((checkbox, index) => {
-        cy.wrap(checkbox).click();
+        cy.wrap(checkbox);
         const name = checkbox.attr('name');
         input[index] = name.split('#')[0];
         cy.wrap(input).as('input');

--- a/repos/fdbt-site/cypress_tests/cypress/support/helpers.ts
+++ b/repos/fdbt-site/cypress_tests/cypress/support/helpers.ts
@@ -348,7 +348,7 @@ export const clickAllCheckboxes = (): string[] => {
     const input: string[] = [];
     cy.get('[class=govuk-checkboxes__input]').each((checkbox, index) => {
         cy.wrap(checkbox).click();
-        const name = checkbox.attr('name');        
+        const name = checkbox.attr('name');
         input[index] = name.split('#')[0];
         cy.wrap(input).as('input');
     });
@@ -368,11 +368,13 @@ export const getAllCheckboxesData = (): void => {
 export const getAllButFirstCheckbox = (): void => {
     const input: string[] = [];
     cy.get('[class=govuk-checkboxes__input]').each((checkbox, index) => {
-        if (index > 0) {
-            const name = checkbox.attr('name');
-            input[index] = name.split('#')[0];
-            cy.wrap(input).as('input');
-        }
+        const name = checkbox.attr('name');
+        input[index] = name.split('#')[0];
+        cy.wrap(input).as('input');
+    });
+    cy.get('@input').then((input) => {
+        const newInputWithoutFirstItem = input.toString().split(',').slice(1);
+        cy.wrap(newInputWithoutFirstItem).as('input');
     });
 };
 


### PR DESCRIPTION
## Description

Correcting other products page tests for edit services as it was failing for two cases (4 - Select all but the first case) and select all was causes an error where each checkobox was unclicked

## Testing instructions

Run the cypress tests for myFares.cy.ts it should pass 
