### PR TITLE
feat: Off-peak NeTEx change

### DIFF
--- a/fdbt-dev/data/netexData/carnetPeriodGeoZone.xml
+++ b/fdbt-dev/data/netexData/carnetPeriodGeoZone.xml
@@ -310,7 +310,7 @@
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="op:Tariff@Product_1@access_zones">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/carnetPeriodGeoZone.xml
+++ b/fdbt-dev/data/netexData/carnetPeriodGeoZone.xml
@@ -310,7 +310,7 @@
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="op:Tariff@Product_1@access_zones">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/carnetPeriodMultiService.xml
+++ b/fdbt-dev/data/netexData/carnetPeriodMultiService.xml
@@ -233,7 +233,7 @@
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="op:Tariff@Test_Product_1@access_lines">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/carnetPeriodMultiService.xml
+++ b/fdbt-dev/data/netexData/carnetPeriodMultiService.xml
@@ -233,7 +233,7 @@
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="op:Tariff@Test_Product_1@access_lines">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/carnetReturn.xml
+++ b/fdbt-dev/data/netexData/carnetReturn.xml
@@ -444,7 +444,7 @@
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@return@lines">
                   <Name>O/D pairs for 19</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Shott_Drive+The_Stag_pub">
                       <priceGroups>

--- a/fdbt-dev/data/netexData/carnetReturn.xml
+++ b/fdbt-dev/data/netexData/carnetReturn.xml
@@ -693,7 +693,7 @@
                   </GenericParameterAssignment>
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@return@availability">
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/carnetReturn.xml
+++ b/fdbt-dev/data/netexData/carnetReturn.xml
@@ -444,7 +444,7 @@
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@return@lines">
                   <Name>O/D pairs for 19</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Shott_Drive+The_Stag_pub">
                       <priceGroups>

--- a/fdbt-dev/data/netexData/carnetSingle.xml
+++ b/fdbt-dev/data/netexData/carnetSingle.xml
@@ -555,7 +555,7 @@
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@single@lines">
                   <Name>O/D pairs for 4</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Test_Stage_1+Test_Stage_2">
                       <priceGroups>

--- a/fdbt-dev/data/netexData/carnetSingle.xml
+++ b/fdbt-dev/data/netexData/carnetSingle.xml
@@ -555,7 +555,7 @@
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@single@lines">
                   <Name>O/D pairs for 4</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Test_Stage_1+Test_Stage_2">
                       <priceGroups>

