### PR TITLE
fix: change spec timeout

### DIFF
--- a/repos/fdbt-site/cypress_tests/browserstack.json
+++ b/repos/fdbt-site/cypress_tests/browserstack.json
@@ -13,7 +13,7 @@
         "exclude": [],
         "parallels": "5",
         "cypress_version": "10",
-        "spec_timeout": 10,
+        "spec_timeout": 30,
         "npm_dependencies": {
             "@cypress/webpack-preprocessor": "^5.7.0",
             "@typescript-eslint/eslint-plugin": "^2.33.0",


### PR DESCRIPTION
## Description

Changing spec timeout to prevent cypress tests from skipping on browserstack

## Testing instructions

Code review 
