### PR TITLE
fix: Adding in mode to function

### DIFF
--- a/repos/fdbt-reference-data-service/src/uploaders/txc_uploader/txc_processor.py
+++ b/repos/fdbt-reference-data-service/src/uploaders/txc_uploader/txc_processor.py
@@ -309,6 +309,7 @@ def check_txc_line_exists(
         service_code,
         origin,
         destination,
+        mode
     ) = extract_data_for_txc_operator_service_table(operator, service, line)
 
     query = f"""


### PR DESCRIPTION
## Description

Error was being thrown "ERROR! Unexpected error. Could not write to database. Error: too many values to unpack (expected 10)" which is suspected to be because the check_txc_line_exists function calling extract_data_for_txc_operator_service_table did not have 11 arguments returning when it should have done, it only had 10 (hence the error we got saying it expected 10).

## Testing instructions

Testing will be done on test env by manually triggering data import.