--- a/fdbt-dev/data/netexData/carnetSingle.xml
+++ b/fdbt-dev/data/netexData/carnetSingle.xml
@@ -1932,7 +1932,7 @@
                   </GenericParameterAssignment>
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@single@availability">
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/flatFareGeoZone.xml
+++ b/fdbt-dev/data/netexData/flatFareGeoZone.xml
@@ -251,7 +251,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="op:Tariff@JTest00@access_zones">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/flatFareGeoZone.xml
+++ b/fdbt-dev/data/netexData/flatFareGeoZone.xml
@@ -251,7 +251,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="op:Tariff@JTest00@access_zones">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/flatFareGroup.xml
+++ b/fdbt-dev/data/netexData/flatFareGroup.xml
@@ -243,7 +243,7 @@
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="op:Tariff@Weekly_Rider@access_lines">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/flatFareGroup.xml
+++ b/fdbt-dev/data/netexData/flatFareGroup.xml
@@ -243,7 +243,7 @@
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="op:Tariff@Weekly_Rider@access_lines">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/multiOpGeoZone.xml
+++ b/fdbt-dev/data/netexData/multiOpGeoZone.xml
@@ -320,7 +320,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="op:Tariff@Product_1@access_zones">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/multiOpGeoZone.xml
+++ b/fdbt-dev/data/netexData/multiOpGeoZone.xml
@@ -320,7 +320,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="op:Tariff@Product_1@access_zones">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/multiOpMultiServices.xml
+++ b/fdbt-dev/data/netexData/multiOpMultiServices.xml
@@ -229,7 +229,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="op:Tariff@Test_Product_1@access_lines">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/multiOpMultiServices.xml
+++ b/fdbt-dev/data/netexData/multiOpMultiServices.xml
@@ -229,7 +229,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="op:Tariff@Test_Product_1@access_lines">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/periodGeoZone.xml
+++ b/fdbt-dev/data/netexData/periodGeoZone.xml
@@ -300,7 +300,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="op:Tariff@Product_1@access_zones">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/periodGeoZone.xml
+++ b/fdbt-dev/data/netexData/periodGeoZone.xml
@@ -300,7 +300,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="op:Tariff@Product_1@access_zones">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/periodGeoZoneGroup.xml
+++ b/fdbt-dev/data/netexData/periodGeoZoneGroup.xml
@@ -312,7 +312,7 @@
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="op:Tariff@Product_1@access_zones">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/periodGeoZoneGroup.xml
+++ b/fdbt-dev/data/netexData/periodGeoZoneGroup.xml
@@ -312,7 +312,7 @@
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="op:Tariff@Product_1@access_zones">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/periodMultiService.xml
+++ b/fdbt-dev/data/netexData/periodMultiService.xml
@@ -223,7 +223,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="op:Tariff@Test_Product_1@access_lines">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/periodMultiService.xml
+++ b/fdbt-dev/data/netexData/periodMultiService.xml
@@ -223,7 +223,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="op:Tariff@Test_Product_1@access_lines">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/periodPointToPoint.xml
+++ b/fdbt-dev/data/netexData/periodPointToPoint.xml
@@ -1198,7 +1198,7 @@
                   </GenericParameterAssignment>
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@period@availability">
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/periodPointToPoint.xml
+++ b/fdbt-dev/data/netexData/periodPointToPoint.xml
@@ -1125,7 +1125,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="Tariff@period@lines">
                   <Name>O/D pairs for 2</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Shott_Drive+The_Stag_pub">
                       <priceGroups>

--- a/fdbt-dev/data/netexData/periodPointToPoint.xml
+++ b/fdbt-dev/data/netexData/periodPointToPoint.xml
@@ -1125,7 +1125,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="Tariff@period@lines">
                   <Name>O/D pairs for 2</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Shott_Drive+The_Stag_pub">
                       <priceGroups>

--- a/fdbt-dev/data/netexData/return.xml
+++ b/fdbt-dev/data/netexData/return.xml
@@ -681,7 +681,7 @@
                   </GenericParameterAssignment>
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@return@availability">
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/return.xml
+++ b/fdbt-dev/data/netexData/return.xml
@@ -432,7 +432,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="Tariff@return@lines">
                   <Name>O/D pairs for 19</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Shott_Drive+The_Stag_pub">
                       <priceGroups>

--- a/fdbt-dev/data/netexData/return.xml
+++ b/fdbt-dev/data/netexData/return.xml
@@ -432,7 +432,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="Tariff@return@lines">
                   <Name>O/D pairs for 19</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Shott_Drive+The_Stag_pub">
                       <priceGroups>

--- a/fdbt-dev/data/netexData/returnCircular.xml
+++ b/fdbt-dev/data/netexData/returnCircular.xml
@@ -340,7 +340,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="Tariff@return@lines">
                   <Name>O/D pairs for 709</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Shott_Drive+The_Stag_pub">
                       <priceGroups>

--- a/fdbt-dev/data/netexData/returnCircular.xml
+++ b/fdbt-dev/data/netexData/returnCircular.xml
@@ -585,7 +585,7 @@
                   </GenericParameterAssignment>
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@return@availability">
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/returnCircular.xml
+++ b/fdbt-dev/data/netexData/returnCircular.xml
@@ -340,7 +340,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="Tariff@return@lines">
                   <Name>O/D pairs for 709</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Shott_Drive+The_Stag_pub">
                       <priceGroups>

