### PR TITLE
fix: Display the dataSource for noServices page

### DIFF
--- a/repos/fdbt-site/src/pages/noServices.tsx
+++ b/repos/fdbt-site/src/pages/noServices.tsx
@@ -1,16 +1,24 @@
 import React, { ReactElement } from 'react';
 import TwoThirdsLayout from '../layout/Layout';
+import { NextPageContextWithSession } from '../interfaces';
+import { getSessionAttribute } from '../utils/sessions';
+import { MULTI_MODAL_ATTRIBUTE } from '../constants/attributes';
 
 const title = 'No Services - Create Fares Data Service';
 const description = 'No Services error page of the Create Fares Data Service';
 
-const NoServices = (): ReactElement => (
+interface NoServicesProps {
+    dataSource: string;
+}
+
+const NoServices = ({ dataSource }: NoServicesProps): ReactElement => (
     <TwoThirdsLayout title={title} description={description}>
         <h1 className="govuk-heading-l">
             Sorry, there is no service data available for your National Operator Code (NOC)
         </h1>
         <p className="govuk-body-m">
-            This service utilises the Bus Open Data Service (BODS) and Traveline National Dataset (TNDS) to obtain
+            This service utilises the{' '}
+            {dataSource === 'tnds' ? 'Traveline National Dataset (TNDS)' : 'Bus Open Data Service (BODS)'} to obtain
             operator&apos;s service data in order to help them create fares data.
         </p>
         <p className="govuk-body-m">
@@ -33,8 +41,14 @@ const NoServices = (): ReactElement => (
     </TwoThirdsLayout>
 );
 
-export const getServerSideProps = (): {} => {
-    return { props: {} };
+export const getServerSideProps = (ctx: NextPageContextWithSession): { props: NoServicesProps } => {
+    const dataSource = !!getSessionAttribute(ctx.req, MULTI_MODAL_ATTRIBUTE) ? 'tnds' : 'bods';
+
+    return {
+        props: {
+            dataSource,
+        },
+    };
 };
 
 export default NoServices;

--- a/repos/fdbt-site/tests/pages/noServices.test.tsx
+++ b/repos/fdbt-site/tests/pages/noServices.test.tsx
@@ -5,7 +5,12 @@ import NoServices from '../../src/pages/noServices';
 describe('pages', () => {
     describe('noServices', () => {
         it('should render correctly', () => {
-            const tree = shallow(<NoServices />);
+            const tree = shallow(<NoServices dataSource="bods" />);
+            expect(tree).toMatchSnapshot();
+        });
+
+        it('should render correctly for tnds datasource', () => {
+            const tree = shallow(<NoServices dataSource="tnds" />);
             expect(tree).toMatchSnapshot();
         });
     });


### PR DESCRIPTION
## Description

Display the accurate data source used for services in the noServices page

## Testing instructions

Login to tnds operator with no services
Login to operator with no bods/tnds services
