### PR TITLE
fix: Showing the additional structuring in cap confirmation

### DIFF
--- a/repos/fdbt-site/src/pages/additionalPricingStructures.tsx
+++ b/repos/fdbt-site/src/pages/additionalPricingStructures.tsx
@@ -170,6 +170,9 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Se
         errors = additionalPricingStructures.additionalPricingStructures.errors;
         additionalPricing = additionalPricingStructures.additionalPricingStructures;
         clickedYes = additionalPricingStructures.clickedYes;
+    } else if (additionalPricingStructures && 'pricingStructureStart' in additionalPricingStructures) {
+        additionalPricing = additionalPricingStructures;
+        clickedYes = true;
     }
 
     return {

--- a/repos/fdbt-site/src/pages/api/additionalPricingStructures.ts
+++ b/repos/fdbt-site/src/pages/api/additionalPricingStructures.ts
@@ -60,6 +60,7 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
     }
 
     if (additionalDiscounts === 'no') {
+        updateSessionAttribute(req, ADDITIONAL_PRICING_ATTRIBUTE, undefined);
         redirectTo(res, '/capConfirmation');
         return;
     }

--- a/repos/fdbt-site/src/pages/capConfirmation.tsx
+++ b/repos/fdbt-site/src/pages/capConfirmation.tsx
@@ -7,6 +7,7 @@ import {
     CAP_START_ATTRIBUTE,
     SERVICE_LIST_ATTRIBUTE,
     MULTI_TAPS_PRICING_ATTRIBUTE,
+    ADDITIONAL_PRICING_ATTRIBUTE,
     CAP_PRICING_PER_DISTANCE_ATTRIBUTE,
 } from '../constants/attributes';
 import { NextPageContextWithSession, ConfirmationElement, Cap } from '../interfaces';
@@ -32,6 +33,7 @@ interface CapConfirmationProps {
     tapsPricingContents: string[];
     capDistancePricingContents: string[];
     distanceBands: string[];
+    additionalPricing: string;
     csrfToken: string;
 }
 
@@ -45,6 +47,7 @@ export const buildCapConfirmationElements = (
     tapsPricingContents: string[],
     capDistancePricingContents: string[],
     distanceBands: string[],
+    additionalPricing: string,
 ): ConfirmationElement[] => {
     const confirmationElements: ConfirmationElement[] = [
         {
@@ -124,6 +127,14 @@ export const buildCapConfirmationElements = (
         });
     }
 
+    if (additionalPricing) {
+        confirmationElements.push({
+            name: 'Additional pricing',
+            content: additionalPricing,
+            href: '/additionalPricingStructures',
+        });
+    }
+
     return confirmationElements;
 };
 
