### PR TITLE
fix: Csv zone upload select all button not working

### DIFF
--- a/repos/fdbt-site/src/pages/csvZoneUpload.tsx
+++ b/repos/fdbt-site/src/pages/csvZoneUpload.tsx
@@ -76,7 +76,7 @@ const CsvZoneUpload = ({
     const [checkedServices, updateChecked] = useState(uniqueServiceLists.filter((service) => service.checked));
 
     const toggleAllServices = (): void => {
-        if (checkedServices.length !== uniqueServiceLists.length) {
+        if (checkedServices.length !== uniqueServiceLists.length && getButtonText === 'Select All Services') {
             updateButtonText('Unselect All Services');
             updateChecked(uniqueServiceLists);
         } else {

--- a/repos/fdbt-site/src/pages/csvZoneUpload.tsx
+++ b/repos/fdbt-site/src/pages/csvZoneUpload.tsx
@@ -72,17 +72,28 @@ const CsvZoneUpload = ({
     const uniqueServiceLists =
         serviceList.filter((item) => (seen.includes(item.lineId) ? false : seen.push(item.lineId))) ?? [];
 
-    const isDefaultChecked = serviceList.every((service) => service.checked);
     const [getButtonText, updateButtonText] = useState(buttonText);
-    const [isCheckedAll, updateChecked] = useState(isDefaultChecked);
+    const [checkedServices, updateChecked] = useState(uniqueServiceLists.filter((service) => service.checked));
 
     const toggleAllServices = (): void => {
-        if (!isCheckedAll) {
+        if (checkedServices.length !== uniqueServiceLists.length) {
             updateButtonText('Unselect All Services');
+            updateChecked(uniqueServiceLists);
         } else {
             updateButtonText('Select All Services');
+            updateChecked([]);
         }
-        updateChecked(!isCheckedAll);
+    };
+
+    const updateCheckedServiceList = (e: React.ChangeEvent<HTMLInputElement>, lineId: string) => {
+        if (!e.target.checked) {
+            updateChecked(checkedServices.filter((service) => service.lineId !== lineId));
+        } else {
+            const serviceToAdd = uniqueServiceLists.find((service) => service.lineId === lineId);
+            if (serviceToAdd) {
+                updateChecked([...checkedServices, serviceToAdd]);
+            }
+        }
     };
 
     return (
@@ -160,7 +171,7 @@ const CsvZoneUpload = ({
                                                 <div className="govuk-form-group">
                                                     <fieldset className="govuk-fieldset">
                                                         <input
-                                                            type="submit"
+                                                            type="button"
                                                             name="selectAll"
                                                             value={getButtonText}
                                                             id="select-all-button"
@@ -200,7 +211,16 @@ const CsvZoneUpload = ({
                                                                             name={`${lineName}#${lineId}#${serviceCode}`}
                                                                             type="checkbox"
                                                                             value={checkBoxValues}
-                                                                            defaultChecked={checked || isCheckedAll}
+                                                                            checked={
+                                                                                !!checkedServices.find(
+                                                                                    (service) =>
+                                                                                        service.lineId === lineId,
+                                                                                )
+                                                                            }
+                                                                            defaultChecked={checked}
+                                                                            onChange={(e) =>
+                                                                                updateCheckedServiceList(e, lineId)
+                                                                            }
                                                                         />
                                                                         <label
                                                                             className="govuk-label govuk-checkboxes__label"

--- a/repos/fdbt-site/tests/pages/__snapshots__/csvZoneUpload.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/csvZoneUpload.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`pages csvzoneupload should render correctly 1`] = `
                           id="select-all-button"
                           name="selectAll"
                           onClick={[Function]}
-                          type="submit"
+                          type="button"
                           value="Select All Services"
                         />
                         <div
@@ -133,10 +133,12 @@ exports[`pages csvzoneupload should render correctly 1`] = `
                             key="checkbox-item-123"
                           >
                             <input
+                              checked={false}
                               className="govuk-checkboxes__input"
                               defaultChecked={false}
                               id="checkbox-0"
                               name="123#3h3vb32ik#NW_05_BLAC_123_1"
+                              onChange={[Function]}
                               type="checkbox"
                               value="IW Bus Service 123"
                             />


### PR DESCRIPTION
## Description

When the user clicks 'unselect all' or 'select all' , there seems to be some sort of page refresh happening and unselect all doesn't unselect all the services.

## Testing instructions

Create a flat fare geozone and test adding / removing services
