### PR TITLE
feat: Allow capped products to bypass matching json

### DIFF
--- a/repos/fdbt-site/src/pages/api/salesConfirmation.ts
+++ b/repos/fdbt-site/src/pages/api/salesConfirmation.ts
@@ -99,7 +99,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                 });
             }
 
-            if (ticketType === 'geoZone' || dataFormat !== 'tnds') {
+            if (ticketType === 'geoZone' || dataFormat !== 'tnds' || fareType === 'capped') {
                 redirectTo(res, '/productCreated');
                 return;
             }

--- a/repos/fdbt-site/src/pages/api/salesConfirmation.ts
+++ b/repos/fdbt-site/src/pages/api/salesConfirmation.ts
@@ -35,6 +35,11 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
     try {
         const fareType = getFareTypeFromFromAttributes(req);
 
+        if (fareType === 'capped') {
+            redirectTo(res, '/productCreated');
+            return;
+        }
+
         const uuid = getUuidFromSession(req);
 
         let userDataJson: TicketWithIds | undefined;
@@ -99,7 +104,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                 });
             }
 
-            if (ticketType === 'geoZone' || dataFormat !== 'tnds' || fareType === 'capped') {
+            if (ticketType === 'geoZone' || dataFormat !== 'tnds') {
                 redirectTo(res, '/productCreated');
                 return;
             }


### PR DESCRIPTION
## Description

In /salesConfirmation API we need to check to see if the ticket is capped, and if it is then just redirect to the success page (the green bannered page).

## Testing instructions

Code review
