### PR TITLE
fix: fixed spelling in reuseOperatorGroup

### DIFF
--- a/repos/fdbt-site/src/pages/reuseOperatorGroup.tsx
+++ b/repos/fdbt-site/src/pages/reuseOperatorGroup.tsx
@@ -39,7 +39,7 @@ const ReuseOperatorGroup = ({
                     <fieldset className="govuk-fieldset" aria-describedby="operator-group-page-heading">
                         <legend className="govuk-fieldset__legend govuk-fieldset__legend--l">
                             <h1 className="govuk-fieldset__heading" id="reuse-operator-group-page-heading">
-                                Select a operator group
+                                Select an operator group
                             </h1>
                         </legend>
                         <div className="govuk-warning-text">

--- a/repos/fdbt-site/tests/pages/__snapshots__/reuseOperatorGroup.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/reuseOperatorGroup.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`pages reuseOperatorGroup should render coorectly when one operator grou
             className="govuk-fieldset__heading"
             id="reuse-operator-group-page-heading"
           >
-            Select a operator group
+            Select an operator group
           </h1>
         </legend>
         <div
@@ -129,7 +129,7 @@ exports[`pages reuseOperatorGroup should render correctly 1`] = `
             className="govuk-fieldset__heading"
             id="reuse-operator-group-page-heading"
           >
-            Select a operator group
+            Select an operator group
           </h1>
         </legend>
         <div
@@ -223,7 +223,7 @@ exports[`pages reuseOperatorGroup should render errors when user does not select
             className="govuk-fieldset__heading"
             id="reuse-operator-group-page-heading"
           >
-            Select a operator group
+            Select an operator group
           </h1>
         </legend>
         <div


### PR DESCRIPTION
## Description

Fixed spelling on reuseOperatorGroup

## Testing instructions

Code review
