### PR TITLE
feat: ChargingMomentType (current products)

### DIFF
--- a/fdbt-dev/data/netexData/carnetReturn.xml
+++ b/fdbt-dev/data/netexData/carnetReturn.xml
@@ -704,6 +704,7 @@
           <fareProducts>
             <PreassignedFareProduct id="Trip@Another_product" version="1.0">
               <Name>Another product</Name>
+              <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="1.0" ref="fxc:standard_product@trip@day_return"/>
               <validableElements>
                 <ValidableElement id="Trip@Another_product@travel" version="1.0">

--- a/fdbt-dev/data/netexData/carnetSingle.xml
+++ b/fdbt-dev/data/netexData/carnetSingle.xml
@@ -1943,6 +1943,7 @@
           <fareProducts>
             <PreassignedFareProduct id="Trip@Product_1" version="1.0">
               <Name>Product 1</Name>
+              <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="1.0" ref="fxc:standard_product@trip@single"/>
               <validableElements>
                 <ValidableElement id="Trip@Product_1@travel" version="1.0">

--- a/fdbt-dev/data/netexData/periodPointToPoint.xml
+++ b/fdbt-dev/data/netexData/periodPointToPoint.xml
@@ -1209,6 +1209,7 @@
           <fareProducts>
             <PreassignedFareProduct id="Trip@Period_Point_to_Point" version="1.0">
               <Name>Period Point to Point</Name>
+              <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="1.0" ref="fxc:standard_product@trip@single"/>
               <validableElements>
                 <ValidableElement id="Trip@Period_Point_to_Point@travel" version="1.0">

--- a/fdbt-dev/data/netexData/return.xml
+++ b/fdbt-dev/data/netexData/return.xml
@@ -692,6 +692,7 @@
           <fareProducts>
             <PreassignedFareProduct id="Trip@Another_product" version="1.0">
               <Name>Another product</Name>
+              <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="1.0" ref="fxc:standard_product@trip@day_return"/>
               <validableElements>
                 <ValidableElement id="Trip@Another_product@travel" version="1.0">

--- a/fdbt-dev/data/netexData/returnCircular.xml
+++ b/fdbt-dev/data/netexData/returnCircular.xml
@@ -596,6 +596,7 @@
           <fareProducts>
             <PreassignedFareProduct id="Trip@Another_product" version="1.0">
               <Name>Another product</Name>
+              <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="1.0" ref="fxc:standard_product@trip@day_return"/>
               <validableElements>
                 <ValidableElement id="Trip@Another_product@travel" version="1.0">

--- a/fdbt-dev/data/netexData/returnCircularGroup.xml
+++ b/fdbt-dev/data/netexData/returnCircularGroup.xml
@@ -633,6 +633,7 @@
           <fareProducts>
             <PreassignedFareProduct id="Trip@Another_product" version="1.0">
               <Name>Another product</Name>
+              <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="1.0" ref="fxc:standard_product@trip@day_return"/>
               <validableElements>
                 <ValidableElement id="Trip@Another_product@travel" version="1.0">

--- a/fdbt-dev/data/netexData/returnWithExtraService.xml
+++ b/fdbt-dev/data/netexData/returnWithExtraService.xml
@@ -701,6 +701,7 @@
           <fareProducts>
             <PreassignedFareProduct id="Trip@Another_product" version="1.0">
               <Name>Another product</Name>
+              <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="1.0" ref="fxc:standard_product@trip@day_return"/>
               <validableElements>
                 <ValidableElement id="Trip@Another_product@travel" version="1.0">

--- a/fdbt-dev/data/netexData/single.xml
+++ b/fdbt-dev/data/netexData/single.xml
@@ -1933,6 +1933,7 @@
           <fareProducts>
             <PreassignedFareProduct id="Trip@adult_-_single" version="1.0">
               <Name>adult - single</Name>
+              <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="1.0" ref="fxc:standard_product@trip@single"/>
               <validableElements>
                 <ValidableElement id="Trip@adult_-_single@travel" version="1.0">

--- a/fdbt-dev/data/netexData/singleGroup.xml
+++ b/fdbt-dev/data/netexData/singleGroup.xml
@@ -1966,6 +1966,7 @@
           <fareProducts>
             <PreassignedFareProduct id="Trip@Super_product" version="1.0">
               <Name>Super product</Name>
+              <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="1.0" ref="fxc:standard_product@trip@single"/>
               <validableElements>
                 <ValidableElement id="Trip@Super_product@travel" version="1.0">

--- a/fdbt-dev/data/netexData/singleGroupMultipleAdults.xml
+++ b/fdbt-dev/data/netexData/singleGroupMultipleAdults.xml
@@ -1966,6 +1966,7 @@
           <fareProducts>
             <PreassignedFareProduct id="Trip@Best_product" version="1.0">
               <Name>Best product</Name>
+              <ChargingMomentType>beforeTravel</ChargingMomentType>
               <TypeOfFareProductRef version="1.0" ref="fxc:standard_product@trip@single"/>
               <validableElements>
                 <ValidableElement id="Trip@Best_product@travel" version="1.0">

--- a/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexHelpers.test.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexHelpers.test.ts
@@ -1907,6 +1907,9 @@ describe('Netex Helpers', () => {
             const expectedPreassignedFareProduct = {
                 id: expect.stringContaining(tripString),
                 Name: { $t: productNameForPlainText },
+                ChargingMomentType: {
+                    $t: 'beforeTravel',
+                },
                 TypeOfFareProductRef: { version: '1.0', ref: expect.stringContaining('fxc:standard_product@trip@') },
                 validableElements: {
                     ValidableElement: {

--- a/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexHelpers.ts
@@ -293,6 +293,9 @@ export const getPreassignedFareProduct = (
         Name: {
             $t: productNameForPlainText,
         },
+        ChargingMomentType: {
+            $t: 'beforeTravel',
+        },
         TypeOfFareProductRef: {
             version: '1.0',
             ref: `fxc:standard_product@trip@${matchingData.type === 'return' ? 'day_return' : 'single'}`,


### PR DESCRIPTION
## Description
All products require a ChargingMomentType within PreassignedFareProduct. 

This is present in some NeTEx outputs but is definitely missing from return tickets. We need to check each product to ensure it is present.

All products a user can currently create should have value of 'beforeTravel'.

## Testing instructions

Check generated netex for example similar to below:
`
<fareProducts>
<PreassignedFareProduct version="1.0" id="op:Pass@DayRider_adult">
<Name>DayRider</Name>
<ChargingMomentType>beforeTravel</ChargingMomentType>
<TypeOfFareProductRef version="fxc:v1.0" ref="fxc:standard_product@pass@period"/>
`
