### PR TITLE
fix: select exports page service change

### DIFF
--- a/.github/workflows/fdbt-site_test_deployment.yml
+++ b/.github/workflows/fdbt-site_test_deployment.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-    - 'fix/service-db-call'
+    - 'develop'
     paths:
     - repos/fdbt-site/**
   workflow_dispatch:
@@ -124,15 +124,15 @@ jobs:
         cluster: ${{ env.ECS_CLUSTER }}
         wait-for-service-stability: true
         
-    # - name: Sleep for 10 mins
-    #   run: sleep 10m
-    #   shell: bash
+    - name: Sleep for 10 mins
+      run: sleep 10m
+      shell: bash
 
-    # - name: run-ui-tests
-    #   env:
-    #     CYPRESS_BASE_URL: ${{ secrets.CYPRESS_BASE_URL }}
-    #   run: |
-    #     cd cypress_tests
-    #     cat cypress.config.ts | sed -e "s/baseUrl: '[^'].*'/baseUrl: '${CYPRESS_BASE_URL}'/g" >> cypress.config.ts2 && mv cypress.config.ts2 cypress.config.ts
-    #     cd ..
-    #     bash run_tests_in_browserstack.sh
+    - name: run-ui-tests
+      env:
+        CYPRESS_BASE_URL: ${{ secrets.CYPRESS_BASE_URL }}
+      run: |
+        cd cypress_tests
+        cat cypress.config.ts | sed -e "s/baseUrl: '[^'].*'/baseUrl: '${CYPRESS_BASE_URL}'/g" >> cypress.config.ts2 && mv cypress.config.ts2 cypress.config.ts
+        cd ..
+        bash run_tests_in_browserstack.sh

--- a/.github/workflows/fdbt-site_test_deployment.yml
+++ b/.github/workflows/fdbt-site_test_deployment.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-    - 'develop'
+    - 'fix/service-db-call'
     paths:
     - repos/fdbt-site/**
   workflow_dispatch:

--- a/.github/workflows/fdbt-site_test_deployment.yml
+++ b/.github/workflows/fdbt-site_test_deployment.yml
@@ -124,15 +124,15 @@ jobs:
         cluster: ${{ env.ECS_CLUSTER }}
         wait-for-service-stability: true
         
-    - name: Sleep for 10 mins
-      run: sleep 10m
-      shell: bash
+    # - name: Sleep for 10 mins
+    #   run: sleep 10m
+    #   shell: bash
 
-    - name: run-ui-tests
-      env:
-        CYPRESS_BASE_URL: ${{ secrets.CYPRESS_BASE_URL }}
-      run: |
-        cd cypress_tests
-        cat cypress.config.ts | sed -e "s/baseUrl: '[^'].*'/baseUrl: '${CYPRESS_BASE_URL}'/g" >> cypress.config.ts2 && mv cypress.config.ts2 cypress.config.ts
-        cd ..
-        bash run_tests_in_browserstack.sh
+    # - name: run-ui-tests
+    #   env:
+    #     CYPRESS_BASE_URL: ${{ secrets.CYPRESS_BASE_URL }}
+    #   run: |
+    #     cd cypress_tests
+    #     cat cypress.config.ts | sed -e "s/baseUrl: '[^'].*'/baseUrl: '${CYPRESS_BASE_URL}'/g" >> cypress.config.ts2 && mv cypress.config.ts2 cypress.config.ts
+    #     cd ..
+    #     bash run_tests_in_browserstack.sh

--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -290,10 +290,10 @@ export const getBodsServiceByNocAndId = async (
     }
 };
 
-export const getBodsServiceByNocAndLineId = async (
+export const getBodsServicesByNocAndLineId = async (
     nationalOperatorCode: string,
     lineId: string,
-): Promise<MyFaresService> => {
+): Promise<MyFaresService[]> => {
     const nocCodeParameter = replaceInternalNocCode(nationalOperatorCode);
 
     logger.info('', {
@@ -311,21 +311,20 @@ export const getBodsServiceByNocAndLineId = async (
         `;
 
         const queryResults = await executeQuery<MyFaresService[]>(queryInput, [nocCodeParameter, lineId]);
-        if (queryResults.length !== 1) {
-            throw new Error(`Expected one service to be returned, ${queryResults.length} results received.`);
-        }
 
-        return {
-            id: queryResults[0].id,
-            origin: queryResults[0].origin,
-            destination: queryResults[0].destination,
-            lineName: queryResults[0].lineName,
-            startDate: convertDateFormat(queryResults[0].startDate),
-            endDate: queryResults[0].endDate ? convertDateFormat(queryResults[0].endDate) : undefined,
-            lineId: queryResults[0].lineId,
-        };
+        return queryResults.map((result) => {
+            return {
+                id: result.id,
+                origin: result.origin,
+                destination: result.destination,
+                lineName: result.lineName,
+                startDate: convertDateFormat(result.startDate),
+                endDate: result.endDate ? convertDateFormat(result.endDate) : undefined,
+                lineId: result.lineId,
+            };
+        });
     } catch (error) {
-        throw new Error(`Could not retrieve individual service from AuroraDB: ${error.stack}`);
+        throw new Error(`Could not retrieve bods services for line id ${lineId} from AuroraDB: ${error.stack}`);
     }
 };
 

--- a/repos/fdbt-site/src/interfaces/index.ts
+++ b/repos/fdbt-site/src/interfaces/index.ts
@@ -695,6 +695,7 @@ export interface ProductToExport {
     id: string;
     productName: string;
     startDate: string;
+    endDate?: string;
     fareType: 'single' | 'return' | 'period' | 'flatFare' | 'multiOperator';
     carnet: boolean;
     schoolTicket: boolean;

--- a/repos/fdbt-site/src/pages/products/selectExports.tsx
+++ b/repos/fdbt-site/src/pages/products/selectExports.tsx
@@ -549,11 +549,17 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
 
     const filteredServices = servicesToDisplay.filter((service) => !!service) as ServiceToDisplay[];
 
+    const seenLineIds: string[] = [];
+    const uniqueServicesToDisplay =
+        filteredServices.filter((item) =>
+            seenLineIds.includes(item.lineId) ? false : seenLineIds.push(item.lineId),
+        ) ?? [];
+
     return {
         props: {
             csrf: getCsrfToken(ctx),
             productsToDisplay,
-            servicesToDisplay: filteredServices,
+            servicesToDisplay: uniqueServicesToDisplay,
         },
     };
 };

--- a/repos/fdbt-site/src/pages/products/selectExports.tsx
+++ b/repos/fdbt-site/src/pages/products/selectExports.tsx
@@ -513,43 +513,41 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
         )
     ).flat();
 
-    const servicesToDisplay: (ServiceToDisplay | undefined)[] = (
-        await Promise.all(
-            allServicesWithMatchingLineIds.map(async (service) => {
-                const productsWithSameLineId = productsToDisplay.filter(
-                    (product) => !!product.serviceLineId && product.serviceLineId === service.lineId,
-                );
+    const servicesToDisplay: (ServiceToDisplay | undefined)[] = await Promise.all(
+        allServicesWithMatchingLineIds.map((service) => {
+            const productsWithSameLineId = productsToDisplay.filter(
+                (product) => !!product.serviceLineId && product.serviceLineId === service.lineId,
+            );
 
-                const matchingProducts = productsWithSameLineId.filter((product) => {
-                    const momentProductStartDate = moment(product.startDate, 'DD/MM/YYYY').valueOf();
-                    const momentProductEndDate = product.endDate && moment(product.endDate, 'DD/MM/YYYY').valueOf();
-                    const momentServiceStartDate = moment(service.startDate, 'DD/MM/YYYY').valueOf();
-                    const momentServiceEndDate = service.endDate
-                        ? moment(service.endDate, 'DD/MM/YYYY').valueOf()
-                        : undefined;
+            const matchingProducts = productsWithSameLineId.filter((product) => {
+                const momentProductStartDate = moment(product.startDate, 'DD/MM/YYYY').valueOf();
+                const momentProductEndDate = product.endDate && moment(product.endDate, 'DD/MM/YYYY').valueOf();
+                const momentServiceStartDate = moment(service.startDate, 'DD/MM/YYYY').valueOf();
+                const momentServiceEndDate = service.endDate
+                    ? moment(service.endDate, 'DD/MM/YYYY').valueOf()
+                    : undefined;
 
-                    const productMatchesService =
-                        (!momentProductEndDate || momentProductEndDate >= momentServiceStartDate) &&
-                        (!momentServiceEndDate || momentServiceEndDate >= momentProductStartDate);
+                const productMatchesService =
+                    (!momentProductEndDate || momentProductEndDate >= momentServiceStartDate) &&
+                    (!momentServiceEndDate || momentServiceEndDate >= momentProductStartDate);
 
-                    return productMatchesService;
-                });
+                return productMatchesService;
+            });
 
-                if (matchingProducts.length > 0) {
-                    return {
-                        lineId: service.lineId,
-                        origin: service.origin,
-                        destination: service.destination,
-                        lineName: service.lineName,
-                    };
-                } else {
-                    return undefined;
-                }
-            }),
-        )
+            if (matchingProducts.length > 0) {
+                return {
+                    lineId: service.lineId,
+                    origin: service.origin,
+                    destination: service.destination,
+                    lineName: service.lineName,
+                };
+            } else {
+                return undefined;
+            }
+        }),
     );
 
-    const filteredServices = servicesToDisplay.filter(service => !!service) as ServiceToDisplay[];
+    const filteredServices = servicesToDisplay.filter((service) => !!service) as ServiceToDisplay[];
 
     return {
         props: {


### PR DESCRIPTION
## Description

On the /selectExports page, there was a DB call being made which could return multiple services as it was using the noc and lineId, but the code only ever expected one service to be returned. The change was to alter this DB call so multiple services can be returned, and the services are deduplicated so that we only show as many services as there needs to be on the page.

## Testing instructions

Using the data on test, create a single/return product for a service which has multiple versions in the DB (same lineId). Then, view that product in the selectExports page.
