### PR TITLE
fix: spelling fix for exports page

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -46,6 +46,10 @@ Unless otherwise stated node 14 has been used for development of the service.
 
 `pip install awscli-local`
 
+## Globally install lerna (from repo root)
+
+`npm install lerna -g`
+
 ## Getting AWS access
 
 See [Access AWS](../how-to/access-aws.md) for details on getting setup with AWS

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -46,7 +46,7 @@ Unless otherwise stated node 14 has been used for development of the service.
 
 `pip install awscli-local`
 
-## Globally install lerna (from repo root)
+## Globally install lerna
 
 `npm install lerna -g`
 

--- a/repos/fdbt-site/src/pages/products/exports.tsx
+++ b/repos/fdbt-site/src/pages/products/exports.tsx
@@ -41,7 +41,9 @@ const getTag = (exportDetails: Export): ReactElement => {
     if (exportDetails.exportFailed) {
         const numberOfFilesMissing = exportDetails.numberOfFilesExpected - exportDetails.netexCount;
         return (
-            <strong className="govuk-tag govuk-tag--red">{`EXPORT FAILED - ${numberOfFilesMissing} files failed`}</strong>
+            <strong className="govuk-tag govuk-tag--red">{`EXPORT FAILED - ${numberOfFilesMissing} file${
+                numberOfFilesMissing > 0 ? 's' : ''
+            } failed`}</strong>
         );
     }
 

--- a/repos/fdbt-site/src/pages/products/exports.tsx
+++ b/repos/fdbt-site/src/pages/products/exports.tsx
@@ -41,8 +41,8 @@ const getTag = (exportDetails: Export): ReactElement => {
     if (exportDetails.exportFailed) {
         const numberOfFilesMissing = exportDetails.numberOfFilesExpected - exportDetails.netexCount;
         return (
-            <strong className="govuk-tag govuk-tag--red">{`EXPORT FAILED - ${numberOfFilesMissing} file${
-                numberOfFilesMissing > 0 ? 's' : ''
+            <strong className="govuk-tag govuk-tag--red">{`EXPORT FAILED - ${numberOfFilesMissing} ${
+                numberOfFilesMissing > 0 ? 'files' : 'file'
             } failed`}</strong>
         );
     }


### PR DESCRIPTION
## Description

If more than one file failed, the export tag says EXPORT FAILED - 3 FILES FAILED. It also says this if 1 file fails, and as such needed some editing. (EXPORT FAILED - 1 FILES FAILED).

## Testing instructions

View tag on an export where 1 file has failed.
