### PR TITLE
fix: Capped product journey for ticket representation

### DIFF
--- a/repos/fdbt-site/src/constants/attributes.ts
+++ b/repos/fdbt-site/src/constants/attributes.ts
@@ -130,8 +130,6 @@ export const VIEW_OPERATOR_GROUP = 'fdbt-products-using-operator-group';
 
 export const VIEW_PRODUCT_GROUP = 'fdbt-products-using-product-group';
 
-export const CAPPED_PRODUCT_ATTRIBUTE = 'fdbt-capped-product-type';
-
 export const TYPE_OF_CAP_ATTRIBUTE = 'fdbt-type-of-cap';
 
 export const CAPPED_PRODUCT_GROUP_ID_ATTRIBUTE = 'fdbt-capped-product-group-id';

--- a/repos/fdbt-site/src/constants/index.ts
+++ b/repos/fdbt-site/src/constants/index.ts
@@ -82,7 +82,7 @@ export const INTERNAL_NOC = 'IWBusCo';
 
 export const CREATED_FILES_NUM_PER_PAGE = 10;
 
-export const validFareTypes = ['single', 'period', 'return', 'flatFare', 'multiOperator', 'schoolService'];
+export const validFareTypes = ['single', 'period', 'return', 'flatFare', 'multiOperator', 'schoolService', 'capped'];
 
 export const purchaseMethodsValuesMap: { [key: string]: string } = {
     agency: 'Travel Shop',

--- a/repos/fdbt-site/src/interfaces/index.ts
+++ b/repos/fdbt-site/src/interfaces/index.ts
@@ -705,7 +705,7 @@ export interface ProductToDisplay {
     productName: string;
     startDate: string;
     endDate?: string;
-    fareType: 'single' | 'return' | 'period' | 'flatFare' | 'multiOperator';
+    fareType: 'single' | 'return' | 'period' | 'flatFare' | 'multiOperator' | 'capped';
     schoolTicket: boolean;
     serviceLineId: string | null;
     direction: string | null;

--- a/repos/fdbt-site/src/interfaces/matchingJsonTypes.ts
+++ b/repos/fdbt-site/src/interfaces/matchingJsonTypes.ts
@@ -63,7 +63,7 @@ export interface SalesOfferPackage {
 
 export type FromDb<T> = T & { id: number };
 
-export type TicketType = 'flatFare' | 'period' | 'multiOperator' | 'schoolService' | 'single' | 'return';
+export type TicketType = 'flatFare' | 'period' | 'multiOperator' | 'schoolService' | 'single' | 'return' | 'capped';
 
 export type Ticket =
     | PointToPointTicket

--- a/repos/fdbt-site/src/pages/api/csvZoneUpload.ts
+++ b/repos/fdbt-site/src/pages/api/csvZoneUpload.ts
@@ -213,6 +213,11 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                 }
             }
 
+            if (fareType === 'capped') {
+                redirectTo(res, '/typeOfCap');
+                return;
+            }
+
             redirectTo(res, '/multipleProducts');
             return;
         }

--- a/repos/fdbt-site/src/pages/api/fareType.ts
+++ b/repos/fdbt-site/src/pages/api/fareType.ts
@@ -2,12 +2,7 @@ import camelCase from 'lodash/camelCase';
 import { NextApiResponse } from 'next';
 import { redirectToError, redirectTo, getAndValidateNoc, isSchemeOperator } from '../../utils/apiUtils/index';
 import { regenerateSession, updateSessionAttribute } from '../../utils/sessions';
-import {
-    FARE_TYPE_ATTRIBUTE,
-    CARNET_FARE_TYPE_ATTRIBUTE,
-    TXC_SOURCE_ATTRIBUTE,
-    CAPPED_PRODUCT_ATTRIBUTE,
-} from '../../constants/attributes';
+import { FARE_TYPE_ATTRIBUTE, CARNET_FARE_TYPE_ATTRIBUTE, TXC_SOURCE_ATTRIBUTE } from '../../constants/attributes';
 import { ErrorInfo, NextApiRequestWithSession } from '../../interfaces';
 import { getAllServicesByNocCode } from '../../data/auroradb';
 import { SCHOOL_FARE_TYPE_ATTRIBUTE } from '../../constants/attributes';