--- a/fdbt-dev/data/netexData/returnCircularGroup.xml
+++ b/fdbt-dev/data/netexData/returnCircularGroup.xml
@@ -365,7 +365,7 @@
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@return@lines">
                   <Name>O/D pairs for 709</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Shott_Drive+The_Stag_pub">
                       <priceGroups>

--- a/fdbt-dev/data/netexData/returnCircularGroup.xml
+++ b/fdbt-dev/data/netexData/returnCircularGroup.xml
@@ -365,7 +365,7 @@
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@return@lines">
                   <Name>O/D pairs for 709</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Shott_Drive+The_Stag_pub">
                       <priceGroups>

--- a/fdbt-dev/data/netexData/returnCircularGroup.xml
+++ b/fdbt-dev/data/netexData/returnCircularGroup.xml
@@ -622,7 +622,7 @@
                   </GenericParameterAssignment>
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@return@availability">
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/returnWithExtraService.xml
+++ b/fdbt-dev/data/netexData/returnWithExtraService.xml
@@ -440,7 +440,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="Tariff@return@lines">
                   <Name>O/D pairs for 19</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Shott_Drive+The_Stag_pub">
                       <priceGroups>

--- a/fdbt-dev/data/netexData/returnWithExtraService.xml
+++ b/fdbt-dev/data/netexData/returnWithExtraService.xml
@@ -690,7 +690,7 @@
                   </GenericParameterAssignment>
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@return@availability">
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/returnWithExtraService.xml
+++ b/fdbt-dev/data/netexData/returnWithExtraService.xml
@@ -440,7 +440,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="Tariff@return@lines">
                   <Name>O/D pairs for 19</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Shott_Drive+The_Stag_pub">
                       <priceGroups>

--- a/fdbt-dev/data/netexData/schemeOperatorGeoZone.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorGeoZone.xml
@@ -326,7 +326,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="op:Tariff@Product_1@access_zones">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/schemeOperatorGeoZone.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorGeoZone.xml
@@ -326,7 +326,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="op:Tariff@Product_1@access_zones">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/schemeOperatorMultiServices.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorMultiServices.xml
@@ -232,7 +232,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="op:Tariff@Week_Rider@access_lines">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/schemeOperatorMultiServices.xml
+++ b/fdbt-dev/data/netexData/schemeOperatorMultiServices.xml
@@ -232,7 +232,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="op:Tariff@Week_Rider@access_lines">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/schoolPeriodMultiService.xml
+++ b/fdbt-dev/data/netexData/schoolPeriodMultiService.xml
@@ -226,7 +226,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="op:Tariff@Test_Product_4@access_lines">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/schoolPeriodMultiService.xml
+++ b/fdbt-dev/data/netexData/schoolPeriodMultiService.xml
@@ -226,7 +226,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="op:Tariff@Test_Product_4@access_lines">
                   <Name>Available lines and/or zones</Name>
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/single.xml
+++ b/fdbt-dev/data/netexData/single.xml
@@ -545,7 +545,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="Tariff@single@lines">
                   <Name>O/D pairs for 4</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Test_Stage_1+Test_Stage_2">
                       <priceGroups>

--- a/fdbt-dev/data/netexData/single.xml
+++ b/fdbt-dev/data/netexData/single.xml
@@ -1922,7 +1922,7 @@
                   </GenericParameterAssignment>
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@single@availability">
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/single.xml
+++ b/fdbt-dev/data/netexData/single.xml
@@ -545,7 +545,7 @@
               <fareStructureElements>
                 <FareStructureElement version="1.0" id="Tariff@single@lines">
                   <Name>O/D pairs for 4</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Test_Stage_1+Test_Stage_2">
                       <priceGroups>

--- a/fdbt-dev/data/netexData/singleGroup.xml
+++ b/fdbt-dev/data/netexData/singleGroup.xml
@@ -570,7 +570,7 @@
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@single@lines">
                   <Name>O/D pairs for 4</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Test_Stage_1+Test_Stage_2">
                       <priceGroups>

