### PR TITLE
fix: Hybrid netex creates duplicate netex element

### DIFF
--- a/fdbt-dev/data/netexData/flatFareWithExemptions.xml
+++ b/fdbt-dev/data/netexData/flatFareWithExemptions.xml
@@ -293,7 +293,7 @@
                       <GroupOfLinesRef version="1.0" ref="BLAC@groupOfLines@1"/>
                     </validityParameters>
                     <includes>
-                      <GenericParameterAssignment version="1.0" id="it_is_random-groupsOfLinesWrapper" order="2">
+                      <GenericParameterAssignment version="1.0" id="it_is_random-exemptedGroupsOfLinesWrapper" order="2">
                         <TypeOfAccessRightAssignmentRef version="fxc:v1.0" ref="fxc:cannot_access"/>
                         <validityParameters>
                           <GroupOfLinesRef version="1.0" ref="BLAC@groupOfLines@1"/>

--- a/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.test.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.test.ts
@@ -1026,7 +1026,7 @@ describe('periodTicketNetexHelpers', () => {
                     includes: {
                         GenericParameterAssignment: {
                             version: '1.0',
-                            id: `test-groupsOfLinesWrapper`,
+                            id: 'test-exemptedGroupsOfLinesWrapper',
                             order: '2',
                             TypeOfAccessRightAssignmentRef: {
                                 version: 'fxc:v1.0',

--- a/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
+++ b/repos/fdbt-netex-output/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
@@ -957,7 +957,7 @@ export const getExemptionsElement = (
         includes: {
             GenericParameterAssignment: {
                 version: '1.0',
-                id: `${productName}-groupsOfLinesWrapper`,
+                id: `${productName}-exemptedGroupsOfLinesWrapper`,
                 order: '2',
                 TypeOfAccessRightAssignmentRef: {
                     version: 'fxc:v1.0',


### PR DESCRIPTION
## Description

There was an error when validating NeTEx file: LNUD/exports/LNUD_2023_01_26/FX-PI-01_UK_LNUD_NETWORK-FARE_Hybrid-product-1_2023-01-26_2010-10-13_126c.xml, error: Element '

{[http://www.netex.org.uk/netex]}
GenericParameterAssignment': Duplicate key-sequence ['Hybrid_product_1-groupsOfLinesWrapper', '1.0', '2'] in key identity-constraint '

{[http://www.netex.org.uk/netex]}
GenericParameterAssignment_AnyVersionedKey_ordered'., line 328

## Testing instructions

Add exempted services to hybridPeriod.json and generate netex, run validation.
