### PR TITLE
fix: Removed isDevOrTest condition in the exports page

### DIFF
--- a/repos/fdbt-site/src/pages/products/exports.tsx
+++ b/repos/fdbt-site/src/pages/products/exports.tsx
@@ -16,7 +16,6 @@ const fetcher = (input: RequestInfo, init: RequestInit) => fetch(input, init).th
 interface GlobalSettingsProps {
     csrf: string;
     operatorHasProducts: boolean;
-    isDevOrTest: boolean;
 }
 
 const getTag = (exportDetails: Export): ReactElement => {
@@ -51,7 +50,7 @@ const getTag = (exportDetails: Export): ReactElement => {
     );
 };
 
-const Exports = ({ csrf, operatorHasProducts, isDevOrTest }: GlobalSettingsProps): ReactElement => {
+const Exports = ({ csrf, operatorHasProducts }: GlobalSettingsProps): ReactElement => {
     const [showExportPopup, setShowExportPopup] = useState(false);
     const [showFailedFilesPopup, setShowFailedFilesPopup] = useState(false);
     const [buttonClicked, setButtonClicked] = useState(false);
@@ -94,12 +93,7 @@ const Exports = ({ csrf, operatorHasProducts, isDevOrTest }: GlobalSettingsProps
                                 ) : showCancelButton ? (
                                     <CsrfForm csrfToken={csrf} method={'post'} action={'/api/cancelExport'}>
                                         <input type="hidden" name="exportName" value={exportInProgress?.name} />
-                                        <button
-                                            type="submit"
-                                            className={`govuk-button govuk-button--warning${
-                                                !isDevOrTest ? ' govuk-visually-hidden' : ''
-                                            }`}
-                                        >
+                                        <button type="submit" className="govuk-button govuk-button--warning">
                                             Cancel export in progress
                                         </button>
                                     </CsrfForm>
@@ -225,15 +219,12 @@ const Exports = ({ csrf, operatorHasProducts, isDevOrTest }: GlobalSettingsProps
 export const getServerSideProps = async (ctx: NextPageContextWithSession): Promise<{ props: GlobalSettingsProps }> => {
     const noc = getAndValidateNoc(ctx);
 
-    const isDevelopment = process.env.NODE_ENV === 'development';
-    const isTest = process.env.STAGE === 'test';
     const operatorHasProducts = (await getAllProductsByNoc(noc)).length > 0;
 
     return {
         props: {
             csrf: getCsrfToken(ctx),
             operatorHasProducts,
-            isDevOrTest: isDevelopment || isTest,
         },
     };
 };

--- a/repos/fdbt-site/tests/pages/products/exports.test.tsx
+++ b/repos/fdbt-site/tests/pages/products/exports.test.tsx
@@ -5,12 +5,12 @@ import Exports from '../../../src/pages/products/exports';
 describe('pages', () => {
     describe('exports', () => {
         it('should render correctly without data when operator has no products', () => {
-            const tree = shallow(<Exports csrf={''} operatorHasProducts={false} isDevOrTest={false} />);
+            const tree = shallow(<Exports csrf={''} operatorHasProducts={false} />);
             expect(tree).toMatchSnapshot();
         });
 
         it('should render the export button correctly when operator has products', () => {
-            const tree = shallow(<Exports csrf={''} operatorHasProducts={true} isDevOrTest={false} />);
+            const tree = shallow(<Exports csrf={''} operatorHasProducts={true} />);
             expect(tree).toMatchSnapshot();
         });
     });


### PR DESCRIPTION
## Description

As per title, removing isDevOrTest condition for the exports page, so the cancel exports button will show.

## Testing instructions

Cancel exports button should show on preprod and prod for failed exports.