--- a/fdbt-dev/data/netexData/singleGroup.xml
+++ b/fdbt-dev/data/netexData/singleGroup.xml
@@ -1955,7 +1955,7 @@
                   </GenericParameterAssignment>
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@single@availability">
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/singleGroup.xml
+++ b/fdbt-dev/data/netexData/singleGroup.xml
@@ -570,7 +570,7 @@
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@single@lines">
                   <Name>O/D pairs for 4</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Test_Stage_1+Test_Stage_2">
                       <priceGroups>

--- a/fdbt-dev/data/netexData/singleGroupMultipleAdults.xml
+++ b/fdbt-dev/data/netexData/singleGroupMultipleAdults.xml
@@ -570,7 +570,7 @@
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@single@lines">
                   <Name>O/D pairs for 4</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Test_Stage_1+Test_Stage_2">
                       <priceGroups>

--- a/fdbt-dev/data/netexData/singleGroupMultipleAdults.xml
+++ b/fdbt-dev/data/netexData/singleGroupMultipleAdults.xml
@@ -1955,7 +1955,7 @@
                   </GenericParameterAssignment>
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@single@availability">
-                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>
+                  <TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>
                   <qualityStructureFactors>
                     <FareDemandFactorRef ref="op@Tariff@Demand" version="1.0"/>
                   </qualityStructureFactors>

--- a/fdbt-dev/data/netexData/singleGroupMultipleAdults.xml
+++ b/fdbt-dev/data/netexData/singleGroupMultipleAdults.xml
@@ -570,7 +570,7 @@
                 </FareStructureElement>
                 <FareStructureElement version="1.0" id="Tariff@single@lines">
                   <Name>O/D pairs for 4</Name>
-                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access_when"/>
+                  <TypeOfFareStructureElementRef versionRef="fxc:v1.0" ref="fxc:access"/>
                   <distanceMatrixElements>
                     <DistanceMatrixElement version="1.0" id="Test_Stage_1+Test_Stage_2">
                       <priceGroups>