@@ -53,9 +48,8 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             }
             updateSessionAttribute(req, CARNET_FARE_TYPE_ATTRIBUTE, false);
             if (fareType === 'cappedProduct') {
-                updateSessionAttribute(req, CAPPED_PRODUCT_ATTRIBUTE, true);
                 updateSessionAttribute(req, FARE_TYPE_ATTRIBUTE, {
-                    fareType: 'period',
+                    fareType: 'capped',
                 });
                 redirectTo(res, '/selectPassengerType');
                 return;

--- a/repos/fdbt-site/src/pages/api/serviceList.ts
+++ b/repos/fdbt-site/src/pages/api/serviceList.ts
@@ -91,6 +91,11 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             return;
         }
 
+        if (fareType === 'capped') {
+            redirectTo(res, '/typeOfCap');
+            return;
+        }
+
         redirectTo(res, '/multipleProducts');
         return;
     } catch (error) {

--- a/repos/fdbt-site/src/utils/apiUtils/index.ts
+++ b/repos/fdbt-site/src/utils/apiUtils/index.ts
@@ -9,7 +9,6 @@ import {
     FARE_TYPE_ATTRIBUTE,
     SCHOOL_FARE_TYPE_ATTRIBUTE,
     TICKET_REPRESENTATION_ATTRIBUTE,
-    CAPPED_PRODUCT_ATTRIBUTE,
 } from '../../constants/attributes';
 import { CognitoIdToken, ErrorInfo, NextApiRequestWithSession, SchoolFareTypeAttribute } from '../../interfaces';
 import { globalSignOut } from '../../data/cognito';
@@ -111,12 +110,6 @@ export const redirectOnSchoolFareType = (req: NextApiRequestWithSession, res: Ne
 
 export const redirectOnFareType = (req: NextApiRequestWithSession, res: NextApiResponse): void => {
     const fareTypeAttribute = getSessionAttribute(req, FARE_TYPE_ATTRIBUTE);
-    const isCapped = getSessionAttribute(req, CAPPED_PRODUCT_ATTRIBUTE);
-
-    if (isCapped) {
-        redirectTo(res, '/typeOfCap');
-        return;
-    }
 
     if (isFareType(fareTypeAttribute)) {
         switch (fareTypeAttribute.fareType) {
@@ -131,6 +124,9 @@ export const redirectOnFareType = (req: NextApiRequestWithSession, res: NextApiR
                 return;
             case 'schoolService':
                 redirectOnSchoolFareType(req, res);
+                return;
+            case 'capped':
+                redirectTo(res, '/ticketRepresentation');
                 return;
             default:
                 throw new Error('Did not receive an expected fareType.');

--- a/repos/fdbt-site/src/utils/sessions.ts
+++ b/repos/fdbt-site/src/utils/sessions.ts
@@ -60,7 +60,6 @@ import {
     VIEW_OPERATOR_GROUP,
     CAPPED_PRODUCT_GROUP_ID_ATTRIBUTE,
     TYPE_OF_CAP_ATTRIBUTE,
-    CAPPED_PRODUCT_ATTRIBUTE,
     UNASSIGNED_STOPS_ATTRIBUTE,
     GS_FARE_DAY_END_ATTRIBUTE,
     UNASSIGNED_INBOUND_STOPS_ATTRIBUTE,
@@ -221,7 +220,6 @@ export interface SessionAttributeTypes {
     [VIEW_TIME_RESTRICTION]: ErrorInfo[];
     [VIEW_OPERATOR_GROUP]: ErrorInfo[];
     [VIEW_PRODUCT_GROUP]: ErrorInfo[];
-    [CAPPED_PRODUCT_ATTRIBUTE]: boolean;
     [TYPE_OF_CAP_ATTRIBUTE]: TypeOfCap | ErrorInfo;
     [CAPPED_PRODUCT_GROUP_ID_ATTRIBUTE]: string | ErrorInfo;
     [CAPS_ATTRIBUTE]: { errors: ErrorInfo[]; caps: Cap[] };

--- a/repos/fdbt-site/tests/pages/api/csvZoneUpload.test.ts
+++ b/repos/fdbt-site/tests/pages/api/csvZoneUpload.test.ts
@@ -138,6 +138,45 @@ describe('csvZoneUpload', () => {
         expect(updateSessionAttributeSpy).toBeCalledWith(multiOperatorReq, FARE_ZONE_ATTRIBUTE, 'Town Centre');
     });
 
+    it('should return 302 redirect to /typeOfCap if fareType is capped, and when valid file is processed and put in S3', async () => {
+        const cappedTicketReq = getMockRequestAndResponse({
+            cookieValues: {},
+            body: null,
+            uuid: {},
+            mockWriteHeadFn: writeHeadMock,
+            session: {
+                [FARE_TYPE_ATTRIBUTE]: { fareType: 'capped' },
+            },
+        }).req;
+
+        const file = {
+            'csv-upload': {
+                size: 999,
+                path: 'string',
+                name: 'string',
+                type: 'text/csv',
+                toJSON(): string {
+                    return '';
+                },
+            },
+        };
+
+        jest.spyOn(fileUpload, 'getFormData').mockImplementation().mockResolvedValue({
+            name: 'file',
+            files: file,
+            fileContents: csvData.testCsv,
+        });
+
+        jest.spyOn(virusCheck, 'containsViruses').mockImplementation().mockResolvedValue(false);
+
+        await csvZoneUpload.default(cappedTicketReq, res);
+
+        expect(writeHeadMock).toBeCalledWith(302, {
+            Location: '/typeOfCap',
+        });
+        expect(updateSessionAttributeSpy).toBeCalledWith(cappedTicketReq, FARE_ZONE_ATTRIBUTE, 'Town Centre');
+    });
+
     it('should redirect to /error when an error is thrown in the default', async () => {
         const file = {
             'csv-upload': {

--- a/repos/fdbt-site/tests/pages/api/fareType.test.ts
+++ b/repos/fdbt-site/tests/pages/api/fareType.test.ts
@@ -1,4 +1,4 @@
-import { CAPPED_PRODUCT_ATTRIBUTE, TXC_SOURCE_ATTRIBUTE } from './../../../src/constants/attributes';
+import { TXC_SOURCE_ATTRIBUTE } from './../../../src/constants/attributes';
 import { getMockRequestAndResponse } from '../../testData/mockData';
 import fareType from '../../../src/pages/api/fareType';
 import * as sessions from '../../../src/utils/sessions';
@@ -178,8 +178,7 @@ describe('fareType', () => {
             mockWriteHeadFn: writeHeadMock,
         });
         await fareType(req, res);
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, CAPPED_PRODUCT_ATTRIBUTE, true);
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, FARE_TYPE_ATTRIBUTE, { fareType: 'period' });
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, FARE_TYPE_ATTRIBUTE, { fareType: 'capped' });
         expect(writeHeadMock).toBeCalledWith(302, {
             Location: '/selectPassengerType',
         });

--- a/repos/fdbt-site/tests/pages/api/serviceList.test.ts
+++ b/repos/fdbt-site/tests/pages/api/serviceList.test.ts
@@ -159,4 +159,29 @@ describe('serviceList', () => {
             Location: '/products/productDetails?productId=2&serviceId=22D',
         });
     });
+
+    it('redirects to /typeOfCap if input is valid and the user is entering details for a capped ticket', async () => {
+        const serviceInfo = {
+            '64': 'Leeds-Bradford#12/02/12',
+            '45': 'gggggg#02/03/91',
+            '47': 'hhhhhh#23/04/20',
+        };
+
+        const { req, res } = getMockRequestAndResponse({
+            body: { ...serviceInfo },
+            uuid: {},
+            mockWriteHeadFn: writeHeadMock,
+            mockEndFn: jest.fn(),
+            requestHeaders: {
+                referer: `http://localhost:5000${selectAllFalseUrl}`,
+            },
+            session: { [FARE_TYPE_ATTRIBUTE]: { fareType: 'capped' } },
+        });
+
+        await serviceList(req, res);
+
+        expect(writeHeadMock).toBeCalledWith(302, {
+            Location: '/typeOfCap',
+        });
+    });
 });


### PR DESCRIPTION
## Description

Fix the capped product journey for the ticket representation

## Testing instructions

Create a capped product and ticket representation page will appear after /fareConfirmation and will be redirected after selecting options in /ticketRepresentation to /typeOfCap
