### PR TITLE
feat: Add the exempted services to geoZone matching JSON

### DIFF
--- a/fdbt-dev/flatFareWithExemptions.json
+++ b/fdbt-dev/flatFareWithExemptions.json
@@ -15,7 +15,7 @@
     }
   ],
   "ticketPeriod": { "startDate": "2020-04-12T00:00:00.000Z" },
-  "operatorName": "Test Operator",
+  "operatorName": "Blackpool transport",
   "products": [
     {
       "productName": "it is random",

--- a/fdbt-dev/flatFareWithExemptions.json
+++ b/fdbt-dev/flatFareWithExemptions.json
@@ -1,0 +1,237 @@
+{
+  "nocCode": "BLAC",
+  "type": "flatFare",
+  "passengerType": "adult",
+  "email": "test@example.com",
+  "uuid": "BLACe439dab1",
+  "timeRestriction": [
+    {
+      "day": "monday",
+      "timeBands": [{ "startTime": "0900", "endTime": "1800" }]
+    },
+    {
+      "day": "thursday",
+      "timeBands": [{ "startTime": "0800", "endTime": "1700" }]
+    }
+  ],
+  "ticketPeriod": { "startDate": "2020-04-12T00:00:00.000Z" },
+  "operatorName": "Test Operator",
+  "products": [
+    {
+      "productName": "it is random",
+      "productPrice": "2",
+      "salesOfferPackages": [
+        {
+          "name": "Onboard (cash)",
+          "description": "",
+          "purchaseLocations": ["onBoard"],
+          "paymentMethods": ["cash"],
+          "ticketFormats": ["paperTicket"],
+          "price": "2.99"
+        },
+        {
+          "name": "Onboard (contactless)",
+          "description": "",
+          "purchaseLocations": ["onBoard"],
+          "paymentMethods": ["contactlessPaymentCard"],
+          "ticketFormats": ["paperTicket"],
+          "price": "2.99"
+        }
+      ]
+    }
+  ],
+  "zoneName": "Test Town Centre",
+  "stops": [
+    {
+      "stopName": "The Towers",
+      "naptanCode": "CHEPJWM",
+      "atcoCode": "0600MA6001",
+      "localityCode": "N0076467",
+      "localityName": "Macclesfield",
+      "parentLocalityName": "",
+      "indicator": "opp",
+      "street": "Park Street"
+    },
+    {
+      "stopName": "Dog & Partridge",
+      "naptanCode": "wrgdpma",
+      "atcoCode": "069000012480",
+      "localityCode": "E0043040",
+      "localityName": "Paddington",
+      "parentLocalityName": "Warrington",
+      "indicator": "o/s",
+      "street": "New Manchester Road"
+    },
+    {
+      "stopName": "Manchester Rd",
+      "naptanCode": "MANATDWT",
+      "atcoCode": "1800ED24711",
+      "localityCode": "E0028839",
+      "localityName": "Hollinwood",
+      "parentLocalityName": "",
+      "indicator": "Stop A",
+      "street": "MANCHESTER RD"
+    },
+    {
+      "stopName": "Bower Fold",
+      "naptanCode": "MANDGADW",
+      "atcoCode": "1800EH37241",
+      "localityCode": "E0028586",
+      "localityName": "Bower Fold",
+      "parentLocalityName": "Stalybridge",
+      "indicator": null,
+      "street": "Mottram Rd"
+    },
+    {
+      "stopName": "Oak Road",
+      "naptanCode": "MANJTPJW",
+      "atcoCode": "1800SJ47971",
+      "localityCode": "N0075113",
+      "localityName": "Partington",
+      "parentLocalityName": "",
+      "indicator": "nr",
+      "street": "WARBURTON LANE"
+    },
+    {
+      "stopName": "Meadow Close",
+      "naptanCode": "MANPATDT",
+      "atcoCode": "1800WA15551",
+      "localityCode": "E0028979",
+      "localityName": "Little Lever",
+      "parentLocalityName": "",
+      "indicator": "opp",
+      "street": "BOOTH ROAD"
+    },
+    {
+      "stopName": "Church Road",
+      "naptanCode": "lanatgjp",
+      "atcoCode": "25001814",
+      "localityCode": "E0015836",
+      "localityName": "Great Plumpton",
+      "parentLocalityName": "",
+      "indicator": "by",
+      "street": "Church Road"
+    },
+    {
+      "stopName": "Hare and Hounds",
+      "naptanCode": "lanawtwg",
+      "atcoCode": "2500759",
+      "localityCode": "E0015881",
+      "localityName": "Clayton-le-Moors",
+      "parentLocalityName": "",
+      "indicator": "Stop 2",
+      "street": "Whalley Road"
+    },
+    {
+      "stopName": "Skippool Avenue",
+      "naptanCode": "langjpaw",
+      "atcoCode": "2500IMG456",
+      "localityCode": "E0016583",
+      "localityName": "Poulton-le-Fylde",
+      "parentLocalityName": "",
+      "indicator": "opp",
+      "street": "Breck Road"
+    },
+    {
+      "stopName": "Lytham St Annes HTC",
+      "naptanCode": "lanpamtw",
+      "atcoCode": "2500LAA16548",
+      "localityCode": "E0015826",
+      "localityName": "Ansdell",
+      "parentLocalityName": "",
+      "indicator": "by",
+      "street": "Church Road"
+    },
+    {
+      "stopName": "Torsway Avenue",
+      "naptanCode": "blpadadw",
+      "atcoCode": "2590B0008",
+      "localityCode": "E0035280",
+      "localityName": "Kingscote",
+      "parentLocalityName": "Blackpool",
+      "indicator": "by",
+      "street": "Newton Drive"
+    },
+    {
+      "stopName": "Spencer Court",
+      "naptanCode": "blpadwgm",
+      "atcoCode": "2590B0316",
+      "localityCode": "N0079370",
+      "localityName": "Central",
+      "parentLocalityName": "Blackpool",
+      "indicator": "by",
+      "street": "Talbot Road"
+    },
+    {
+      "stopName": "Mesnes Park",
+      "naptanCode": "mergjpjd",
+      "atcoCode": "2800S10110A",
+      "localityCode": "E0029817",
+      "localityName": "Newton le Willows",
+      "parentLocalityName": "",
+      "indicator": "Opposite",
+      "street": "Park Road North"
+    },
+    {
+      "stopName": "Grosvenor Road",
+      "naptanCode": "merdwgmt",
+      "atcoCode": "2800S51045B",
+      "localityCode": "E0052682",
+      "localityName": "Prescot",
+      "parentLocalityName": "",
+      "indicator": "Adjacent",
+      "street": "St Helens Road"
+    },
+    {
+      "stopName": "Campbell Avenue",
+      "naptanCode": "32900357",
+      "atcoCode": "3290YYA00357",
+      "localityCode": "E0043596",
+      "localityName": "Holgate",
+      "parentLocalityName": "York",
+      "indicator": "opp",
+      "street": "Hamilton Drive"
+    },
+    {
+      "stopName": "Main Street St Johns Close",
+      "naptanCode": "45010202",
+      "atcoCode": "450010202",
+      "localityCode": "E0032162",
+      "localityName": "Aberford",
+      "parentLocalityName": "Leeds",
+      "indicator": "at",
+      "street": "Main Street"
+    },
+    {
+      "stopName": "Midgley Road Spring Villas",
+      "naptanCode": "45019529",
+      "atcoCode": "450019529",
+      "localityCode": "E0033244",
+      "localityName": "Mytholmroyd",
+      "parentLocalityName": "Hebden Bridge",
+      "indicator": "at",
+      "street": "Midgley Road"
+    }
+  ],
+  "exemptedServices": [
+    {
+      "lineName": "1",
+      "lineId": "4YyoI0",
+      "serviceCode": "NW_05_BLAC_1_1",
+      "serviceDescription": "FLEETWOOD - BLACKPOOL via Promenade"
+    },
+    {
+      "lineName": "2",
+      "lineId": "YpQjUw",
+      "serviceCode": "NW_05_BLAC_2_1",
+      "serviceDescription": "POULTON - BLACKPOOL via Victoria Hospital Outpatients"
+    },
+    {
+      "lineName": "2C",
+      "lineId": "vySmfewe0",
+      "serviceCode": "NW_05_BLAC_2C_1",
+      "serviceDescription": "KNOTT END - POULTON - BLACKPOOL"
+    }
+  ],
+  "carnet": false
+}

--- a/repos/fdbt-site/src/interfaces/matchingJsonTypes.ts
+++ b/repos/fdbt-site/src/interfaces/matchingJsonTypes.ts
@@ -8,11 +8,13 @@ export interface PointToPointCarnetProductDetails extends BaseProduct {
 export type FlatFareGeoZoneTicket = Omit<PeriodGeoZoneTicket, 'products' | 'type'> & {
     type: 'flatFare';
     products: FlatFareProduct[];
+    exemptedServices?: SelectedService[];
 };
 
 export interface PeriodGeoZoneTicket extends BasePeriodTicket {
     zoneName: string;
     stops: Stop[];
+    exemptedServices?: SelectedService[];
 }
 
 export interface BasePeriodTicket extends BaseTicket<'period' | 'multiOperator' | 'capped'> {

--- a/repos/fdbt-site/src/utils/apiUtils/userData.ts
+++ b/repos/fdbt-site/src/utils/apiUtils/userData.ts
@@ -35,6 +35,7 @@ import {
     CAP_EXPIRY_ATTRIBUTE,
     CAP_START_ATTRIBUTE,
     CAPPED_PRODUCT_GROUP_ID_ATTRIBUTE,
+    SERVICE_LIST_EXEMPTION_ATTRIBUTE,
 } from '../../constants/attributes';
 import {
     batchGetStopsByAtcoCode,
@@ -547,6 +548,7 @@ export const getGeoZoneTicketJson = async (
 
     const fareZoneName = getSessionAttribute(req, FARE_ZONE_ATTRIBUTE);
     const multiOpAttribute = getSessionAttribute(req, MULTIPLE_OPERATOR_ATTRIBUTE);
+    const exemptions = getSessionAttribute(req, SERVICE_LIST_EXEMPTION_ATTRIBUTE) as ServiceListAttribute;
 
     if (!fareZoneName || isFareZoneAttributeWithErrors(fareZoneName)) {
         throw new Error('Could not create geo zone ticket json. Necessary cookies and session objects not found.');
@@ -577,6 +579,7 @@ export const getGeoZoneTicketJson = async (
         stops: zoneStops,
         ...(additionalNocs && { additionalNocs }),
         ...(operatorGroupId && { operatorGroupId }),
+        ...(exemptions && { exemptedServices: exemptions.selectedServices }),
     };
 };
 

--- a/repos/fdbt-site/tests/testData/mockData.ts
+++ b/repos/fdbt-site/tests/testData/mockData.ts
@@ -3058,6 +3058,60 @@ export const expectedFlatFareGeoZoneTicket: WithIds<FlatFareGeoZoneTicket> = {
     ],
 };
 
+export const expectedFlatFareGeoZoneTicketWithExemptions: WithIds<FlatFareGeoZoneTicket> = {
+    operatorName: 'test',
+    passengerType: { id: 9 },
+    type: 'flatFare',
+    nocCode: 'TEST',
+    uuid: '1e0459b3-082e-4e70-89db-96e8ae173e10',
+    email: 'test@example.com',
+    zoneName: 'my flat fare zone',
+    stops: zoneStops,
+    ticketPeriod: {
+        startDate: '2020-12-17T09:30:46.0Z',
+        endDate: '2020-12-18T09:30:46.0Z',
+    },
+    products: [
+        {
+            productName: 'Flat fare with geo zone',
+            productPrice: '7',
+            salesOfferPackages: [
+                {
+                    id: 1,
+                    price: undefined,
+                },
+                {
+                    id: 3,
+                    price: undefined,
+                },
+            ],
+        },
+    ],
+    exemptedServices: [
+        {
+            lineName: '100',
+            lineId: '3h3rthsrty56y5',
+            serviceCode: '11-444-_-y08-1',
+            serviceDescription: 'Test Under Lyne - Glossop',
+            startDate: '07/04/2020',
+        },
+        {
+            lineName: '101',
+            lineId: '3h34t43deefsf',
+            serviceCode: 'NW_01_MCT_391_1',
+            serviceDescription: 'Macclesfield - Bollington - Poynton - Stockport',
+            startDate: '23/04/2019',
+        },
+        {
+            lineName: '102',
+            lineId: '34tvwevdsvb32ik',
+            serviceCode: 'NW_04_MCTR_232_1',
+            serviceDescription: 'Ashton - Hurst Cross - Broadoak Circular',
+            startDate: '06/04/2020',
+        },
+    ],
+};
+
 export const expectedSchemeOperatorTicket = (
     type: BaseSchemeOperatorTicket['type'],
 ): WithBaseIds<BaseSchemeOperatorTicket> => {


### PR DESCRIPTION
## Description

We need to add the exempted services for a geoZone ticket if the user selects them, so we can display them in the netex.

## Testing instructions

Code review