--- a/repos/fdbt-netex-output/src/data/auroradb.test.ts
+++ b/repos/fdbt-netex-output/src/data/auroradb.test.ts
@@ -1,0 +1,191 @@
+import { removeDuplicateOperators } from './auroradb';
+import { Operator } from '../types';
+
+describe('removeDuplicateOperators', () => {
+    it('returns operators that are not duplicates and for those that are duplicates chooses the element with the mode Bus', () => {
+        const operators: Operator[] = [
+            {
+                nocCode: '1CTL',
+                opId: '135427',
+                vosaPsvLicenseName: '1St Choice Transport Ltd',
+                operatorName: '1st Choice Transport Ltd',
+                url: 'www.1stchoiceltdcoachhire.co.uk#http://www.1stchoiceltdcoachhire.co.uk#',
+                email: 'info@1stchoiceltd.co.uk',
+                contactNumber: '01554759888',
+                street: 'The Transport Depot, Sandy Road, Llanelli SA15 4DP',
+                mode: 'Bus',
+            },
+            {
+                nocCode: 'KCAB',
+                opId: '136871',
+                vosaPsvLicenseName: 'K Cabs (North Yorkshire)',
+                operatorName: 'K Cabs (North Yorkshire)',
+                url: '',
+                email: '',
+                contactNumber: '',
+                street: '',
+                mode: 'Taxi',
+            },
+            {
+                nocCode: 'KEVS',
+                opId: '138238',
+                vosaPsvLicenseName: '',
+                operatorName: 'Kevs Cars and Coaches',
+                url: '#http://www.kevscarsandcoaches.co.uk/#',
+                email: 'info@kevscarsandcoaches.co.uk',
+                contactNumber: '0121 457 9168',
+                street: '39 Orchard Road, Bromsgrove, Worcestershire B61 8HZ',
+                mode: 'Coach',
+            },
+            {
+                nocCode: 'KEVS',
+                opId: '138238',
+                vosaPsvLicenseName: '',
+                operatorName: 'Kevs Cars and Coaches',
+                url: '#http://www.kevscarsandcoaches.co.uk/#',
+                email: 'info@kevscarsandcoaches.co.uk',
+                contactNumber: '0121 457 9168',
+                street: '39 Orchard Road, Bromsgrove, Worcestershire B61 8HZ',
+                mode: 'Bus',
+            },
+            {
+                nocCode: 'ZX',
+                opId: '138130',
+                vosaPsvLicenseName: 'Zoom Airlines Inc',
+                operatorName: 'Zoom Airlines',
+                url: '',
+                email: '',
+                contactNumber: '',
+                street: '',
+                mode: 'Airline',
+            },
+        ];
+
+        const result = removeDuplicateOperators(operators);
+        expect(result).toEqual([
+            {
+                nocCode: '1CTL',
+                opId: '135427',
+                vosaPsvLicenseName: '1St Choice Transport Ltd',
+                operatorName: '1st Choice Transport Ltd',
+                url: 'www.1stchoiceltdcoachhire.co.uk#http://www.1stchoiceltdcoachhire.co.uk#',
+                email: 'info@1stchoiceltd.co.uk',
+                contactNumber: '01554759888',
+                street: 'The Transport Depot, Sandy Road, Llanelli SA15 4DP',
+                mode: 'Bus',
+            },
+            {
+                nocCode: 'KCAB',
+                opId: '136871',
+                vosaPsvLicenseName: 'K Cabs (North Yorkshire)',
+                operatorName: 'K Cabs (North Yorkshire)',
+                url: '',
+                email: '',
+                contactNumber: '',
+                street: '',
+                mode: 'Taxi',
+            },
+            {
+                nocCode: 'KEVS',
+                opId: '138238',
+                vosaPsvLicenseName: '',
+                operatorName: 'Kevs Cars and Coaches',
+                url: '#http://www.kevscarsandcoaches.co.uk/#',
+                email: 'info@kevscarsandcoaches.co.uk',
+                contactNumber: '0121 457 9168',
+                street: '39 Orchard Road, Bromsgrove, Worcestershire B61 8HZ',
+                mode: 'Bus',
+            },
+            {
+                nocCode: 'ZX',
+                opId: '138130',
+                vosaPsvLicenseName: 'Zoom Airlines Inc',
+                operatorName: 'Zoom Airlines',
+                url: '',
+                email: '',
+                contactNumber: '',
+                street: '',
+                mode: 'Airline',
+            },
+        ]);
+    });
+    it('returns operators that are not duplicates', () => {
+        const operators: Operator[] = [
+            {
+                nocCode: '1CTL',
+                opId: '135427',
+                vosaPsvLicenseName: '1St Choice Transport Ltd',
+                operatorName: '1st Choice Transport Ltd',
+                url: 'www.1stchoiceltdcoachhire.co.uk#http://www.1stchoiceltdcoachhire.co.uk#',
+                email: 'info@1stchoiceltd.co.uk',
+                contactNumber: '01554759888',
+                street: 'The Transport Depot, Sandy Road, Llanelli SA15 4DP',
+                mode: 'Bus',
+            },
+            {
+                nocCode: 'KBMT',
+                opId: '136879',
+                vosaPsvLicenseName: 'Keighley Bus Museum Trust Ltd',
+                operatorName: 'Keighley Bus Museum Trust',
+                url: '#http://www.kbmt.org.uk/#',
+                email: 'enquiries@kbmt.org.uk',
+                contactNumber: '07546704558',
+                street: 'Unit 5, River Technology Park, Dalton Lane BD21 4JP',
+                mode: 'Bus',
+            },
+            {
+                nocCode: 'KBUS',
+                opId: '136923',
+                vosaPsvLicenseName: 'Kinchbus Ltd',
+                operatorName: 'Kinchbus',
+                url: 'www.kinchbus.co.uk#http://www.kinchbus.co.uk#',
+                email: 'customer.services@kinchbus.co.uk',
+                contactNumber: '01509 815637',
+                street: 'Sullivan Way, Swingbridge Road, Loughborough LE11 5QS',
+                mode: 'Bus',
+            },
+        ];
+
+        const result = removeDuplicateOperators(operators);
+        expect(result).toEqual([
+            {
+                nocCode: '1CTL',
+                opId: '135427',
+                vosaPsvLicenseName: '1St Choice Transport Ltd',
+                operatorName: '1st Choice Transport Ltd',
+                url: 'www.1stchoiceltdcoachhire.co.uk#http://www.1stchoiceltdcoachhire.co.uk#',
+                email: 'info@1stchoiceltd.co.uk',
+                contactNumber: '01554759888',
+                street: 'The Transport Depot, Sandy Road, Llanelli SA15 4DP',
+                mode: 'Bus',
+            },
+            {
+                nocCode: 'KBMT',
+                opId: '136879',
+                vosaPsvLicenseName: 'Keighley Bus Museum Trust Ltd',
+                operatorName: 'Keighley Bus Museum Trust',
+                url: '#http://www.kbmt.org.uk/#',
+                email: 'enquiries@kbmt.org.uk',
+                contactNumber: '07546704558',
+                street: 'Unit 5, River Technology Park, Dalton Lane BD21 4JP',
+                mode: 'Bus',
+            },
+            {
+                nocCode: 'KBUS',
+                opId: '136923',
+                vosaPsvLicenseName: 'Kinchbus Ltd',
+                operatorName: 'Kinchbus',
+                url: 'www.kinchbus.co.uk#http://www.kinchbus.co.uk#',
+                email: 'customer.services@kinchbus.co.uk',
+                contactNumber: '01509 815637',
+                street: 'Sullivan Way, Swingbridge Road, Loughborough LE11 5QS',
+                mode: 'Bus',
+            },
+        ]);
+    });
+    it('returns an empty array when there are no operators', () => {
+        const operators: Operator[] = [];
+        const result = removeDuplicateOperators(operators);
+        expect(result).toEqual([]);
+    });
+});

