### PR TITLE
feat: Create caps section in operator settings

### DIFF
--- a/repos/fdbt-site/src/interfaces/index.ts
+++ b/repos/fdbt-site/src/interfaces/index.ts
@@ -217,6 +217,7 @@ export interface SettingsOverview {
 }
 
 export interface GlobalSettingsCounts {
+    capCount: number;
     passengerTypesCount: number;
     purchaseMethodsCount: number;
     timeRestrictionsCount: number;
@@ -267,6 +268,12 @@ export interface ResponseWithLocals extends ServerResponse {
         nonce: string;
         csrfToken: string;
     };
+}
+
+export interface PremadeCaps {
+    id: number;
+    contents: DbTimeRestriction[];
+    isExpiry: boolean;
 }
 
 export interface PremadeTimeRestriction {

--- a/repos/fdbt-site/src/layout/Navigation.tsx
+++ b/repos/fdbt-site/src/layout/Navigation.tsx
@@ -64,6 +64,7 @@ const Navigation = (): ReactElement => (
                 className={`app-navigation__list-item ${
                     isActivePage([
                         'globalSettings',
+                        'viewCaps',
                         'viewPassengerTypes',
                         'viewPurchaseMethods',
                         'viewTimeRestrictions',

--- a/repos/fdbt-site/src/layout/SubNavigation.tsx
+++ b/repos/fdbt-site/src/layout/SubNavigation.tsx
@@ -22,6 +22,7 @@ const SubNavigation = (): ReactElement => {
 
                 <ul className="app-subnav__section">
                     {link('/globalSettings', 'Settings overview')}
+                    {link('/viewCaps', 'Caps')}
                     {link('/viewPassengerTypes', 'Passenger types')}
                     {link('/viewPurchaseMethods', 'Purchase methods')}
                     {link('/viewTimeRestrictions', 'Time restrictions')}

--- a/repos/fdbt-site/src/pages/globalSettings.tsx
+++ b/repos/fdbt-site/src/pages/globalSettings.tsx
@@ -8,6 +8,7 @@ import {
     getFareDayEnd,
     getOperatorDetails,
     getOperatorGroupsByNoc,
+    getCapsByNocCode,
 } from '../data/auroradb';
 import { GlobalSettingsCounts, NextPageContextWithSession } from '../interfaces';
 import { BaseLayout } from '../layout/Layout';
@@ -39,6 +40,12 @@ const GlobalSettings = ({ globalSettingsCounts, referer }: GlobalSettingsProps):
                             default settings.
                         </p>
                         <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+                        <SettingOverview
+                            href="/viewCaps"
+                            name="Caps"
+                            description="Define your different types of caps and their expiries"
+                            count={globalSettingsCounts.capCount}
+                        />
                         <SettingOverview
                             href="/viewPassengerTypes"
                             name="Passenger types"
@@ -93,6 +100,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
 
     const referer = extractGlobalSettingsReferer(ctx);
 
+    const savedCaps = await getCapsByNocCode(noc);
     const savedPassengerTypes = await getPassengerTypesByNocCode(noc, 'single');
     const savedGroupPassengerTypes = await getGroupPassengerTypesFromGlobalSettings(noc);
     const savedTimeRestrictions = await getTimeRestrictionByNocCode(noc);
@@ -102,6 +110,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     const operatorGroups = await getOperatorGroupsByNoc(noc);
 
     const globalSettingsCounts: GlobalSettingsCounts = {
+        capCount: savedCaps.length,
         passengerTypesCount: savedPassengerTypes.length + savedGroupPassengerTypes.length,
         timeRestrictionsCount: savedTimeRestrictions.length,
         purchaseMethodsCount: purchaseMethodsCount.length,

--- a/repos/fdbt-site/src/pages/viewCaps.tsx
+++ b/repos/fdbt-site/src/pages/viewCaps.tsx
@@ -1,0 +1,47 @@
+import React, { ReactElement } from 'react';
+import ErrorSummary from '../components/ErrorSummary';
+import { BaseLayout } from '../layout/Layout';
+import SubNavigation from '../layout/SubNavigation';
+import { extractGlobalSettingsReferer } from '../utils/globalSettings';
+import { ErrorInfo, NextPageContextWithSession } from '../interfaces';
+
+const title = 'Caps - Create Fares Data Service';
+const description = 'View and edit your caps.';
+
+interface CapProps {
+    referer: string | null;
+    viewCapErrors: ErrorInfo[];
+}
+
+const ViewCap = ({ referer, viewCapErrors = [] }: CapProps): ReactElement => {
+    return (
+        <BaseLayout title={title} description={description} showNavigation referer={referer}>
+            <div>
+                <ErrorSummary errors={viewCapErrors} />
+            </div>
+            <div className="govuk-grid-row">
+                <div className="govuk-grid-column-one-quarter">
+                    <SubNavigation />
+                </div>
+
+                <div className="govuk-grid-column-three-quarters">
+                    <h1 className="govuk-heading-xl">Caps</h1>
+                    <p className="govuk-body govuk-!-margin-bottom-8">
+                        Define your different types of caps and their expiries
+                    </p>
+                </div>
+            </div>
+        </BaseLayout>
+    );
+};
+
+export const getServerSideProps = (ctx: NextPageContextWithSession): { props: CapProps } => {
+    return {
+        props: {
+            referer: extractGlobalSettingsReferer(ctx),
+            viewCapErrors: [],
+        },
+    };
+};
+
+export default ViewCap;

--- a/repos/fdbt-site/src/utils/globalSettings.ts
+++ b/repos/fdbt-site/src/utils/globalSettings.ts
@@ -16,7 +16,6 @@ export const extractGlobalSettingsReferer = (ctx: NextPageContextWithSession): s
             'fareType',
             'reuseOperatorGroup',
             'selectCapValidity',
-            'selectCappedProductGroup',
         ].includes(refererPage)
     ) {
         updateSessionAttribute(ctx.req, GS_REFERER, refererPage);

--- a/repos/fdbt-site/tests/pages/__snapshots__/globalSettings.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/globalSettings.test.tsx.snap
@@ -34,6 +34,12 @@ exports[`pages globalSettings should render correctly in a non-test env 1`] = `
         />
         <SettingOverview
           count={0}
+          description="Define your different types of caps and their expiries"
+          href="/viewCaps"
+          name="Caps"
+        />
+        <SettingOverview
+          count={0}
           description="Define age range and required proof documents of your passengers as well as passenger groups"
           href="/viewPassengerTypes"
           name="Passenger types"
@@ -105,6 +111,12 @@ exports[`pages globalSettings should render correctly in test env 1`] = `
         </p>
         <hr
           className="govuk-section-break govuk-section-break--l govuk-section-break--visible"
+        />
+        <SettingOverview
+          count={0}
+          description="Define your different types of caps and their expiries"
+          href="/viewCaps"
+          name="Caps"
         />
         <SettingOverview
           count={0}

--- a/repos/fdbt-site/tests/pages/globalSettings.test.tsx
+++ b/repos/fdbt-site/tests/pages/globalSettings.test.tsx
@@ -7,6 +7,7 @@ describe('pages', () => {
     describe('globalSettings', () => {
         it('should render correctly in test env', () => {
             const globalSettingsCounts: GlobalSettingsCounts = {
+                capCount: 0,
                 passengerTypesCount: 0,
                 timeRestrictionsCount: 3,
                 purchaseMethodsCount: 7,
@@ -20,6 +21,7 @@ describe('pages', () => {
 
         it('should render correctly in a non-test env', () => {
             const globalSettingsCounts: GlobalSettingsCounts = {
+                capCount: 0,
                 passengerTypesCount: 0,
                 timeRestrictionsCount: 3,
                 purchaseMethodsCount: 7,


### PR DESCRIPTION
## Description

Similar to passenger types etc, we need a section of operator settings where operators can create different types of caps.

This ticket is just creating the actual area in operator settings, with all the links.

## Testing instructions

Code review and navigate to operator settings and see if caps is on the sub navigation and main operator settings page.
