### PR TITLE
feat: Edit multi operator group for GeoZone ticket

### DIFF
--- a/repos/fdbt-site/src/pages/api/reuseOperatorGroup.ts
+++ b/repos/fdbt-site/src/pages/api/reuseOperatorGroup.ts
@@ -45,7 +45,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
 
                 updateSessionAttribute(req, MULTIPLE_OPERATOR_ATTRIBUTE, undefined);
 
-                redirectTo(res, `/products/productDetails?productId=${matchingJsonMetaData?.productId}}`);
+                redirectTo(res, `/products/productDetails?productId=${matchingJsonMetaData?.productId}`);
                 return;
             }
             updateSessionAttribute(req, MULTIPLE_OPERATOR_ATTRIBUTE, {

--- a/repos/fdbt-site/src/pages/api/reuseOperatorGroup.ts
+++ b/repos/fdbt-site/src/pages/api/reuseOperatorGroup.ts
@@ -45,12 +45,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
 
                 updateSessionAttribute(req, MULTIPLE_OPERATOR_ATTRIBUTE, undefined);
 
-                redirectTo(
-                    res,
-                    `/products/productDetails?productId=${matchingJsonMetaData?.productId}${
-                        matchingJsonMetaData.serviceId ? `&serviceId=${matchingJsonMetaData?.serviceId}` : ''
-                    }`,
-                );
+                redirectTo(res, `/products/productDetails?productId=${matchingJsonMetaData?.productId}}`);
                 return;
             }
             updateSessionAttribute(req, MULTIPLE_OPERATOR_ATTRIBUTE, {

--- a/repos/fdbt-site/src/pages/api/reuseOperatorGroup.ts
+++ b/repos/fdbt-site/src/pages/api/reuseOperatorGroup.ts
@@ -3,12 +3,15 @@ import { getAndValidateNoc, isSchemeOperator, redirectTo, redirectToError } from
 import { getOperatorGroupByNocAndId } from '../../data/auroradb';
 import {
     FARE_TYPE_ATTRIBUTE,
+    MATCHING_JSON_ATTRIBUTE,
+    MATCHING_JSON_META_DATA_ATTRIBUTE,
     MULTIPLE_OPERATOR_ATTRIBUTE,
     REUSE_OPERATOR_GROUP_ATTRIBUTE,
     TICKET_REPRESENTATION_ATTRIBUTE,
 } from '../../constants/attributes';
 import { NextApiRequestWithSession, TicketRepresentationAttribute, FareType } from '../../interfaces';
 import { updateSessionAttribute, getSessionAttribute } from '../../utils/sessions';
+import { putUserDataInProductsBucketWithFilePath } from '../../utils/apiUtils/userData';
 
 export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
     try {
@@ -25,12 +28,37 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
 
         const multipleOperators = await getOperatorGroupByNocAndId(selectedOperatorGroup, noc);
 
+        const ticket = getSessionAttribute(req, MATCHING_JSON_ATTRIBUTE);
+        const matchingJsonMetaData = getSessionAttribute(req, MATCHING_JSON_META_DATA_ATTRIBUTE);
+
         if (multipleOperators) {
-            updateSessionAttribute(req, MULTIPLE_OPERATOR_ATTRIBUTE, {
-                selectedOperators: multipleOperators.operators,
-                id: multipleOperators.id,
-            });
-            updateSessionAttribute(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, []);
+            if (ticket && matchingJsonMetaData) {
+                // edit mode
+                const updatedTicket = {
+                    ...ticket,
+                    additionalNocs: multipleOperators.operators.map((operator) => operator.nocCode),
+                };
+
+                // put the now updated matching json into s3
+                // overriding the existing object
+                await putUserDataInProductsBucketWithFilePath(updatedTicket, matchingJsonMetaData.matchingJsonLink);
+
+                updateSessionAttribute(req, MULTIPLE_OPERATOR_ATTRIBUTE, undefined);
+
+                redirectTo(
+                    res,
+                    `/products/productDetails?productId=${matchingJsonMetaData?.productId}${
+                        matchingJsonMetaData.serviceId ? `&serviceId=${matchingJsonMetaData?.serviceId}` : ''
+                    }`,
+                );
+                return;
+            } else {
+                updateSessionAttribute(req, MULTIPLE_OPERATOR_ATTRIBUTE, {
+                    selectedOperators: multipleOperators.operators,
+                    id: multipleOperators.id,
+                });
+                updateSessionAttribute(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, []);
+            }
         } else {
             updateSessionAttribute(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, [
                 { errorMessage: 'Select a valid operator group', id: 'operatorGroup' },

--- a/repos/fdbt-site/src/pages/api/reuseOperatorGroup.ts
+++ b/repos/fdbt-site/src/pages/api/reuseOperatorGroup.ts
@@ -52,13 +52,12 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                     }`,
                 );
                 return;
-            } else {
-                updateSessionAttribute(req, MULTIPLE_OPERATOR_ATTRIBUTE, {
-                    selectedOperators: multipleOperators.operators,
-                    id: multipleOperators.id,
-                });
-                updateSessionAttribute(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, []);
             }
+            updateSessionAttribute(req, MULTIPLE_OPERATOR_ATTRIBUTE, {
+                selectedOperators: multipleOperators.operators,
+                id: multipleOperators.id,
+            });
+            updateSessionAttribute(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, []);
         } else {
             updateSessionAttribute(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, [
                 { errorMessage: 'Select a valid operator group', id: 'operatorGroup' },

--- a/repos/fdbt-site/src/pages/products/productDetails.tsx
+++ b/repos/fdbt-site/src/pages/products/productDetails.tsx
@@ -358,6 +358,7 @@ const createProductDetails = async (
                 id: 'multi-operator-group',
                 name: `Multi Operator Group`,
                 content: [`${noc}, ${ticket.additionalNocs.join(', ')}`],
+                editLink: '/reuseOperatorGroup',
             });
         }
     }

--- a/repos/fdbt-site/tests/pages/api/reuseOperatorGroup.test.ts
+++ b/repos/fdbt-site/tests/pages/api/reuseOperatorGroup.test.ts
@@ -1,10 +1,16 @@
 import {
     FARE_TYPE_ATTRIBUTE,
+    MATCHING_JSON_ATTRIBUTE,
+    MATCHING_JSON_META_DATA_ATTRIBUTE,
     MULTIPLE_OPERATOR_ATTRIBUTE,
     REUSE_OPERATOR_GROUP_ATTRIBUTE,
     TICKET_REPRESENTATION_ATTRIBUTE,
 } from '../../../src/constants/attributes';
-import { getMockRequestAndResponse } from '../../testData/mockData';
+import {
+    expectedMultiOperatorGeoZoneTicketWithMultipleProducts,
+    getMockRequestAndResponse,
+} from '../../testData/mockData';
+import * as userData from '../../../src/utils/apiUtils/userData';
 import * as sessions from '../../../src/utils/sessions';
 import reuseOperatorGroup from '../../../src/pages/api/reuseOperatorGroup';
 import * as auroradb from '../../../src/data/auroradb';
@@ -13,6 +19,8 @@ import * as index from '../../../src/utils/apiUtils/index';
 describe('reuseOperatorGroup', () => {
     const updateSessionAttributeSpy = jest.spyOn(sessions, 'updateSessionAttribute');
     const writeHeadMock = jest.fn();
+    const s3Spy = jest.spyOn(userData, 'putUserDataInProductsBucketWithFilePath');
+    s3Spy.mockImplementation(() => Promise.resolve('pathToFile'));
 
     afterEach(() => {
         jest.resetAllMocks();
@@ -124,5 +132,53 @@ describe('reuseOperatorGroup', () => {
 
         expect(updateSessionAttributeSpy).toBeCalledWith(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, []);
         expect(writeHeadMock).toBeCalledWith(302, { Location: '/multipleOperatorsServiceList' });
+    });
+    it('should update the multi operators for geozone ticket when in edit mode and redirect back to products/productDetails', async () => {
+        const getOperatorGroupByNocAndId = jest.spyOn(auroradb, 'getOperatorGroupByNocAndId');
+        const testOperators = [
+            {
+                name: 'Best Op 1',
+                nocCode: 'BO1',
+            },
+            {
+                name: 'Best Op 2',
+                nocCode: 'BO3',
+            },
+            {
+                name: 'Best Op Supreme',
+                nocCode: 'BOS',
+            },
+        ];
+        getOperatorGroupByNocAndId.mockImplementation().mockResolvedValue({
+            id: 1,
+            name: 'Best Ops',
+            operators: testOperators,
+        });
+
+        const { req, res } = getMockRequestAndResponse({
+            cookieValues: {},
+            body: {
+                operatorGroupId: '1',
+            },
+            uuid: {},
+            session: {
+                [MATCHING_JSON_ATTRIBUTE]: expectedMultiOperatorGeoZoneTicketWithMultipleProducts,
+                [MATCHING_JSON_META_DATA_ATTRIBUTE]: {
+                    productId: '2',
+                    matchingJsonLink: 'test/path',
+                },
+            },
+            mockWriteHeadFn: writeHeadMock,
+        });
+        await reuseOperatorGroup(req, res);
+
+        expect(userData.putUserDataInProductsBucketWithFilePath).toBeCalledWith(
+            { ...expectedMultiOperatorGeoZoneTicketWithMultipleProducts, additionalNocs: ['BO1', 'BO3', 'BOS'] },
+            'test/path',
+        );
+
+        expect(res.writeHead).toBeCalledWith(302, {
+            Location: '/products/productDetails?productId=2',
+        });
     });
 });

--- a/repos/fdbt-site/tests/pages/products/productDetails.test.tsx
+++ b/repos/fdbt-site/tests/pages/products/productDetails.test.tsx
@@ -650,6 +650,7 @@ describe('myfares pages', () => {
                             id: 'multi-operator-group',
                             name: 'Multi Operator Group',
                             content: ['TEST, MCTR, WBTR, BLAC'],
+                            editLink: '/reuseOperatorGroup',
                         },
                         { id: 'period-duration', name: 'Period duration', content: ['5 weeks'] },
                         { id: 'product-expiry', name: 'Product expiry', content: ['24 hr'] },


### PR DESCRIPTION
## Description

If the product is a multi operator geoZone ticket, we should let the user edit which operator group it has assigned to it.

## Testing instructions

Create a multi operator geozone ticket and edit the 'Multi Operator Group'
Make sure you have at least two operator groups
