### PR TITLE
feat: Adding the new tnds services for modes

### DIFF
--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -161,8 +161,9 @@ export const getTndsServicesByNocAndModes = async (nocCode: string, modes: strin
     const nocCodeParameter = replaceInternalNocCode(nocCode);
     logger.info('', {
         context: 'data.auroradb',
-        message: 'retrieving services for given noc',
-        noc: nocCode,
+        message: 'retrieving tnds services for given noc and modes',
+        nocCode,
+        modes,
     });
 
     try {

--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -194,10 +194,7 @@ export const getServicesByNocCodeAndDataSourceWithGrouping = async (
     }
 };
 
-export const getTndsServicesByNocAndModes = async (
-    noc: string,
-    modes: string[],
-): Promise<ServiceWithOriginAndDestination[]> => {
+export const getTndsServicesByNocAndModes = async (noc: string, modes: string[]): Promise<ServiceType[]> => {
     const nocCodeParameter = replaceInternalNocCode(noc);
     logger.info('', {
         context: 'data.auroradb',
@@ -208,7 +205,7 @@ export const getTndsServicesByNocAndModes = async (
     try {
         const substitution = modes.map(() => '?').join(',');
         const queryInput = `
-            SELECT lineName, lineId, startDate, serviceDescription, origin, destination, serviceCode
+            SELECT id, lineName, lineId, startDate, serviceDescription, origin, destination, serviceCode
             FROM txcOperatorLine
             WHERE nocCode = ? AND dataSource = 'tnds' AND (endDate IS NULL OR CURDATE() <= endDate)
             AND mode in (${substitution}) 
@@ -216,10 +213,7 @@ export const getTndsServicesByNocAndModes = async (
             ORDER BY CAST(lineName AS UNSIGNED) = 0, CAST(lineName AS UNSIGNED), LEFT(lineName, 1), MID(lineName, 2), startDate;
         `;
 
-        const queryResults = await executeQuery<ServiceWithOriginAndDestination[]>(
-            queryInput,
-            [nocCodeParameter].concat(modes),
-        );
+        const queryResults = await executeQuery<ServiceType[]>(queryInput, [nocCodeParameter].concat(modes));
 
         return (
             queryResults.map((item) => ({

--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -201,7 +201,7 @@ export const getTndsServicesByNocAndModes = async (
     const nocCodeParameter = replaceInternalNocCode(noc);
     logger.info('', {
         context: 'data.auroradb',
-        message: 'retrieving services for given noc and modes',
+        message: 'retrieving tnds services for given noc and modes',
         noc,
     });
 
@@ -420,37 +420,6 @@ export const getBodsServiceDirectionDescriptionsByNocAndServiceId = async (
         };
     } catch (error) {
         throw new Error(`Could not retrieve individual service direction descriptions from AuroraDB: ${error.stack}`);
-    }
-};
-
-export const getServicesByNocAndModes = async (nocCode: string, modes: string[]): Promise<ServiceType[]> => {
-    const nocCodeParameter = replaceInternalNocCode(nocCode);
-    logger.info('', {
-        context: 'data.auroradb',
-        message: 'retrieving services for given noc',
-        noc: nocCode,
-    });
-
-    try {
-        const substitution = modes.map(() => '?').join(',');
-
-        const queryInput = `
-            SELECT id, lineName, lineId, startDate, serviceDescription AS description, origin, destination, serviceCode
-            FROM txcOperatorLine
-            WHERE nocCode = ? AND dataSource = 'tnds' AND mode in (${substitution})  AND (endDate IS NULL OR CURDATE() <= endDate)
-            ORDER BY CAST(lineName AS UNSIGNED) = 0, CAST(lineName AS UNSIGNED), LEFT(lineName, 1), MID(lineName, 2), startDate;
-        `;
-
-        const queryResults = await executeQuery<ServiceType[]>(queryInput, [nocCodeParameter].concat(modes));
-
-        return (
-            queryResults.map((item) => ({
-                ...item,
-                startDate: convertDateFormat(item.startDate),
-            })) || []
-        );
-    } catch (error) {
-        throw new Error(`Could not retrieve services from AuroraDB: ${error.stack}`);
     }
 };
 

--- a/repos/fdbt-site/src/pages/api/fareType.ts
+++ b/repos/fdbt-site/src/pages/api/fareType.ts
@@ -21,8 +21,6 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             const nocCode = getAndValidateNoc(req, res);
             const services = await getAllServicesByNocCode(nocCode);
             const hasBodsServices = services.some((service) => service.dataSource && service.dataSource === 'bods');
-            // removed as TNDS is being disabled until further notice
-            //const hasTndsServices = services.some((service) => service.dataSource && service.dataSource === 'tnds');
             const multiModalAttribute = getSessionAttribute(req, MULTI_MODAL_ATTRIBUTE);
 
             if (!schemeOp && !hasBodsServices && !multiModalAttribute) {

--- a/repos/fdbt-site/src/pages/api/fareType.ts
+++ b/repos/fdbt-site/src/pages/api/fareType.ts
@@ -23,9 +23,9 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             const hasBodsServices = services.some((service) => service.dataSource && service.dataSource === 'bods');
             // removed as TNDS is being disabled until further notice
             //const hasTndsServices = services.some((service) => service.dataSource && service.dataSource === 'tnds');
-            const modes = getSessionAttribute(req, MULTI_MODAL_ATTRIBUTE);
+            const multiModalAttribute = getSessionAttribute(req, MULTI_MODAL_ATTRIBUTE);
 
-            if (!schemeOp && !hasBodsServices && !modes) {
+            if (!schemeOp && !hasBodsServices && !multiModalAttribute) {
                 redirectTo(res, '/noServices');
                 return;
             }

--- a/repos/fdbt-site/src/pages/api/returnService.ts
+++ b/repos/fdbt-site/src/pages/api/returnService.ts
@@ -2,6 +2,7 @@ import { NextApiResponse } from 'next';
 import {
     MATCHING_JSON_ATTRIBUTE,
     MATCHING_JSON_META_DATA_ATTRIBUTE,
+    MULTI_MODAL_ATTRIBUTE,
     RETURN_SERVICE_ATTRIBUTE,
 } from '../../constants/attributes';
 import { redirectToError, redirectTo, getAndValidateNoc } from '../../utils/apiUtils';
@@ -38,7 +39,12 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             return;
         }
 
-        const service = await getServiceByIdAndDataSource(getAndValidateNoc(req, res), serviceId, 'bods');
+        let dataSource = 'bods';
+        const modesAttribute = getSessionAttribute(req, MULTI_MODAL_ATTRIBUTE);
+        if (modesAttribute) {
+            dataSource = 'tnds';
+        }
+        const service = await getServiceByIdAndDataSource(getAndValidateNoc(req, res), serviceId, dataSource);
 
         const additionalServices: AdditionalService[] = [
             {

--- a/repos/fdbt-site/src/pages/multiOperatorServiceList.tsx
+++ b/repos/fdbt-site/src/pages/multiOperatorServiceList.tsx
@@ -10,11 +10,7 @@ import {
     MULTIPLE_OPERATOR_ATTRIBUTE,
     MULTI_MODAL_ATTRIBUTE,
 } from '../constants/attributes';
-import {
-    getTndsServicesByNocAndModes,
-    getOperatorDetailsFromNocTable,
-    getServicesByNocCodeAndDataSourceWithGrouping,
-} from '../data/auroradb';
+import { getOperatorDetailsFromNocTable, getServicesByNocCodeAndDataSourceWithGrouping } from '../data/auroradb';
 import {
     ErrorInfo,
     MultiOperatorInfo,
@@ -468,12 +464,12 @@ export const getServerSideProps = async (
         multiOperatorData = await Promise.all(
             ticket.additionalOperators.map(async (operator) => {
                 let dataSource: 'bods' | 'tnds' = 'bods';
-                let services = await getServicesByNocCodeAndDataSourceWithGrouping(operator.nocCode, dataSource);
 
-                if (services.length === 0 && modesAttribute) {
-                    services = await getTndsServicesByNocAndModes(operator.nocCode, modesAttribute.modes);
+                if (modesAttribute) {
                     dataSource = 'tnds';
                 }
+                const services = await getServicesByNocCodeAndDataSourceWithGrouping(operator.nocCode, dataSource);
+
                 // get the operators name, as we only have the nocCode
                 const operatorDetails = (await getOperatorDetailsFromNocTable(operator.nocCode)) as OperatorDetails;
 
@@ -508,12 +504,12 @@ export const getServerSideProps = async (
         multiOperatorData = await Promise.all(
             multiOperatorAttribute.selectedOperators.map(async (operator) => {
                 let dataSource: 'bods' | 'tnds' = 'bods';
-                let services = await getServicesByNocCodeAndDataSourceWithGrouping(operator.nocCode, dataSource);
 
-                if (services.length === 0 && modesAttribute) {
-                    services = await getTndsServicesByNocAndModes(operator.nocCode, modesAttribute.modes);
+                if (modesAttribute) {
                     dataSource = 'tnds';
                 }
+
+                const services = await getServicesByNocCodeAndDataSourceWithGrouping(operator.nocCode, dataSource);
 
                 return {
                     name: operator.name,

--- a/repos/fdbt-site/src/pages/multiOperatorServiceList.tsx
+++ b/repos/fdbt-site/src/pages/multiOperatorServiceList.tsx
@@ -8,9 +8,10 @@ import {
     MATCHING_JSON_META_DATA_ATTRIBUTE,
     MULTIPLE_OPERATORS_SERVICES_ATTRIBUTE,
     MULTIPLE_OPERATOR_ATTRIBUTE,
+    MULTI_MODAL_ATTRIBUTE,
 } from '../constants/attributes';
 import {
-    getFerryAndBusServices,
+    getTndsServicesByNocAndModes,
     getOperatorDetailsFromNocTable,
     getServicesByNocCodeAndDataSourceWithGrouping,
 } from '../data/auroradb';
@@ -442,6 +443,7 @@ export const getServerSideProps = async (
     const csrfToken = getCsrfToken(ctx);
     const multiOperatorAttribute = getSessionAttribute(ctx.req, MULTIPLE_OPERATOR_ATTRIBUTE);
     const multiOperatorServicesAttribute = getSessionAttribute(ctx.req, MULTIPLE_OPERATORS_SERVICES_ATTRIBUTE);
+    const modesAttribute = getSessionAttribute(ctx.req, MULTI_MODAL_ATTRIBUTE);
     let multiOperatorData: MultiOperatorInfo[] = [];
     let errors: ErrorInfo[] = [];
     let backHref = '';
@@ -468,8 +470,8 @@ export const getServerSideProps = async (
                 let dataSource: 'bods' | 'tnds' = 'bods';
                 let services = await getServicesByNocCodeAndDataSourceWithGrouping(operator.nocCode, dataSource);
 
-                if (services.length === 0) {
-                    services = await getFerryAndBusServices(operator.nocCode);
+                if (services.length === 0 && modesAttribute) {
+                    services = await getTndsServicesByNocAndModes(operator.nocCode, modesAttribute.modes);
                     dataSource = 'tnds';
                 }
                 // get the operators name, as we only have the nocCode
@@ -508,8 +510,8 @@ export const getServerSideProps = async (
                 let dataSource: 'bods' | 'tnds' = 'bods';
                 let services = await getServicesByNocCodeAndDataSourceWithGrouping(operator.nocCode, dataSource);
 
-                if (services.length === 0) {
-                    services = await getFerryAndBusServices(operator.nocCode);
+                if (services.length === 0 && modesAttribute) {
+                    services = await getTndsServicesByNocAndModes(operator.nocCode, modesAttribute.modes);
                     dataSource = 'tnds';
                 }
 

--- a/repos/fdbt-site/src/pages/returnService.tsx
+++ b/repos/fdbt-site/src/pages/returnService.tsx
@@ -7,8 +7,9 @@ import {
     OPERATOR_ATTRIBUTE,
     MATCHING_JSON_ATTRIBUTE,
     MATCHING_JSON_META_DATA_ATTRIBUTE,
+    MULTI_MODAL_ATTRIBUTE,
 } from '../constants/attributes';
-import { getPassengerTypeById, getServicesByNocCodeAndDataSource } from '../data/auroradb';
+import { getPassengerTypeById, getServicesByNocAndModes, getServicesByNocCodeAndDataSource } from '../data/auroradb';
 import ErrorSummary from '../components/ErrorSummary';
 import { getAndValidateNoc, getCsrfToken, isReturnTicket } from '../utils';
 import CsrfForm from '../components/CsrfForm';
@@ -96,6 +97,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
 
     const ticket = getSessionAttribute(ctx.req, MATCHING_JSON_ATTRIBUTE);
     const matchingJsonMetaData = getSessionAttribute(ctx.req, MATCHING_JSON_META_DATA_ATTRIBUTE);
+    const modesAttribute = getSessionAttribute(ctx.req, MULTI_MODAL_ATTRIBUTE);
     const nocCode = getAndValidateNoc(ctx);
     const selectedServiceId = Number(ctx.query.selectedServiceId);
 
@@ -112,7 +114,11 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
         throw new Error('Ticket should be return type');
     }
 
-    const services = await getServicesByNocCodeAndDataSource(nocCode, 'bods');
+    let services;
+    if (modesAttribute) {
+        services = await getServicesByNocAndModes(nocCode, modesAttribute.modes);
+    }
+    services = await getServicesByNocCodeAndDataSource(nocCode, 'bods');
 
     if (services.length === 0) {
         if (ctx.res) {

--- a/repos/fdbt-site/src/pages/returnService.tsx
+++ b/repos/fdbt-site/src/pages/returnService.tsx
@@ -9,7 +9,11 @@ import {
     MATCHING_JSON_META_DATA_ATTRIBUTE,
     MULTI_MODAL_ATTRIBUTE,
 } from '../constants/attributes';
-import { getPassengerTypeById, getServicesByNocAndModes, getServicesByNocCodeAndDataSource } from '../data/auroradb';
+import {
+    getPassengerTypeById,
+    getServicesByNocCodeAndDataSource,
+    getTndsServicesByNocAndModes,
+} from '../data/auroradb';
 import ErrorSummary from '../components/ErrorSummary';
 import { getAndValidateNoc, getCsrfToken, isReturnTicket } from '../utils';
 import CsrfForm from '../components/CsrfForm';
@@ -116,7 +120,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
 
     let services;
     if (modesAttribute) {
-        services = await getServicesByNocAndModes(nocCode, modesAttribute.modes);
+        services = await getTndsServicesByNocAndModes(nocCode, modesAttribute.modes);
     }
     services = await getServicesByNocCodeAndDataSource(nocCode, 'bods');
 

--- a/repos/fdbt-site/src/pages/returnService.tsx
+++ b/repos/fdbt-site/src/pages/returnService.tsx
@@ -34,6 +34,7 @@ interface ReturnServiceProps {
     csrfToken: string;
     selectedServiceId: number;
     backHref: string;
+    dataSource: string;
 }
 
 const ReturnService = ({
@@ -44,6 +45,7 @@ const ReturnService = ({
     csrfToken,
     selectedServiceId,
     backHref,
+    dataSource,
 }: ReturnServiceProps): ReactElement => (
     <TwoThirdsLayout title={title} description={description} errors={errors}>
         <BackButton href={backHref} />
@@ -85,8 +87,14 @@ const ReturnService = ({
                         </select>
                     </FormElementWrapper>
                     <span className="govuk-hint hint-text" id="traveline-hint">
-                        This data is taken from the <b>Bus Open Data Service (BODS)</b>. If the service you are looking
-                        for is not listed, contact the BODS help desk for advice <a href="/contact">here</a>
+                        This data is taken from the{' '}
+                        <b>
+                            {dataSource === 'tnds'
+                                ? 'Traveline National Dataset (TNDS)'
+                                : 'Bus Open Data Service (BODS)'}
+                        </b>
+                        . If the service you are looking for is not listed, contact the BODS help desk for advice{' '}
+                        <a href="/contact">here</a>
                     </span>
                 </div>
                 <input type="hidden" name="selectedServiceId" value={selectedServiceId} />
@@ -118,8 +126,10 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
         throw new Error('Ticket should be return type');
     }
 
+    let dataSource = 'bods';
     let services;
     if (modesAttribute) {
+        dataSource = 'tnds';
         services = await getTndsServicesByNocAndModes(nocCode, modesAttribute.modes);
     } else {
         services = await getServicesByNocCodeAndDataSource(nocCode, 'bods');
@@ -148,6 +158,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
             csrfToken,
             selectedServiceId,
             backHref,
+            dataSource,
         },
     };
 };

--- a/repos/fdbt-site/src/pages/returnService.tsx
+++ b/repos/fdbt-site/src/pages/returnService.tsx
@@ -121,8 +121,9 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     let services;
     if (modesAttribute) {
         services = await getTndsServicesByNocAndModes(nocCode, modesAttribute.modes);
+    } else {
+        services = await getServicesByNocCodeAndDataSource(nocCode, 'bods');
     }
-    services = await getServicesByNocCodeAndDataSource(nocCode, 'bods');
 
     if (services.length === 0) {
         if (ctx.res) {

--- a/repos/fdbt-site/src/pages/service.tsx
+++ b/repos/fdbt-site/src/pages/service.tsx
@@ -8,8 +8,9 @@ import {
     SERVICE_ATTRIBUTE,
     PASSENGER_TYPE_ATTRIBUTE,
     TXC_SOURCE_ATTRIBUTE,
+    MULTI_MODAL_ATTRIBUTE,
 } from '../constants/attributes';
-import { getServicesByNocCodeAndDataSource } from '../data/auroradb';
+import { getServicesByNocAndModes, getServicesByNocCodeAndDataSource } from '../data/auroradb';
 import ErrorSummary from '../components/ErrorSummary';
 import { getAndValidateNoc, getCsrfToken } from '../utils';
 import CsrfForm from '../components/CsrfForm';
@@ -114,7 +115,14 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     }
 
     const dataSourceAttribute = getRequiredSessionAttribute(ctx.req, TXC_SOURCE_ATTRIBUTE);
-    const services = await getServicesByNocCodeAndDataSource(nocCode, dataSourceAttribute.source);
+    const modesAttribute = getSessionAttribute(ctx.req, MULTI_MODAL_ATTRIBUTE);
+
+    let services;
+    if (modesAttribute && modesAttribute.modes.length > 0) {
+        services = await getServicesByNocAndModes(nocCode, modesAttribute.modes);
+    }
+
+    services = await getServicesByNocCodeAndDataSource(nocCode, dataSourceAttribute.source);
 
     if (services.length === 0) {
         if (ctx.res) {

--- a/repos/fdbt-site/src/pages/service.tsx
+++ b/repos/fdbt-site/src/pages/service.tsx
@@ -10,7 +10,7 @@ import {
     TXC_SOURCE_ATTRIBUTE,
     MULTI_MODAL_ATTRIBUTE,
 } from '../constants/attributes';
-import { getServicesByNocAndModes, getServicesByNocCodeAndDataSource } from '../data/auroradb';
+import { getServicesByNocCodeAndDataSource, getTndsServicesByNocAndModes } from '../data/auroradb';
 import ErrorSummary from '../components/ErrorSummary';
 import { getAndValidateNoc, getCsrfToken } from '../utils';
 import CsrfForm from '../components/CsrfForm';
@@ -119,7 +119,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
 
     let services;
     if (modesAttribute && modesAttribute.modes.length > 0) {
-        services = await getServicesByNocAndModes(nocCode, modesAttribute.modes);
+        services = await getTndsServicesByNocAndModes(nocCode, modesAttribute.modes);
     }
 
     services = await getServicesByNocCodeAndDataSource(nocCode, dataSourceAttribute.source);

--- a/repos/fdbt-site/src/pages/serviceList.tsx
+++ b/repos/fdbt-site/src/pages/serviceList.tsx
@@ -11,7 +11,11 @@ import {
     MATCHING_JSON_META_DATA_ATTRIBUTE,
     MULTI_MODAL_ATTRIBUTE,
 } from '../constants/attributes';
-import { getAllServicesByNocCode, getServicesByNocAndModes, getServicesByNocCodeAndDataSource } from '../data/auroradb';
+import {
+    getAllServicesByNocCode,
+    getServicesByNocCodeAndDataSource,
+    getTndsServicesByNocAndModes,
+} from '../data/auroradb';
 import {
     ErrorInfo,
     NextPageContextWithSession,
@@ -190,7 +194,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
 
     let chosenDataSourceServices;
     if (modesAttribute && modesAttribute.modes.length > 0) {
-        chosenDataSourceServices = await getServicesByNocAndModes(nocCode, modesAttribute.modes);
+        chosenDataSourceServices = await getTndsServicesByNocAndModes(nocCode, modesAttribute.modes);
     }
     chosenDataSourceServices = await getServicesByNocCodeAndDataSource(nocCode, dataSourceAttribute.source);
 

--- a/repos/fdbt-site/src/pages/serviceList.tsx
+++ b/repos/fdbt-site/src/pages/serviceList.tsx
@@ -9,8 +9,9 @@ import {
     TICKET_REPRESENTATION_ATTRIBUTE,
     MATCHING_JSON_ATTRIBUTE,
     MATCHING_JSON_META_DATA_ATTRIBUTE,
+    MULTI_MODAL_ATTRIBUTE,
 } from '../constants/attributes';
-import { getAllServicesByNocCode, getServicesByNocCodeAndDataSource } from '../data/auroradb';
+import { getAllServicesByNocCode, getServicesByNocAndModes, getServicesByNocCodeAndDataSource } from '../data/auroradb';
 import {
     ErrorInfo,
     NextPageContextWithSession,
@@ -185,7 +186,13 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
 
     const { selectAll } = ctx.query;
 
-    const chosenDataSourceServices = await getServicesByNocCodeAndDataSource(nocCode, dataSourceAttribute.source);
+    const modesAttribute = getSessionAttribute(ctx.req, MULTI_MODAL_ATTRIBUTE);
+
+    let chosenDataSourceServices;
+    if (modesAttribute && modesAttribute.modes.length > 0) {
+        chosenDataSourceServices = await getServicesByNocAndModes(nocCode, modesAttribute.modes);
+    }
+    chosenDataSourceServices = await getServicesByNocCodeAndDataSource(nocCode, dataSourceAttribute.source);
 
     const serviceList: ServicesInfo[] = chosenDataSourceServices.map((service) => {
         return {

--- a/repos/fdbt-site/tests/pages/__snapshots__/returnService.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/returnService.test.tsx.snap
@@ -108,11 +108,13 @@ exports[`pages returnService should render correctly 1`] = `
         className="govuk-hint hint-text"
         id="traveline-hint"
       >
-        This data is taken from the 
+        This data is taken from the
+         
         <b>
           Bus Open Data Service (BODS)
         </b>
-        . If the service you are looking for is not listed, contact the BODS help desk for advice 
+        . If the service you are looking for is not listed, contact the BODS help desk for advice
+         
         <a
           href="/contact"
         >

--- a/repos/fdbt-site/tests/pages/multipleOperatorsServiceList.test.tsx
+++ b/repos/fdbt-site/tests/pages/multipleOperatorsServiceList.test.tsx
@@ -4,7 +4,7 @@ import MultipleOperatorsServiceList, { getServerSideProps } from '../../src/page
 import { getMockContext } from '../testData/mockData';
 import * as aurora from '../../src/data/auroradb';
 import { ErrorInfo, MultiOperatorInfo, ServiceWithOriginAndDestination } from '../../src/interfaces';
-import { MULTIPLE_OPERATOR_ATTRIBUTE, MULTI_MODAL_ATTRIBUTE } from '../../src/constants/attributes';
+import { MULTIPLE_OPERATOR_ATTRIBUTE } from '../../src/constants/attributes';
 
 describe('pages', () => {
     describe('multipleOperatorsServiceList', () => {
@@ -91,51 +91,6 @@ describe('pages', () => {
                 dataSource: 'bods',
             },
         ];
-        const mockMultiOperatorTndsData: MultiOperatorInfo[] = [
-            {
-                nocCode: 'BLAC',
-                name: 'Blackpool Transport',
-                services: [
-                    {
-                        lineName: '1',
-                        lineId: '4YyoI0',
-                        startDate: '05/04/2020',
-                        serviceDescription: 'FLEETWOOD - BLACKPOOL via Promenade',
-                        origin: 'Fleetwood',
-                        destination: 'Blackpool',
-                        serviceCode: 'NW_05_BLAC_1_1',
-                    },
-                    {
-                        lineName: '2',
-                        lineId: 'YpQjUw',
-                        startDate: '05/04/2020',
-                        serviceDescription: 'POULTON - BLACKPOOL via Victoria Hospital Outpatients',
-                        origin: 'Poulton',
-                        destination: 'Blackpool',
-                        serviceCode: 'NW_05_BLAC_2_1',
-                    },
-                ],
-                selectedServices: [],
-                dataSource: 'tnds',
-            },
-            {
-                nocCode: 'LNUD',
-                name: 'Testing ops',
-                services: [
-                    {
-                        lineName: '259',
-                        lineId: 'vHaXmz',
-                        startDate: '25/03/2020',
-                        serviceDescription: 'Brighouse - East Bierley',
-                        origin: 'Brighouse',
-                        destination: 'East Bierley',
-                        serviceCode: 'YWAO259',
-                    },
-                ],
-                selectedServices: [],
-                dataSource: 'tnds',
-            },
-        ];
         const getServicesByNocCodeAndDataSourceAndDescriptionSpy = jest.spyOn(
             aurora,
             'getServicesByNocCodeAndDataSourceWithGrouping',
@@ -189,26 +144,6 @@ describe('pages', () => {
                 const result = await getServerSideProps(ctx);
                 expect(result.props.errors.length).toBe(0);
                 expect(result.props.multiOperatorData).toEqual(mockMultiOperatorData);
-            });
-
-            it('should return expected props to the page when there is no bods but having tnds services with multi modes', async () => {
-                getServicesByNocCodeAndDataSourceAndDescriptionSpy.mockResolvedValueOnce(mockBlackServices);
-                const ctx = getMockContext({
-                    session: {
-                        [MULTIPLE_OPERATOR_ATTRIBUTE]: {
-                            selectedOperators: [
-                                { nocCode: 'BLAC', name: 'Blackpool Transport' },
-                                { nocCode: 'LNUD', name: 'Testing ops' },
-                            ],
-                        },
-                        [MULTI_MODAL_ATTRIBUTE]: {
-                            modes: ['ferry', 'tram', 'coach'],
-                        },
-                    },
-                });
-                const result = await getServerSideProps(ctx);
-                expect(result.props.errors.length).toBe(0);
-                expect(result.props.multiOperatorData).toEqual(mockMultiOperatorTndsData);
             });
         });
     });

--- a/repos/fdbt-site/tests/pages/multipleOperatorsServiceList.test.tsx
+++ b/repos/fdbt-site/tests/pages/multipleOperatorsServiceList.test.tsx
@@ -4,7 +4,7 @@ import MultipleOperatorsServiceList, { getServerSideProps } from '../../src/page
 import { getMockContext } from '../testData/mockData';
 import * as aurora from '../../src/data/auroradb';
 import { ErrorInfo, MultiOperatorInfo, ServiceWithOriginAndDestination } from '../../src/interfaces';
-import { MULTIPLE_OPERATOR_ATTRIBUTE } from '../../src/constants/attributes';
+import { MULTIPLE_OPERATOR_ATTRIBUTE, MULTI_MODAL_ATTRIBUTE } from '../../src/constants/attributes';
 
 describe('pages', () => {
     describe('multipleOperatorsServiceList', () => {
@@ -91,6 +91,51 @@ describe('pages', () => {
                 dataSource: 'bods',
             },
         ];
+        const mockMultiOperatorTndsData: MultiOperatorInfo[] = [
+            {
+                nocCode: 'BLAC',
+                name: 'Blackpool Transport',
+                services: [
+                    {
+                        lineName: '1',
+                        lineId: '4YyoI0',
+                        startDate: '05/04/2020',
+                        serviceDescription: 'FLEETWOOD - BLACKPOOL via Promenade',
+                        origin: 'Fleetwood',
+                        destination: 'Blackpool',
+                        serviceCode: 'NW_05_BLAC_1_1',
+                    },
+                    {
+                        lineName: '2',
+                        lineId: 'YpQjUw',
+                        startDate: '05/04/2020',
+                        serviceDescription: 'POULTON - BLACKPOOL via Victoria Hospital Outpatients',
+                        origin: 'Poulton',
+                        destination: 'Blackpool',
+                        serviceCode: 'NW_05_BLAC_2_1',
+                    },
+                ],
+                selectedServices: [],
+                dataSource: 'tnds',
+            },
+            {
+                nocCode: 'LNUD',
+                name: 'Testing ops',
+                services: [
+                    {
+                        lineName: '259',
+                        lineId: 'vHaXmz',
+                        startDate: '25/03/2020',
+                        serviceDescription: 'Brighouse - East Bierley',
+                        origin: 'Brighouse',
+                        destination: 'East Bierley',
+                        serviceCode: 'YWAO259',
+                    },
+                ],
+                selectedServices: [],
+                dataSource: 'tnds',
+            },
+        ];
         const getServicesByNocCodeAndDataSourceAndDescriptionSpy = jest.spyOn(
             aurora,
             'getServicesByNocCodeAndDataSourceWithGrouping',
@@ -144,6 +189,26 @@ describe('pages', () => {
                 const result = await getServerSideProps(ctx);
                 expect(result.props.errors.length).toBe(0);
                 expect(result.props.multiOperatorData).toEqual(mockMultiOperatorData);
+            });
+
+            it('should return expected props to the page when there is no bods but having tnds services with multi modes', async () => {
+                getServicesByNocCodeAndDataSourceAndDescriptionSpy.mockResolvedValueOnce(mockBlackServices);
+                const ctx = getMockContext({
+                    session: {
+                        [MULTIPLE_OPERATOR_ATTRIBUTE]: {
+                            selectedOperators: [
+                                { nocCode: 'BLAC', name: 'Blackpool Transport' },
+                                { nocCode: 'LNUD', name: 'Testing ops' },
+                            ],
+                        },
+                        [MULTI_MODAL_ATTRIBUTE]: {
+                            modes: ['ferry', 'tram', 'coach'],
+                        },
+                    },
+                });
+                const result = await getServerSideProps(ctx);
+                expect(result.props.errors.length).toBe(0);
+                expect(result.props.multiOperatorData).toEqual(mockMultiOperatorTndsData);
             });
         });
     });

--- a/repos/fdbt-site/tests/pages/returnService.test.tsx
+++ b/repos/fdbt-site/tests/pages/returnService.test.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import ReturnService, { getServerSideProps } from '../../src/pages/returnService';
-import { getServicesByNocCodeAndDataSource } from '../../src/data/auroradb';
+import { getServicesByNocCodeAndDataSource, getTndsServicesByNocAndModes } from '../../src/data/auroradb';
 import { expectedReturnTicketWithAdditionalService, expectedSingleTicket, getMockContext } from '../testData/mockData';
 import {
     MATCHING_JSON_ATTRIBUTE,
     MATCHING_JSON_META_DATA_ATTRIBUTE,
+    MULTI_MODAL_ATTRIBUTE,
     OPERATOR_ATTRIBUTE,
 } from '../../src/constants/attributes';
 import { OperatorAttribute, ServiceType } from '../../src/interfaces';
@@ -112,6 +113,69 @@ describe('pages', () => {
                     [OPERATOR_ATTRIBUTE]: operatorData,
                     [MATCHING_JSON_ATTRIBUTE]: expectedReturnTicketWithAdditionalService,
                     [MATCHING_JSON_META_DATA_ATTRIBUTE]: { productId: '1', serviceId: '2', matchingJsonLink: 'blah' },
+                },
+                query: {
+                    selectedServiceId: 1,
+                },
+            });
+            const result = await getServerSideProps(ctx);
+            expect(result).toEqual({
+                props: {
+                    errors: [],
+                    operator: 'Test Op',
+                    passengerType: '',
+                    services: [
+                        {
+                            id: 11,
+                            lineName: '123',
+                            lineId: '3h3vb32ik',
+                            startDate: '05/02/2020',
+                            description: 'this bus service is 123',
+                            origin: 'Manchester',
+                            destination: 'Leeds',
+                            serviceCode: 'NW_05_BLAC_123_1',
+                        },
+                        {
+                            id: 12,
+                            lineName: 'X1',
+                            lineId: '3h3vb32ik',
+                            startDate: '06/02/2020',
+                            description: 'this bus service is X1',
+                            origin: 'Edinburgh',
+                            serviceCode: 'NW_05_BLAC_X1_1',
+                        },
+                        {
+                            id: 13,
+                            lineName: 'Infinity Line',
+                            lineId: '3h3vb32ik',
+                            startDate: '07/02/2020',
+                            description: 'this bus service is Infinity Line',
+                            destination: 'London',
+                            serviceCode: 'WY_13_IWBT_07_1',
+                        },
+                    ],
+                    csrfToken: '',
+                    backHref: '/products/productDetails?productId=1&serviceId=2',
+                    selectedServiceId: 1,
+                },
+            });
+        });
+
+        it('return list of services if multi modal attribute is present', async () => {
+            (getServicesByNocCodeAndDataSource as jest.Mock).mockImplementation(() => []);
+            (getTndsServicesByNocAndModes as jest.Mock).mockImplementation(() => mockServices);
+
+            const operatorData: OperatorAttribute = {
+                name: 'Test Op',
+                nocCode: 'TEST',
+            };
+
+            const ctx = getMockContext({
+                session: {
+                    [OPERATOR_ATTRIBUTE]: operatorData,
+                    [MATCHING_JSON_ATTRIBUTE]: expectedReturnTicketWithAdditionalService,
+                    [MATCHING_JSON_META_DATA_ATTRIBUTE]: { productId: '1', serviceId: '2', matchingJsonLink: 'blah' },
+                    [MULTI_MODAL_ATTRIBUTE]: { modes: ['ferry', 'tram', 'coach'] },
                 },
                 query: {
                     selectedServiceId: 1,

--- a/repos/fdbt-site/tests/pages/returnService.test.tsx
+++ b/repos/fdbt-site/tests/pages/returnService.test.tsx
@@ -60,6 +60,7 @@ describe('pages', () => {
                     csrfToken=""
                     selectedServiceId={1}
                     backHref="/productDetails?productId=1"
+                    dataSource="bods"
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -75,6 +76,7 @@ describe('pages', () => {
                     csrfToken=""
                     selectedServiceId={1}
                     backHref="/productDetails?productId=1"
+                    dataSource="bods"
                 />,
             );
             const operatorWelcome = wrapper.find('#service-operator-passenger-type-hint').first();
@@ -92,6 +94,28 @@ describe('pages', () => {
                     csrfToken=""
                     selectedServiceId={1}
                     backHref=""
+                    dataSource="bods"
+                />,
+            );
+            const operatorServices = wrapper.find('.service-option');
+
+            expect(operatorServices).toHaveLength(3);
+            expect(operatorServices.first().text()).toBe('123 Manchester - Leeds (Start date 05/02/2020)');
+            expect(operatorServices.at(1).text()).toBe('X1 Edinburgh - N/A (Start date 06/02/2020)');
+            expect(operatorServices.at(2).text()).toBe('Infinity Line N/A - London (Start date 07/02/2020)');
+        });
+
+        it('shows a list of services for the operator in the select box with tnds data source', () => {
+            const wrapper = shallow(
+                <ReturnService
+                    operator="Connexions Buses"
+                    passengerType="Adult"
+                    services={mockServices}
+                    errors={[]}
+                    csrfToken=""
+                    selectedServiceId={1}
+                    backHref=""
+                    dataSource="tnds"
                 />,
             );
             const operatorServices = wrapper.find('.service-option');
@@ -157,6 +181,7 @@ describe('pages', () => {
                     csrfToken: '',
                     backHref: '/products/productDetails?productId=1&serviceId=2',
                     selectedServiceId: 1,
+                    dataSource: 'bods',
                 },
             });
         });
@@ -220,6 +245,7 @@ describe('pages', () => {
                     csrfToken: '',
                     backHref: '/products/productDetails?productId=1&serviceId=2',
                     selectedServiceId: 1,
+                    dataSource: 'tnds',
                 },
             });
         });

--- a/repos/fdbt-site/tests/pages/service.test.tsx
+++ b/repos/fdbt-site/tests/pages/service.test.tsx
@@ -3,7 +3,12 @@ import { shallow } from 'enzyme';
 import Service, { getServerSideProps } from '../../src/pages/service';
 import { getServicesByNocCodeAndDataSource } from '../../src/data/auroradb';
 import { getMockContext } from '../testData/mockData';
-import { OPERATOR_ATTRIBUTE, PASSENGER_TYPE_ATTRIBUTE, TXC_SOURCE_ATTRIBUTE } from '../../src/constants/attributes';
+import {
+    MULTI_MODAL_ATTRIBUTE,
+    OPERATOR_ATTRIBUTE,
+    PASSENGER_TYPE_ATTRIBUTE,
+    TXC_SOURCE_ATTRIBUTE,
+} from '../../src/constants/attributes';
 import { ServiceType } from '../../src/interfaces';
 
 jest.mock('../../src/data/auroradb');
@@ -146,6 +151,66 @@ describe('pages', () => {
             expect(operatorServices.first().text()).toBe('123 Manchester - Leeds (Start date 05/02/2020)');
             expect(operatorServices.at(1).text()).toBe('X1 Edinburgh - N/A (Start date 06/02/2020)');
             expect(operatorServices.at(2).text()).toBe('Infinity Line N/A - London (Start date 07/02/2020)');
+        });
+
+        it('returns operator value and list of services for the multi modal operator if multi modal attribute is present in session', async () => {
+            const ctx = getMockContext({
+                session: {
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'tnds',
+                        hasBods: false,
+                        hasTnds: true,
+                    },
+                    [MULTI_MODAL_ATTRIBUTE]: {
+                        modes: ['tram', 'bus', 'coach'],
+                    },
+                },
+            });
+            const result = await getServerSideProps(ctx);
+
+            expect(result).toEqual({
+                props: {
+                    error: [],
+                    operator: 'test',
+                    passengerType: 'Adult',
+                    services: [
+                        {
+                            id: 11,
+                            lineName: '123',
+                            lineId: '3h3vb32ik',
+                            startDate: '05/02/2020',
+                            description: 'this bus service is 123',
+                            origin: 'Manchester',
+                            destination: 'Leeds',
+                            serviceCode: 'NW_05_BLAC_123_1',
+                        },
+                        {
+                            id: 12,
+                            lineName: 'X1',
+                            lineId: '3h3vb32ik',
+                            startDate: '06/02/2020',
+                            description: 'this bus service is X1',
+                            origin: 'Edinburgh',
+                            serviceCode: 'NW_05_BLAC_X1_1',
+                        },
+                        {
+                            id: 13,
+                            lineName: 'Infinity Line',
+                            lineId: '3h3vb32ik',
+                            startDate: '07/02/2020',
+                            description: 'this bus service is Infinity Line',
+                            destination: 'London',
+                            serviceCode: 'WY_13_IWBT_07_1',
+                        },
+                    ],
+                    dataSourceAttribute: {
+                        source: 'tnds',
+                        hasBods: false,
+                        hasTnds: true,
+                    },
+                    csrfToken: '',
+                },
+            });
         });
 
         it('returns operator value and list of services when operator attribute exists with NOCCode', async () => {

--- a/repos/fdbt-site/tests/pages/serviceList.test.tsx
+++ b/repos/fdbt-site/tests/pages/serviceList.test.tsx
@@ -2,8 +2,12 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import ServiceList, { getServerSideProps } from '../../src/pages/serviceList';
 import { getMockContext } from '../testData/mockData';
-import { getServicesByNocCodeAndDataSource, getAllServicesByNocCode } from '../../src/data/auroradb';
-import { OPERATOR_ATTRIBUTE, SERVICE_LIST_ATTRIBUTE } from '../../src/constants/attributes';
+import {
+    getServicesByNocCodeAndDataSource,
+    getAllServicesByNocCode,
+    getTndsServicesByNocAndModes,
+} from '../../src/data/auroradb';
+import { MULTI_MODAL_ATTRIBUTE, OPERATOR_ATTRIBUTE, SERVICE_LIST_ATTRIBUTE } from '../../src/constants/attributes';
 import { ErrorInfo, ServiceType, ServicesInfo } from '../../src/interfaces';
 
 jest.mock('../../src/data/auroradb');
@@ -88,6 +92,7 @@ describe('pages', () => {
         beforeEach(() => {
             (getServicesByNocCodeAndDataSource as jest.Mock).mockImplementation(() => mockServices);
             (getAllServicesByNocCode as jest.Mock).mockImplementation(() => mockServices);
+            (getTndsServicesByNocAndModes as jest.Mock).mockImplementation(() => []);
         });
         /*
         it('should render correctly with tnds data source', () => {
@@ -198,6 +203,27 @@ describe('pages', () => {
                     checked: false,
                 }));
                 expect(result.props.errors.length).toBe(0);
+                expect(result.props.serviceList).toEqual(expectedCheckedServiceList);
+                expect(result.props.buttonText).toEqual('Select All Services');
+            });
+
+            it('should return expected props to the page when the page when multi modal attribute is present', async () => {
+                const ctx = getMockContext({
+                    session: {
+                        [MULTI_MODAL_ATTRIBUTE]: {
+                            modes: ['ferry', 'tram', 'coach'],
+                        },
+                    },
+                });
+                (getAllServicesByNocCode as jest.Mock).mockImplementation(() => []);
+                (getTndsServicesByNocAndModes as jest.Mock).mockImplementation(() => mockServices);
+
+                const result = await getServerSideProps(ctx);
+                const expectedCheckedServiceList: ServicesInfo[] = mockServices.map((mockService) => ({
+                    ...mockService,
+                    checked: false,
+                }));
+
                 expect(result.props.serviceList).toEqual(expectedCheckedServiceList);
                 expect(result.props.buttonText).toEqual('Select All Services');
             });


### PR DESCRIPTION
## Description

Enabling the operators which do not have the BODS services but the TNDS service having multi modes.

## Testing instructions

Create the different kind of tickets like single, return, period with multi services, capped ticket and the multi-operator tickets for the operator as mentioned in the description.