@@ -137,6 +148,7 @@ const CapConfirmation = ({
     tapsPricingContents,
     capDistancePricingContents,
     distanceBands,
+    additionalPricing,
     csrfToken,
 }: CapConfirmationProps): ReactElement => (
     <TwoThirdsLayout title={title} description={description} errors={[]}>
@@ -155,6 +167,7 @@ const CapConfirmation = ({
                         tapsPricingContents,
                         capDistancePricingContents,
                         distanceBands,
+                        additionalPricing,
                     )}
                 />
                 <input type="submit" value="Continue" id="continue-button" className="govuk-button" />
@@ -168,6 +181,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     const noc = getAndValidateNoc(ctx);
 
     const typeOfCapAttribute = getSessionAttribute(ctx.req, TYPE_OF_CAP_ATTRIBUTE);
+    const additionalPricingAttribute = getSessionAttribute(ctx.req, ADDITIONAL_PRICING_ATTRIBUTE);
 
     if (!typeOfCapAttribute || !('typeOfCap' in typeOfCapAttribute)) {
         throw new Error('Could not extract the correct attributes for the user journey.');
@@ -233,6 +247,13 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
                 : 'Rolling days'
             : '';
 
+    const additionalPricing =
+        typeOfCapAttribute.typeOfCap === 'byDistance'
+            ? additionalPricingAttribute && 'pricingStructureStart' in additionalPricingAttribute
+                ? `Pricing structure starts after ${additionalPricingAttribute.pricingStructureStart} min with percentage discount ${additionalPricingAttribute.structureDiscount} %`
+                : 'N/A'
+            : '';
+
     return {
         props: {
             typeOfCap: typeOfCapAttribute.typeOfCap,
@@ -247,6 +268,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
             tapsPricingContents,
             capDistancePricingContents,
             distanceBands,
+            additionalPricing,
             csrfToken,
         },
     };

--- a/repos/fdbt-site/src/pages/capConfirmation.tsx
+++ b/repos/fdbt-site/src/pages/capConfirmation.tsx
@@ -250,7 +250,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     const additionalPricing =
         typeOfCapAttribute.typeOfCap === 'byDistance'
             ? additionalPricingAttribute && 'pricingStructureStart' in additionalPricingAttribute
-                ? `Pricing structure starts after ${additionalPricingAttribute.pricingStructureStart} min with percentage discount ${additionalPricingAttribute.structureDiscount} %`
+                ? `Pricing structure starts after ${additionalPricingAttribute.pricingStructureStart} min with percentage discount ${additionalPricingAttribute.structureDiscount}%`
                 : 'N/A'
             : '';
 

--- a/repos/fdbt-site/tests/pages/__snapshots__/capConfirmation.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/capConfirmation.test.tsx.snap
@@ -49,6 +49,11 @@ exports[`pages capConfirmation should render correctly for capped ticket by dist
             "href": "/defineCapPricingPerDistance",
             "name": "Distance band 1",
           },
+          Object {
+            "content": "Pricing structure starts after 2 min with percentage discount 2 %",
+            "href": "/additionalPricingStructures",
+            "name": "Additional pricing",
+          },
         ]
       }
       header="Cap Information"

--- a/repos/fdbt-site/tests/pages/__snapshots__/capConfirmation.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/capConfirmation.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`pages capConfirmation should render correctly for capped ticket by dist
             "name": "Distance band 1",
           },
           Object {
-            "content": "Pricing structure starts after 2 min with percentage discount 2 %",
+            "content": "Pricing structure starts after 2 min with percentage discount 2%",
             "href": "/additionalPricingStructures",
             "name": "Additional pricing",
           },

--- a/repos/fdbt-site/tests/pages/api/additionalPricingStructures.test.ts
+++ b/repos/fdbt-site/tests/pages/api/additionalPricingStructures.test.ts
@@ -75,7 +75,7 @@ describe('additionalPricingStructures', () => {
 
         additionalPricingStructures(req, res);
 
-        expect(updateSessionAttributeSpy).not.toBeCalled();
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, ADDITIONAL_PRICING_ATTRIBUTE, undefined);
 
         expect(writeHeadMock).toBeCalledWith(302, { Location: '/capConfirmation' });
     });

--- a/repos/fdbt-site/tests/pages/capConfirmation.test.tsx
+++ b/repos/fdbt-site/tests/pages/capConfirmation.test.tsx
@@ -25,6 +25,7 @@ describe('pages', () => {
                     capDistancePricingContents={[]}
                     distanceBands={[]}
                     csrfToken=""
+                    additionalPricing=""
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -50,6 +51,7 @@ describe('pages', () => {
                     capDistancePricingContents={[]}
                     distanceBands={[]}
                     csrfToken=""
+                    additionalPricing=""
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -75,6 +77,7 @@ describe('pages', () => {
                     capDistancePricingContents={['Min price: £2, Max price: £4']}
                     distanceBands={['0 km - End of journey, Price per km: £4']}
                     csrfToken=""
+                    additionalPricing="Pricing structure starts after 2 min with percentage discount 2 %"
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -92,6 +95,7 @@ describe('pages', () => {
                     [],
                     [],
                     [],
+                    '',
                 );
                 expect(result).toStrictEqual([
                     { content: 'Pricing by products ', href: 'typeOfCap', name: 'Cap type' },
@@ -134,6 +138,7 @@ describe('pages', () => {
                     ['Tap number - 1, Price - £2', 'Tap number - 2, Price - £4'],
                     [],
                     [],
+                    '',
                 );
                 expect(result).toStrictEqual([
                     { content: 'Pricing by taps ', href: 'typeOfCap', name: 'Cap type' },
@@ -176,6 +181,7 @@ describe('pages', () => {
                     [],
                     ['Min price: £2, Max price: £9'],
                     ['0 km - 2 km, Price per km: £4', '2 km - End of journey, Price per km: £3'],
+                    'Pricing structure starts after 2 min with percentage discount 2 %',
                 );
                 expect(result).toStrictEqual([
                     { content: 'Pricing by distance ', href: 'typeOfCap', name: 'Cap type' },
@@ -198,6 +204,11 @@ describe('pages', () => {
                         content: '2 km - End of journey, Price per km: £3',
                         href: '/defineCapPricingPerDistance',
                         name: 'Distance band 2',
+                    },
+                    {
+                        content: 'Pricing structure starts after 2 min with percentage discount 2 %',
+                        href: '/additionalPricingStructures',
+                        name: 'Additional pricing',
                     },
                 ]);
             });

--- a/repos/fdbt-site/tests/pages/capConfirmation.test.tsx
+++ b/repos/fdbt-site/tests/pages/capConfirmation.test.tsx
@@ -77,7 +77,7 @@ describe('pages', () => {
                     capDistancePricingContents={['Min price: £2, Max price: £4']}
                     distanceBands={['0 km - End of journey, Price per km: £4']}
                     csrfToken=""
-                    additionalPricing="Pricing structure starts after 2 min with percentage discount 2 %"
+                    additionalPricing="Pricing structure starts after 2 min with percentage discount 2%"
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -181,7 +181,7 @@ describe('pages', () => {
                     [],
                     ['Min price: £2, Max price: £9'],
                     ['0 km - 2 km, Price per km: £4', '2 km - End of journey, Price per km: £3'],
-                    'Pricing structure starts after 2 min with percentage discount 2 %',
+                    'Pricing structure starts after 2 min with percentage discount 2%',
                 );
                 expect(result).toStrictEqual([
                     { content: 'Pricing by distance ', href: 'typeOfCap', name: 'Cap type' },
@@ -206,7 +206,7 @@ describe('pages', () => {
                         name: 'Distance band 2',
                     },
                     {
-                        content: 'Pricing structure starts after 2 min with percentage discount 2 %',
+                        content: 'Pricing structure starts after 2 min with percentage discount 2%',
                         href: '/additionalPricingStructures',
                         name: 'Additional pricing',
                     },


### PR DESCRIPTION
## Description

Showing the additional structuring in the cap confirmation

## Testing instructions

Create a capped ticket by the distance, taps, and price and check for additional structuring int the cap confirmation page
