### PR TITLE
fix: Removed feature flag and saving product name correctly for PPD

### DIFF
--- a/repos/fdbt-site/src/interfaces/matchingJsonTypes.ts
+++ b/repos/fdbt-site/src/interfaces/matchingJsonTypes.ts
@@ -47,6 +47,7 @@ export interface FlatFareProduct extends BaseProduct {
 }
 
 export interface PriceByDistanceProduct extends BaseProduct {
+    productName: string;
     pricingByDistance: DistancePricingData;
 }
 

--- a/repos/fdbt-site/src/pages/ticketRepresentation.tsx
+++ b/repos/fdbt-site/src/pages/ticketRepresentation.tsx
@@ -26,7 +26,6 @@ interface TicketRepresentationProps {
     showPointToPoint: boolean;
     showFlatFlare: boolean;
     showMultiOperator: boolean;
-    isDevOrTest: boolean;
 }
 
 const getFareTypeDesc = (fareType: TicketType) => {
@@ -68,7 +67,6 @@ const TicketRepresentation = ({
     showPointToPoint,
     showFlatFlare,
     showMultiOperator,
-    isDevOrTest,
 }: TicketRepresentationProps): ReactElement => {
     const fareTypeDesc = getFareTypeDesc(fareType);
     const fareTypeHint = getFareTypeHint(fareType);
@@ -131,7 +129,7 @@ const TicketRepresentation = ({
                                                   },
                                               ]
                                             : []),
-                                        ...(showFlatFlare && isDevOrTest
+                                        ...(showFlatFlare
                                             ? [
                                                   {
                                                       value: 'multipleServicesPricedByDistance',
@@ -158,7 +156,6 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Ti
     const ticketType = getSessionAttribute(ctx.req, TICKET_REPRESENTATION_ATTRIBUTE);
     const isCarnet = getSessionAttribute(ctx.req, CARNET_FARE_TYPE_ATTRIBUTE);
     const isScheme = isSchemeOperator(ctx);
-    const isDevOrTest = process.env.NODE_ENV === 'development' || process.env.STAGE === 'test';
 
     return {
         props: {
@@ -169,7 +166,6 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Ti
             showPointToPoint: fareType === 'period' && !isCarnet && !isScheme,
             showFlatFlare: fareType === 'flatFare' && !isScheme && !isCarnet,
             showMultiOperator: fareType === 'multiOperator',
-            isDevOrTest,
         },
     };
 };

--- a/repos/fdbt-site/src/utils/apiUtils/userData.ts
+++ b/repos/fdbt-site/src/utils/apiUtils/userData.ts
@@ -111,7 +111,6 @@ import {
     CappedTicket,
     ExpiryUnit,
     FlatFareMultipleServices,
-    PriceByDistanceProduct,
 } from '../../interfaces/matchingJsonTypes';
 
 export const isTermTime = (req: NextApiRequestWithSession): boolean => {
@@ -631,8 +630,9 @@ export const getMultipleServicesByDistanceTicketJson = (
         {
             salesOfferPackages,
             pricingByDistance,
+            productName: pricingByDistance.productName,
         },
-    ] as PriceByDistanceProduct[];
+    ];
 
     return {
         operatorName: name,

--- a/repos/fdbt-site/tests/pages/ticketRepresentation.test.tsx
+++ b/repos/fdbt-site/tests/pages/ticketRepresentation.test.tsx
@@ -15,7 +15,6 @@ describe('pages', () => {
                     showHybrid
                     showPointToPoint
                     showMultiOperator
-                    isDevOrTest
                     showFlatFlare={false}
                 />,
             );
@@ -31,7 +30,6 @@ describe('pages', () => {
                     showHybrid={false}
                     showPointToPoint
                     showMultiOperator={true}
-                    isDevOrTest
                     showFlatFlare
                 />,
             );
@@ -53,7 +51,6 @@ describe('pages', () => {
                     showPointToPoint
                     showFlatFlare
                     showMultiOperator
-                    isDevOrTest
                 />,
             );
             expect(tree).toMatchSnapshot();

--- a/repos/fdbt-types/matchingJsonTypes.ts
+++ b/repos/fdbt-types/matchingJsonTypes.ts
@@ -42,6 +42,7 @@ export interface FlatFareProduct extends BaseProduct {
 }
 
 export interface PriceByDistanceProduct extends BaseProduct {
+    productName: string;
     pricingByDistance: DistancePricingData;
 }
 


### PR DESCRIPTION
## Description

PPD (priced by distance) products did not have the product name saved at the top level of the product, which meant that it wasn't being picked up in the netex converter where it is required to be.

## Testing instructions

Export a flat fare priced by distance ticket and examine netex. Also, ensure saved JSON has product name correctly.