--- a/repos/fdbt-netex-output/src/data/auroradb.ts
+++ b/repos/fdbt-netex-output/src/data/auroradb.ts
@@ -54,7 +54,7 @@ export const getOperatorDetailsByNoc = async (nocCode: string): Promise<Operator
     }
 };
 
-export const removeDuplicateOperators = (operators: Operator[]) => {
+export const removeDuplicateOperators = (operators: Operator[]): Operator[] => {
     const filteredOperators = operators.filter(op => {
         // find the number of times the operator appears in the operators array
         const operatorCount = operators.filter(operator => operator.nocCode === op.nocCode).length;

--- a/repos/fdbt-netex-output/src/data/auroradb.ts
+++ b/repos/fdbt-netex-output/src/data/auroradb.ts
@@ -54,6 +54,16 @@ export const getOperatorDetailsByNoc = async (nocCode: string): Promise<Operator
     }
 };
 
+export const removeDuplicateOperators = (operators: Operator[]) => {
+    const filteredOperators = operators.filter(op => {
+        // find the number of times the operator appears in the operators array
+        const operatorCount = operators.filter(operator => operator.nocCode === op.nocCode).length;
+        // only return operators where they appear once or their mode is bus
+        return operatorCount === 1 || op.mode === 'Bus';
+    });
+    return filteredOperators;
+};
+
 export const getOperatorDataByNocCode = async (nocCodes: string[]): Promise<Operator[]> => {
     try {
         const cleansedNocs: string[] = nocCodes.map(noc => replaceIWBusCoNocCode(noc));
@@ -77,7 +87,9 @@ export const getOperatorDataByNocCode = async (nocCodes: string[]): Promise<Oper
             throw new Error(`No operator data found for nocCodes: ${cleansedNocs.join(',')}`);
         }
 
-        return operatorData;
+        const filteredOperators = removeDuplicateOperators(operatorData);
+
+        return filteredOperators;
     } catch (err) {
         throw new Error(`Could not retrieve operator data from AuroraDB: ${err.stack}`);
     }

--- a/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
@@ -666,7 +666,7 @@ export const getPeriodAvailabilityElement = (
     Name: { $t: 'Available lines and/or zones' },
     TypeOfFareStructureElementRef: {
         version: 'fxc:v1.0',
-        ref: 'fxc:access',
+        ref: hasTimeRestriction ? 'fxc:access_when' : 'fxc:access',
     },
     qualityStructureFactors: hasTimeRestriction
         ? {

--- a/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
@@ -666,7 +666,7 @@ export const getPeriodAvailabilityElement = (
     Name: { $t: 'Available lines and/or zones' },
     TypeOfFareStructureElementRef: {
         version: 'fxc:v1.0',
-        ref: hasTimeRestriction ? 'fxc:access_when' : 'fxc:access',
+        ref: 'fxc:access',
     },
     qualityStructureFactors: hasTimeRestriction
         ? {

--- a/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexHelpers.ts
@@ -550,7 +550,7 @@ export const getLinesElement = (
         Name: { $t: `O/D pairs for ${lineName}` },
         TypeOfFareStructureElementRef: {
             versionRef: 'fxc:v1.0',
-            ref: 'fxc:access',
+            ref: 'fxc:access_when',
         },
         distanceMatrixElements: {
             DistanceMatrixElement: isReturnTicket(ticket)

--- a/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexHelpers.ts
@@ -261,20 +261,23 @@ export const getInnerFareTables = (
 
 export const getPointToPointAvailabilityElement = (
     ticket: PointToPointTicket | PointToPointPeriodTicket,
-): NetexObject => ({
-    version: '1.0',
-    id: `Tariff@${ticket.type}@availability`,
-    TypeOfFareStructureElementRef: {
-        version: 'fxc:v1.0',
-        ref: 'fxc:access',
-    },
-    qualityStructureFactors: {
-        FareDemandFactorRef: {
-            ref: 'op@Tariff@Demand',
-            version: '1.0',
+): NetexObject => {
+    const hasTimeRestriction = !!ticket.timeRestriction && ticket.timeRestriction.length > 0;
+    return {
+        version: '1.0',
+        id: `Tariff@${ticket.type}@availability`,
+        TypeOfFareStructureElementRef: {
+            version: 'fxc:v1.0',
+            ref: hasTimeRestriction ? 'fxc:access_when' : 'fxc:access',
         },
-    },
-});
+        qualityStructureFactors: {
+            FareDemandFactorRef: {
+                ref: 'op@Tariff@Demand',
+                version: '1.0',
+            },
+        },
+    };
+};
 
 export const getPreassignedFareProduct = (
     matchingData: PointToPointTicket | PointToPointPeriodTicket,

--- a/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexHelpers.ts
@@ -516,7 +516,7 @@ export const getLinesElement = (
                 ref: ticket.additionalServices[0].lineId,
             },
         ];
-        const hasTimeRestriction = !!ticket.timeRestriction && ticket.timeRestriction.length > 0;
+        const hasTimeRestriction = ticket.timeRestriction.length > 0;
         return {
             version: '1.0',
             id: `Tariff@${typeOfPointToPoint}@lines`,

--- a/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexHelpers.ts
@@ -261,23 +261,20 @@ export const getInnerFareTables = (
 
 export const getPointToPointAvailabilityElement = (
     ticket: PointToPointTicket | PointToPointPeriodTicket,
-): NetexObject => {
-    const hasTimeRestriction = !!ticket.timeRestriction && ticket.timeRestriction.length > 0;
-    return {
-        version: '1.0',
-        id: `Tariff@${ticket.type}@availability`,
-        TypeOfFareStructureElementRef: {
-            version: 'fxc:v1.0',
-            ref: hasTimeRestriction ? 'fxc:access_when' : 'fxc:access',
+): NetexObject => ({
+    version: '1.0',
+    id: `Tariff@${ticket.type}@availability`,
+    TypeOfFareStructureElementRef: {
+        version: 'fxc:v1.0',
+        ref: 'fxc:access_when',
+    },
+    qualityStructureFactors: {
+        FareDemandFactorRef: {
+            ref: 'op@Tariff@Demand',
+            version: '1.0',
         },
-        qualityStructureFactors: {
-            FareDemandFactorRef: {
-                ref: 'op@Tariff@Demand',
-                version: '1.0',
-            },
-        },
-    };
-};
+    },
+});
 
 export const getPreassignedFareProduct = (
     matchingData: PointToPointTicket | PointToPointPeriodTicket,

--- a/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexHelpers.ts
@@ -516,14 +516,14 @@ export const getLinesElement = (
                 ref: ticket.additionalServices[0].lineId,
             },
         ];
-
+        const hasTimeRestriction = !!ticket.timeRestriction && ticket.timeRestriction.length > 0;
         return {
             version: '1.0',
             id: `Tariff@${typeOfPointToPoint}@lines`,
             Name: { $t: `O/D pairs for ${lineName}` },
             TypeOfFareStructureElementRef: {
                 versionRef: 'fxc:v1.0',
-                ref: 'fxc:access',
+                ref: hasTimeRestriction ? 'fxc:access_when' : 'fxc:access',
             },
             distanceMatrixElements: {
                 DistanceMatrixElement: getDistanceMatrixElements(

--- a/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/point-to-point-tickets/pointToPointTicketNetexHelpers.ts
@@ -516,14 +516,14 @@ export const getLinesElement = (
                 ref: ticket.additionalServices[0].lineId,
             },
         ];
-        const hasTimeRestriction = ticket.timeRestriction.length > 0;
+
         return {
             version: '1.0',
             id: `Tariff@${typeOfPointToPoint}@lines`,
             Name: { $t: `O/D pairs for ${lineName}` },
             TypeOfFareStructureElementRef: {
                 versionRef: 'fxc:v1.0',
-                ref: hasTimeRestriction ? 'fxc:access_when' : 'fxc:access',
+                ref: 'fxc:access',
             },
             distanceMatrixElements: {
                 DistanceMatrixElement: getDistanceMatrixElements(
@@ -550,7 +550,7 @@ export const getLinesElement = (
         Name: { $t: `O/D pairs for ${lineName}` },
         TypeOfFareStructureElementRef: {
             versionRef: 'fxc:v1.0',
-            ref: 'fxc:access_when',
+            ref: 'fxc:access',
         },
         distanceMatrixElements: {
             DistanceMatrixElement: isReturnTicket(ticket)

--- a/repos/fdbt-netex-output/src/netex-convertor/sharedHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/sharedHelpers.ts
@@ -416,7 +416,7 @@ export const getFareStructuresElements = (
     const productFareStructureElements = ticket.products.flatMap(product => {
         let availabilityElementId = '';
         let validityParametersObject = {};
-        const hasTimeRestriction = !!ticket.timeRestriction && ticket.timeRestriction.length > 0;
+        const hasTimeRestriction = ticket.timeRestriction.length > 0;
 
         if (isGeoZoneTicket(ticket)) {
             availabilityElementId = `Tariff@${product.productName}@access_zones`;


### PR DESCRIPTION
## Description

NeTEx created with time restrictions include an additional FareStructureElement to include the additional restrictions to access rights of product. This should only apply to the FareStructureElement that includes the qualityStructureFactors. The other FareStructureElements relating to access (i.e. include GenericParameterAssignments) should remain unchanged.

## Testing instructions

Currently this FareStructureElement includes: 

`<TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access"/>`
 
This needs to be replaced with:

`<TypeOfFareStructureElementRef version="fxc:v1.0" ref="fxc:access_when"/>`

Code review required
