### PR TITLE
feat: Display to user the name of failed export files

### DIFF
--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -12,7 +12,7 @@ import {
 } from '../interfaces';
 import logger from '../utils/logger';
 import { convertDateFormat } from '../utils';
-import _ from 'lodash';
+import { difference } from 'lodash';
 import {
     RawService,
     RawJourneyPattern,
@@ -459,7 +459,7 @@ export const batchGetStopsByAtcoCode = async (atcoCodes: string[]): Promise<Stop
         const queryResults = await executeQuery<NaptanInfo[]>(batchQuery, atcoCodes);
         if (queryResults.length !== atcoCodes.length) {
             const queryResultsAtcos = queryResults.map((qr) => qr.atcoCode);
-            const missingAtcosFromDb = _.difference(atcoCodes, queryResultsAtcos);
+            const missingAtcosFromDb = difference(atcoCodes, queryResultsAtcos);
 
             logger.info('', {
                 context: 'data.auroradb',

--- a/repos/fdbt-site/src/utils/apiUtils/index.ts
+++ b/repos/fdbt-site/src/utils/apiUtils/index.ts
@@ -262,6 +262,6 @@ export const validatePassword = (
 export const dateIsOverThirtyMinutesAgo = (inputDate: Date): boolean => {
     const thirtyMinutesInMilliseconds = 60 * 30 * 1000;
     const date = new Date(inputDate).getTime();
-    const oneHourAgo = Date.now() - thirtyMinutesInMilliseconds;
+    const thirtyMinutesAgo = Date.now() - thirtyMinutesInMilliseconds;
     return date < oneHourAgo;
 };

--- a/repos/fdbt-site/src/utils/apiUtils/index.ts
+++ b/repos/fdbt-site/src/utils/apiUtils/index.ts
@@ -263,5 +263,5 @@ export const dateIsOverThirtyMinutesAgo = (inputDate: Date): boolean => {
     const thirtyMinutesInMilliseconds = 60 * 30 * 1000;
     const date = new Date(inputDate).getTime();
     const thirtyMinutesAgo = Date.now() - thirtyMinutesInMilliseconds;
-    return date < oneHourAgo;
+    return date < thirtyMinutesAgo;
 };

--- a/repos/fdbt-site/src/utils/apiUtils/index.ts
+++ b/repos/fdbt-site/src/utils/apiUtils/index.ts
@@ -259,9 +259,9 @@ export const validatePassword = (
     return null;
 };
 
-export const dateIsOverAnHourAgo = (inputDate: Date): boolean => {
-    const hourInMilliseconds = 60 * 60 * 1000;
+export const dateIsOverThirtyMinutesAgo = (inputDate: Date): boolean => {
+    const thirtyMinutesInMilliseconds = 60 * 30 * 1000;
     const date = new Date(inputDate).getTime();
-    const oneHourAgo = Date.now() - hourInMilliseconds;
+    const oneHourAgo = Date.now() - thirtyMinutesInMilliseconds;
     return date < oneHourAgo;
 };

--- a/repos/fdbt-site/src/utils/index.ts
+++ b/repos/fdbt-site/src/utils/index.ts
@@ -27,6 +27,19 @@ import {
 import dateFormat from 'dateformat';
 import { Stop, Ticket, TicketWithIds, ReturnTicket } from '../interfaces/matchingJsonTypes';
 
+export const formatFailedFileNames = (failedExportFileNames: string[]): string => {
+    // example filename
+    // FX-PI-01_UK_BRTB_NETWORK-FARE_My-Best-Product_2022-10-28_2020-02-01_fab0.xml
+    const names = failedExportFileNames.map((fileName) => {
+        const isNetworkFare = fileName.includes('NETWORK-FARE');
+        const productNameChunk = fileName.split(isNetworkFare ? 'NETWORK-FARE_' : 'LINE-FARE_')[1];
+        const amountOfCharactersInProductName = productNameChunk.length - 31;
+        return productNameChunk.substring(0, amountOfCharactersInProductName);
+    });
+
+    return names.join(', ');
+};
+
 export const getProofDocumentsString = (documents: string[]): string =>
     documents.map((document) => sentenceCaseString(document)).join(', ');
 

--- a/repos/fdbt-site/tests/utils/index.test.ts
+++ b/repos/fdbt-site/tests/utils/index.test.ts
@@ -8,10 +8,11 @@ import {
     getAndValidateSchemeOpRegion,
     isSchemeOperator,
     objectKeyMatchesExportNameExactly,
+    formatFailedFileNames,
 } from '../../src/utils';
 import { getMockContext, mockSchemOpIdToken } from '../testData/mockData';
 import { OPERATOR_ATTRIBUTE } from '../../src/constants/attributes';
-import { dateIsOverAnHourAgo } from '../../src/utils/apiUtils';
+import { dateIsOverThirtyMinutesAgo } from '../../src/utils/apiUtils';
 import { Stop } from '../../src/interfaces/matchingJsonTypes';
 
 describe('index', () => {
@@ -38,6 +39,19 @@ describe('index', () => {
             });
             const result = getHost(req);
             expect(result).toEqual(expected);
+        });
+    });
+
+    describe('formatFailedFileNames', () => {
+        it('correctly returns the text with only the product names', () => {
+            const fileNames = [
+                'FX-PI-01_UK_LNUD_LINE-FARE_1_eeee-return_2022-11-15_2020-02-01_7628.xml',
+                'FX-PI-01_UK_LNUD_LINE-FARE_Carnet_2022-11-15_2020-02-01_3237.xml',
+                'FX-PI-01_UK_LNUD_NETWORK-FARE_Carnet-product-superb_2022-11-15_2020-02-01_3cc9.xml',
+            ];
+            const result = formatFailedFileNames(fileNames);
+
+            expect(result).toEqual('1_eeee-return, Carnet, Carnet-product-superb');
         });
     });
 
@@ -208,16 +222,16 @@ describe('index', () => {
         });
     });
 
-    describe('dateIsOverAnHourAgo', () => {
-        it('returns true if the date is over an hour ago', () => {
-            const result = dateIsOverAnHourAgo(new Date('2022-06-17T03:24:00'));
+    describe('dateIsOverThirtyMinutesAgo', () => {
+        it('returns true if the date is over thirty minutes ago', () => {
+            const result = dateIsOverThirtyMinutesAgo(new Date('2022-06-17T03:24:00'));
 
             expect(result).toBeTruthy();
         });
 
-        it('returns false if the date is less than an hour ago', () => {
+        it('returns false if the date is less than thirty minutes ago', () => {
             const date = new Date();
-            const result = dateIsOverAnHourAgo(date);
+            const result = dateIsOverThirtyMinutesAgo(date);
 
             expect(result).toBeFalsy();
         });


### PR DESCRIPTION
## Description

To display to the user the name of the failed files, when an export fails validation.

## Testing instructions

Simulate an export failing on test, and then click the button to view the names.
