### PR TITLE
feature: Added new functionality to exempt stops from multi service tickets

### DIFF
--- a/repos/fdbt-site/src/components/UserDataUploads.tsx
+++ b/repos/fdbt-site/src/components/UserDataUploads.tsx
@@ -100,8 +100,6 @@ const UserDataUploadComponent = ({
                     <div className="govuk-details__text">{detailBody}</div>
                 </details>
             )}
-
-            <input type="submit" value="Upload and continue" id="submit-button" className="govuk-button" />
         </>
     );
 };

--- a/repos/fdbt-site/src/constants/attributes.ts
+++ b/repos/fdbt-site/src/constants/attributes.ts
@@ -157,3 +157,5 @@ export const ADDITIONAL_PRICING_ATTRIBUTE = 'fdbt-additional-pricing';
 export const MULTI_MODAL_ATTRIBUTE = 'fdbt-multi-modal';
 
 export const SERVICE_LIST_EXEMPTION_ATTRIBUTE = 'fdbt-exemption-services';
+
+export const STOPS_EXEMPTION_ATTRIBUTE = 'fdbt-exemption-stops';

--- a/repos/fdbt-site/src/interfaces/index.ts
+++ b/repos/fdbt-site/src/interfaces/index.ts
@@ -16,6 +16,7 @@ import {
     TicketType,
     ExpiryUnit,
     AdditionalOperator,
+    Stop,
 } from './matchingJsonTypes';
 
 // Session Attributes and Cookies
@@ -198,8 +199,8 @@ export interface ServiceListAttribute {
     selectedServices: SelectedService[];
 }
 
-export interface ServiceListAttributeWithErrors {
-    errors: ErrorInfo[];
+export interface ExemptedStopsAttribute {
+    exemptStops: Stop[];
 }
 
 export interface GlobalSettingsAttribute<T> {

--- a/repos/fdbt-site/src/interfaces/matchingJsonTypes.ts
+++ b/repos/fdbt-site/src/interfaces/matchingJsonTypes.ts
@@ -38,6 +38,7 @@ export type AdditionalService = Omit<SelectedService, 'serviceCode' | 'startDate
 export interface PeriodMultipleServicesTicket extends BasePeriodTicket {
     selectedServices: SelectedService[];
     termTime: boolean;
+    exemptStops?: Stop[];
 }
 
 export interface FlatFareProduct extends BaseProduct {
@@ -56,6 +57,7 @@ export interface FlatFareMultipleServices extends BaseTicket<'flatFare'> {
     termTime: boolean;
     selectedServices: SelectedService[];
     operatorName: string;
+    exemptStops?: Stop[];
 }
 
 export type FlatFareTicket = FlatFareGeoZoneTicket | FlatFareMultipleServices;

--- a/repos/fdbt-site/src/interfaces/typeGuards.ts
+++ b/repos/fdbt-site/src/interfaces/typeGuards.ts
@@ -1,5 +1,6 @@
 import {
     ErrorInfo,
+    ExemptedStopsAttribute,
     FareStagesAttribute,
     FareStagesAttributeWithErrors,
     FareType,
@@ -19,6 +20,7 @@ import {
     ProductWithSalesOfferPackages,
     SelectSalesOfferPackageWithError,
     Service,
+    ServiceListAttribute,
     ServiceWithErrors,
     TicketPeriodWithErrors,
     TicketPeriodWithInput,
@@ -178,3 +180,13 @@ export const isMultiOperatorMultipleServicesTicket = (
     (ticket as MultiOperatorMultipleServicesTicket).additionalOperators &&
     (ticket as MultiOperatorMultipleServicesTicket).additionalOperators.length > 0 &&
     'selectedServices' in ticket;
+
+export const isServiceListAttributeWithErrors = (
+    serviceListAttribute: ServiceListAttribute | { errors: ErrorInfo[] },
+): serviceListAttribute is { errors: ErrorInfo[] } =>
+    (serviceListAttribute as { errors: ErrorInfo[] }).errors !== undefined;
+
+export const isExemptStopsAttributeWithErrors = (
+    exemptStopsAttribute: ExemptedStopsAttribute | { errors: ErrorInfo[] },
+): exemptStopsAttribute is { errors: ErrorInfo[] } =>
+    (exemptStopsAttribute as { errors: ErrorInfo[] }).errors !== undefined;

--- a/repos/fdbt-site/src/pages/api/csvZoneUpload.ts
+++ b/repos/fdbt-site/src/pages/api/csvZoneUpload.ts
@@ -160,7 +160,6 @@ export const processServices = (
     const clickedYes = 'exempt' in fields && fields['exempt'] === 'yes';
 
     const dataFields: { [key: string]: string | string[] } = fields;
-    delete dataFields['poundsOrPence'];
     delete dataFields['exempt'];
 
     const selectedServices: SelectedService[] = [];
@@ -274,7 +273,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                 }
 
                 if (ticketType.name === 'hybrid') {
-                    redirectTo(res, '/serviceList?selectAll=false');
+                    redirectTo(res, '/serviceList');
                     return;
                 }
             }

--- a/repos/fdbt-site/src/pages/api/serviceList.ts
+++ b/repos/fdbt-site/src/pages/api/serviceList.ts
@@ -1,48 +1,123 @@
 import { NextApiResponse } from 'next';
 import isArray from 'lodash/isArray';
-import { NextApiRequestWithSession, TicketRepresentationAttribute } from '../../interfaces/index';
+import {
+    ErrorInfo,
+    NextApiRequestWithSession,
+    TicketRepresentationAttribute,
+    UserFareZone,
+} from '../../interfaces/index';
 import { getFareTypeFromFromAttributes, redirectTo, redirectToError } from '../../utils/apiUtils';
+import { putUserDataInProductsBucketWithFilePath } from '../../../src/utils/apiUtils/userData';
 import {
     MATCHING_JSON_ATTRIBUTE,
     MATCHING_JSON_META_DATA_ATTRIBUTE,
     SERVICE_LIST_ATTRIBUTE,
+    STOPS_EXEMPTION_ATTRIBUTE,
     TICKET_REPRESENTATION_ATTRIBUTE,
 } from '../../constants/attributes';
 import { getSessionAttribute, updateSessionAttribute } from '../../utils/sessions';
-import { putUserDataInProductsBucketWithFilePath } from '../../../src/utils/apiUtils/userData';
-import { SelectedService } from '../../interfaces/matchingJsonTypes';
+import { SelectedService, Stop } from '../../interfaces/matchingJsonTypes';
+import { FileData, getServiceListFormData, processFileUpload } from '../../utils/apiUtils/fileUpload';
+import uniq from 'lodash/uniq';
+import { batchGetStopsByAtcoCode } from '../../data/auroradb';
+import { csvParser, getAtcoCodesForStops } from './csvZoneUpload';
+import logger from '../../utils/logger';
 
-const errorId = 'checkbox-0';
+// The below 'config' needs to be exported for the formidable library to work.
+export const config = {
+    api: {
+        bodyParser: false,
+    },
+};
 
-export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
-    const redirectUrl = '/serviceList';
-    const selectAllText = 'Select All Services';
+export const processCsv = async (fileContent: string): Promise<UserFareZone[]> => {
+    let parsedFileContent: UserFareZone[];
 
     try {
-        const refererUrl = req?.headers?.referer;
-        const queryString = refererUrl?.substring(refererUrl?.indexOf('?') + 1);
-        const { selectAll } = req.body;
+        parsedFileContent = csvParser(fileContent);
+    } catch (error) {
+        logger.warn(error, {
+            context: 'api.serviceList',
+            message: 'failed to parse exempted stops CSV',
+        });
 
-        const isSelected = selectAll === selectAllText;
+        return [];
+    }
 
-        if (selectAll && queryString) {
-            redirectTo(res, `${redirectUrl}?selectAll=${isSelected}`);
-            return;
-        }
+    try {
+        let csvValid = true;
+        const rawUserFareZones = parsedFileContent
+            .map((parsedItem) => {
+                const item = {
+                    FareZoneName: parsedFileContent?.[0]?.FareZoneName,
+                    NaptanCodes: parsedItem.NaptanCodes,
+                    AtcoCodes: parsedItem.AtcoCodes,
+                };
 
-        if ((!req.body || Object.keys(req.body).length === 0) && !selectAll) {
-            updateSessionAttribute(req, SERVICE_LIST_ATTRIBUTE, {
-                errors: [{ id: errorId, errorMessage: 'Choose at least one service from the options' }],
+                if (!item.FareZoneName || item.NaptanCodes === undefined || item.AtcoCodes === undefined) {
+                    logger.warn('', {
+                        context: 'api.serviceList',
+                        message:
+                            'the uploaded exempt stops was not of the correct format, one of the required columns of information is missing or misnamed',
+                    });
+                    csvValid = false;
+                }
+
+                return item;
+            })
+            .filter((parsedItem) => parsedItem.NaptanCodes !== '' || parsedItem.AtcoCodes !== '');
+
+        if (rawUserFareZones.length === 0) {
+            logger.warn('', {
+                context: 'api.serviceList',
+                message: 'the uploaded exempted stops contained no Naptan Codes or Atco Codes',
             });
-            redirectTo(res, `${redirectUrl}?selectAll=false`);
-            return;
+            csvValid = false;
         }
 
-        const selectedServices: SelectedService[] = [];
+        if (!csvValid) {
+            return [];
+        }
 
-        const requestBody: { [key: string]: string | string[] } = req.body;
+        let userFareZones = rawUserFareZones;
+        const naptanCodesToQuery = rawUserFareZones
+            .filter((rawUserFareZone) => rawUserFareZone.AtcoCodes === '')
+            .map((rawUserFareZone) => rawUserFareZone.NaptanCodes);
 
-        Object.entries(requestBody).forEach((entry) => {
+        if (naptanCodesToQuery.length !== 0) {
+            userFareZones = await getAtcoCodesForStops(rawUserFareZones, naptanCodesToQuery);
+        }
+
+        return userFareZones;
+    } catch (error) {
+        throw new Error(error.stack);
+    }
+};
+
+export const processServices = (
+    formData: FileData,
+): {
+    serviceErrors: ErrorInfo[];
+    selectedServices: SelectedService[];
+    clickedYes: boolean;
+    wantsToEditExemptStops: boolean;
+} => {
+    const fields = formData.fields;
+
+    if (!fields) {
+        throw new Error('Unable to fetch the form data');
+    }
+    const clickedYes = 'exempt' in fields && fields['exempt'] === 'yes';
+    const wantsToEditExemptStops = 'edit-exempt' in fields && fields['edit-exempt'] === 'yes';
+
+    const dataFields: { [key: string]: string | string[] } = fields;
+    delete dataFields['exempt'];
+    delete dataFields['edit-exempt'];
+
+    const selectedServices: SelectedService[] = [];
+
+    Object.entries(dataFields).forEach((entry) => {
+        if (entry[0] !== 'csv-upload') {
             const lineNameLineIdServiceCodeStartDate = entry[0];
             const description = entry[1];
             let serviceDescription: string;
@@ -59,21 +134,106 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                 startDate: splitData[3],
                 serviceDescription,
             });
-        });
+        }
+    });
 
+    if (selectedServices.length !== 0) {
+        return { selectedServices, clickedYes, wantsToEditExemptStops, serviceErrors: [] };
+    }
+
+    return {
+        selectedServices,
+        clickedYes,
+        wantsToEditExemptStops,
+        serviceErrors: [{ id: 'checkbox-0', errorMessage: 'Choose at least one service from the options' }],
+    };
+};
+
+export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
+    try {
         const ticket = getSessionAttribute(req, MATCHING_JSON_ATTRIBUTE);
         const matchingJsonMetaData = getSessionAttribute(req, MATCHING_JSON_META_DATA_ATTRIBUTE);
+        const inEditMode = !!ticket && !!matchingJsonMetaData;
+        const formData = await getServiceListFormData(req);
+        const { serviceErrors, selectedServices, clickedYes, wantsToEditExemptStops } = processServices(formData);
 
-        // edit mode
-        if (ticket && matchingJsonMetaData && 'selectedServices' in ticket) {
-            const updatedTicket = {
+        const errors: ErrorInfo[] = serviceErrors;
+        let exemptStops: Stop[] = [];
+
+        if (inEditMode && !wantsToEditExemptStops && clickedYes) {
+            // do nothing
+        } else if (clickedYes) {
+            const { fileContents, fileError } = await processFileUpload(formData, 'csv-upload');
+
+            if (fileError) {
+                errors.push({
+                    id: 'csv-upload',
+                    errorMessage: fileError,
+                });
+
+                updateSessionAttribute(req, STOPS_EXEMPTION_ATTRIBUTE, {
+                    errors,
+                });
+
+                if (selectedServices.length > 0) {
+                    updateSessionAttribute(req, SERVICE_LIST_ATTRIBUTE, { selectedServices });
+                } else {
+                    updateSessionAttribute(req, SERVICE_LIST_ATTRIBUTE, undefined);
+                }
+
+                redirectTo(res, '/serviceList');
+                return;
+            }
+
+            const processedStops = await processCsv(fileContents);
+
+            if (processedStops.length === 0) {
+                errors.push({ id: 'csv-upload', errorMessage: 'The selected file must use the template' });
+            } else {
+                const atcoCodes: string[] = processedStops.map((fareZone) => fareZone.AtcoCodes);
+                const deduplicatedAtcoCodes = uniq(atcoCodes);
+
+                let stops: Stop[] = [];
+                try {
+                    stops = await batchGetStopsByAtcoCode(deduplicatedAtcoCodes);
+                } catch (error) {
+                    errors.push({
+                        id: 'csv-upload',
+                        errorMessage: 'Incorrect ATCO/NaPTAN codes detected in file. All codes must be correct.',
+                    });
+                }
+                exemptStops = stops;
+            }
+        }
+
+        if (errors.length > 0) {
+            updateSessionAttribute(req, SERVICE_LIST_ATTRIBUTE, {
+                errors,
+            });
+            updateSessionAttribute(req, STOPS_EXEMPTION_ATTRIBUTE, undefined);
+            redirectTo(res, '/serviceList');
+            return;
+        }
+
+        if (inEditMode && 'selectedServices' in ticket) {
+            let updatedTicket = {
                 ...ticket,
                 selectedServices,
+                ...(exemptStops.length > 0 && { exemptStops }),
             };
+
+            if (!clickedYes) {
+                updatedTicket = {
+                    ...updatedTicket,
+                    exemptStops: undefined,
+                };
+            }
 
             // put the now updated matching json into s3
             await putUserDataInProductsBucketWithFilePath(updatedTicket, matchingJsonMetaData.matchingJsonLink);
             updateSessionAttribute(req, SERVICE_LIST_ATTRIBUTE, undefined);
+            updateSessionAttribute(req, STOPS_EXEMPTION_ATTRIBUTE, undefined);
+
             redirectTo(
                 res,
                 `/products/productDetails?productId=${matchingJsonMetaData.productId}${
@@ -83,9 +243,10 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             return;
         }
 
-        const fareType = getFareTypeFromFromAttributes(req);
-
         updateSessionAttribute(req, SERVICE_LIST_ATTRIBUTE, { selectedServices });
+        updateSessionAttribute(req, STOPS_EXEMPTION_ATTRIBUTE, exemptStops.length > 0 ? { exemptStops } : undefined);
+
+        const fareType = getFareTypeFromFromAttributes(req);
 
         const ticketType = (getSessionAttribute(req, TICKET_REPRESENTATION_ATTRIBUTE) as TicketRepresentationAttribute)
             .name;

--- a/repos/fdbt-site/src/pages/api/ticketRepresentation.ts
+++ b/repos/fdbt-site/src/pages/api/ticketRepresentation.ts
@@ -33,7 +33,7 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
                 case 'multipleServices':
                 case 'multipleServicesFlatFareMultiOperator':
                 case 'multipleServicesPricedByDistance':
-                    redirectTo(res, isScheme ? '/reuseOperatorGroup' : '/serviceList?selectAll=false');
+                    redirectTo(res, isScheme ? '/reuseOperatorGroup' : '/serviceList');
                     return;
                 case 'pointToPointPeriod':
                     redirectTo(res, '/service');

--- a/repos/fdbt-site/src/pages/csvUpload.tsx
+++ b/repos/fdbt-site/src/pages/csvUpload.tsx
@@ -68,6 +68,7 @@ const CsvUpload = ({
                             </>
                         }
                     />
+                    <input type="submit" value="Upload and continue" id="submit-button" className="govuk-button" />
                 </CsrfForm>
             </div>
 

--- a/repos/fdbt-site/src/pages/products/productDetails.tsx
+++ b/repos/fdbt-site/src/pages/products/productDetails.tsx
@@ -330,7 +330,7 @@ const createProductDetails = async (
             editLink: '/csvZoneUpload',
         });
         productDetailsElements.push({
-            id: 'exempt-services',
+            id: 'exempted-services',
             name: 'Exempt services',
             content:
                 ticket.exemptedServices && ticket.exemptedServices.length > 0

--- a/repos/fdbt-site/src/pages/serviceList.tsx
+++ b/repos/fdbt-site/src/pages/serviceList.tsx
@@ -1,7 +1,9 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 import ErrorSummary from '../components/ErrorSummary';
-import FormElementWrapper from '../components/FormElementWrapper';
+import FormElementWrapper, { FormGroupWrapper } from '../components/FormElementWrapper';
 import { FullColumnLayout } from '../layout/Layout';
+import FareZoneExampleCsv from '../assets/files/Fare-Zone-Example.csv';
+import csvImage from '../assets/images/csv.png';
 import {
     SERVICE_LIST_ATTRIBUTE,
     FARE_TYPE_ATTRIBUTE,
@@ -10,72 +12,99 @@ import {
     MATCHING_JSON_ATTRIBUTE,
     MATCHING_JSON_META_DATA_ATTRIBUTE,
     MULTI_MODAL_ATTRIBUTE,
+    STOPS_EXEMPTION_ATTRIBUTE,
 } from '../constants/attributes';
-import {
-    getAllServicesByNocCode,
-    getServicesByNocCodeAndDataSource,
-    getTndsServicesByNocAndModes,
-} from '../data/auroradb';
-import {
-    ErrorInfo,
-    NextPageContextWithSession,
-    ServicesInfo,
-    FareType,
-    ServiceListAttribute,
-    ServiceListAttributeWithErrors,
-    TxcSourceAttribute,
-} from '../interfaces';
+import { getAllServicesByNocCode, getServicesByNocCodeAndDataSource } from '../data/auroradb';
+import { ErrorInfo, NextPageContextWithSession, ServicesInfo, FareType, TxcSourceAttribute } from '../interfaces';
 import { getAndValidateNoc, getCsrfToken } from '../utils';
 import CsrfForm from '../components/CsrfForm';
 import { getSessionAttribute, updateSessionAttribute } from '../utils/sessions';
 import { redirectTo } from '../utils/apiUtils';
 import BackButton from '../components/BackButton';
+import FileAttachment from '../components/FileAttachment';
+import { isExemptStopsAttributeWithErrors, isServiceListAttributeWithErrors } from '../interfaces/typeGuards';
 
 const pageTitle = 'Service List - Create Fares Data Service';
 const pageDescription = 'Service List selection page of the Create Fares Data Service';
 
 interface ServiceListProps {
     serviceList: ServicesInfo[];
-    buttonText: string;
     errors: ErrorInfo[];
     multiOperator: boolean;
     dataSourceAttribute: TxcSourceAttribute;
     csrfToken: string;
     additional: boolean;
     backHref: string;
+    selectedYesToExempt: boolean;
+    exemptStops: string;
+    isEditMode: boolean;
 }
+
+const containsErrorForServices = (errors: ErrorInfo[]): boolean => !!errors.find((error) => error.id === 'checkbox-0');
+
+const containsErrorForExempt = (errors: ErrorInfo[]): boolean => !!errors.find((error) => error.id === 'csv-upload');
 
 const ServiceList = ({
     serviceList,
-    buttonText,
     csrfToken,
     errors,
     multiOperator,
     dataSourceAttribute,
     additional,
     backHref,
+    selectedYesToExempt,
+    exemptStops,
+    isEditMode,
 }: ServiceListProps): ReactElement => {
-    const multiOperatorText = multiOperator ? 'of your ' : '';
     const seen: string[] = [];
-    const uniqueServiceLists =
-        serviceList?.filter((item) => (seen.includes(item.lineId) ? false : seen.push(item.lineId))) ?? [];
+    const uniqueServiceList =
+        serviceList.filter((item) => (seen.includes(item.lineId) ? false : seen.push(item.lineId))) ?? [];
+
+    const [buttonText, setButtonText] = useState(
+        serviceList.every((service) => service.checked) ? 'Unselect All Services' : 'Select All Services',
+    );
+
+    const [checkedServices, setCheckedServices] = useState(uniqueServiceList.filter((service) => service.checked));
+
+    const [userWantsToEditExemptStops, setUserWantsToEditExemptStops] = useState(false);
+
+    const toggleAllServices = (): void => {
+        if (checkedServices.length !== uniqueServiceList.length && buttonText === 'Select All Services') {
+            setButtonText('Unselect All Services');
+            setCheckedServices(uniqueServiceList);
+        } else {
+            setButtonText('Select All Services');
+            setCheckedServices([]);
+        }
+    };
+
+    const updateCheckedServiceList = (e: React.ChangeEvent<HTMLInputElement>, lineId: string) => {
+        if (!e.target.checked) {
+            setCheckedServices(checkedServices.filter((service) => service.lineId !== lineId));
+        } else {
+            const serviceToAdd = uniqueServiceList.find((service) => service.lineId === lineId);
+            if (serviceToAdd) {
+                setCheckedServices([...checkedServices, serviceToAdd]);
+            }
+        }
+    };
+
+    const multiOperatorText = multiOperator ? 'of your ' : '';
+
+    const defaultCheckedYes = !userWantsToEditExemptStops || selectedYesToExempt || !!exemptStops;
+    const defaultCheckedNo = !defaultCheckedYes;
 
     return (
         <FullColumnLayout title={pageTitle} description={pageDescription}>
-            {/* removed as TNDS is being disabled until further notice */}
-            {/* {!editMode && (
-                <SwitchDataSource
-                    dataSourceAttribute={dataSourceAttribute}
-                    pageUrl="/serviceList"
-                    attributeVersion="baseOperator"
-                    csrfToken={csrfToken}
-                />
-            )} */}
             {!!backHref && errors.length === 0 ? <BackButton href={backHref} /> : null}
-            <CsrfForm action="/api/serviceList" method="post" csrfToken={csrfToken}>
+            <CsrfForm action="/api/serviceList" method="post" csrfToken={csrfToken} encType="multipart/form-data">
                 <>
                     <ErrorSummary errors={errors} />
-                    <div className={`govuk-form-group ${errors.length > 0 ? 'govuk-form-group--error' : ''}`}>
+                    <div
+                        className={`govuk-form-group ${
+                            containsErrorForServices(errors) ? 'govuk-form-group--error' : ''
+                        }`}
+                    >
                         <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
                             <h1 className="govuk-heading-l" id="service-list-page-heading">
                                 Which {additional ? 'additional ' : multiOperatorText}services is the ticket valid for?
@@ -85,11 +114,12 @@ const ServiceList = ({
                         <span className="govuk-heading-s">Select all {multiOperatorText}services that apply</span>
                         <fieldset className="govuk-fieldset">
                             <input
-                                type="submit"
+                                type="button"
                                 name="selectAll"
                                 value={buttonText}
                                 id="select-all-button"
                                 className="govuk-button govuk-button--secondary"
+                                onClick={toggleAllServices}
                             />
                             <span className="govuk-hint" id="txc-hint">
                                 This data is taken from the{' '}
@@ -102,13 +132,13 @@ const ServiceList = ({
                                 advice <a href="/contact">here</a>.
                             </span>
                             <FormElementWrapper
-                                errors={errors}
+                                errors={containsErrorForServices(errors) ? errors : []}
                                 errorId="checkbox-0"
                                 errorClass=""
                                 addFormGroupError={false}
                             >
                                 <div className="govuk-checkboxes">
-                                    {uniqueServiceLists.map((service, index) => {
+                                    {uniqueServiceList.map((service, index) => {
                                         const {
                                             lineName,
                                             lineId,
@@ -135,6 +165,10 @@ const ServiceList = ({
                                                     type="checkbox"
                                                     value={checkBoxValues}
                                                     defaultChecked={checked}
+                                                    checked={
+                                                        !!checkedServices.find((service) => service.lineId === lineId)
+                                                    }
+                                                    onChange={(e) => updateCheckedServiceList(e, lineId)}
                                                 />
                                                 <label
                                                     className="govuk-label govuk-checkboxes__label"
@@ -149,6 +183,191 @@ const ServiceList = ({
                             </FormElementWrapper>
                         </fieldset>
                     </div>
+
+                    {isEditMode ? (
+                        <div className="govuk-!-margin-bottom-6">
+                            <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">
+                                <h2 className="govuk-fieldset__heading">
+                                    You previously uploaded{' '}
+                                    {!!exemptStops
+                                        ? `${exemptStops.split(', ').length} exempt stops`
+                                        : 'no exempt stops'}
+                                    . Do you want to edit them?{' '}
+                                </h2>
+                            </legend>
+                            <div className="govuk-radios" data-module="govuk-radios">
+                                <div className="govuk-radios__item">
+                                    <input
+                                        className="govuk-radios__input"
+                                        id="exempt-yes"
+                                        name="edit-exempt"
+                                        value="yes"
+                                        type="radio"
+                                        data-aria-controls="conditional-yes"
+                                        onChange={() => {
+                                            setUserWantsToEditExemptStops(true);
+                                        }}
+                                    />
+                                    <label className="govuk-label govuk-radios__label" htmlFor="exempt-yes">
+                                        Yes
+                                    </label>
+                                </div>
+                                <div className="govuk-radios__item">
+                                    <input
+                                        className="govuk-radios__input"
+                                        id="exempt-no"
+                                        name="edit-exempt"
+                                        value="no"
+                                        type="radio"
+                                        defaultChecked
+                                        onChange={() => {
+                                            setUserWantsToEditExemptStops(false);
+                                        }}
+                                    />
+                                    <label className="govuk-label govuk-radios__label" htmlFor="exempt-no">
+                                        No
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+                    ) : null}
+
+                    <div className={isEditMode && !userWantsToEditExemptStops ? `govuk-visually-hidden` : ''}>
+                        <div className="govuk-warning-text">
+                            <span className="govuk-warning-text__icon" aria-hidden="true">
+                                !
+                            </span>
+                            <strong className="govuk-warning-text__text">
+                                <span className="govuk-warning-text__assistive">Warning</span>
+                                If there are stops exempt, you can omit them by selecting yes below and uploading the
+                                stops you want to omit.
+                            </strong>
+                        </div>
+                        <div className="govuk-form-group">
+                            <fieldset className="govuk-fieldset">
+                                <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">
+                                    <h2 className="govuk-fieldset__heading">Are there stops which are not included?</h2>
+                                </legend>
+                                <FormElementWrapper
+                                    errorId="csv-upload"
+                                    errorClass="govuk-form-group--error"
+                                    errors={containsErrorForExempt(errors) ? errors : []}
+                                >
+                                    <div className="govuk-radios" data-module="govuk-radios">
+                                        <div className="govuk-radios__item">
+                                            <input
+                                                className="govuk-radios__input"
+                                                id="yes"
+                                                name="exempt"
+                                                type="radio"
+                                                value="yes"
+                                                data-aria-controls="conditional-yes"
+                                                defaultChecked={defaultCheckedYes}
+                                            />
+                                            <label className="govuk-label govuk-radios__label" htmlFor="yes">
+                                                Yes
+                                            </label>
+                                        </div>
+                                        <div
+                                            className="govuk-radios__conditional govuk-radios__conditional--hidden"
+                                            id="conditional-yes"
+                                        >
+                                            <>
+                                                <div
+                                                    className={`govuk-form-group ${
+                                                        containsErrorForExempt(errors) ? 'govuk-form-group--error' : ''
+                                                    }`}
+                                                >
+                                                    <label htmlFor="csv-upload">
+                                                        <h1 className="govuk-heading-m">Upload exempt stops</h1>
+                                                    </label>
+
+                                                    <span
+                                                        className="govuk-hint govuk-!-margin-bottom-5"
+                                                        id="csv-upload-hint"
+                                                    >
+                                                        Upload exempt stops as a .csv or MS Excel file. Exempt stops are
+                                                        all of the relevant NaPTAN or ATCO codes that the service(s) you
+                                                        selected do not stop at.
+                                                    </span>
+
+                                                    {exemptStops && (
+                                                        <span
+                                                            className="govuk-hint govuk-!-margin-bottom-5"
+                                                            id="previously-uploaded-stops"
+                                                        >
+                                                            You previously uploaded: {exemptStops}
+                                                        </span>
+                                                    )}
+
+                                                    <FormGroupWrapper
+                                                        errors={containsErrorForExempt(errors) ? errors : []}
+                                                        errorIds={['csv-upload']}
+                                                    >
+                                                        <fieldset className="govuk-fieldset">
+                                                            <FormElementWrapper
+                                                                errorId="csv-upload"
+                                                                errorClass="govuk-file-upload--error"
+                                                                errors={containsErrorForExempt(errors) ? errors : []}
+                                                            >
+                                                                <input
+                                                                    className="govuk-file-upload"
+                                                                    id="csv-upload"
+                                                                    name="csv-upload"
+                                                                    type="file"
+                                                                    accept=".csv,.xlsx,.xls"
+                                                                    aria-describedby="csv-upload-hint"
+                                                                />
+                                                            </FormElementWrapper>
+                                                        </fieldset>
+                                                    </FormGroupWrapper>
+                                                </div>
+
+                                                <details
+                                                    className="govuk-details govuk-!-margin-top-2"
+                                                    data-module="govuk-details"
+                                                >
+                                                    <summary className="govuk-details__summary">
+                                                        <span className="govuk-details__summary-text">
+                                                            My exempt stops won&apos;t upload
+                                                        </span>
+                                                    </summary>
+                                                    <div className="govuk-details__text">
+                                                        <p>
+                                                            Use the below template to upload your exempt stops. This is
+                                                            the same template as used for fare zones, but just include
+                                                            ATCO/NaPTAN codes of the stops that you wish to exempt.
+                                                        </p>
+                                                        <FileAttachment
+                                                            displayName={
+                                                                'Download fare zone CSV template - File Type CSV - File Size 673B'
+                                                            }
+                                                            attachmentUrl={`${FareZoneExampleCsv}`}
+                                                            imageUrl={csvImage}
+                                                            size={'673B'}
+                                                        />
+                                                    </div>
+                                                </details>
+                                            </>
+                                        </div>
+                                        <div className="govuk-radios__item">
+                                            <input
+                                                className="govuk-radios__input"
+                                                id="no"
+                                                name="exempt"
+                                                type="radio"
+                                                value="no"
+                                                defaultChecked={defaultCheckedNo}
+                                            />
+                                            <label className="govuk-label govuk-radios__label" htmlFor="no">
+                                                No
+                                            </label>
+                                        </div>
+                                    </div>
+                                </FormElementWrapper>
+                            </fieldset>
+                        </div>
+                    </div>
                     <input type="submit" value="Continue" id="continue-button" className="govuk-button" />
                 </>
             </CsrfForm>
@@ -156,15 +375,11 @@ const ServiceList = ({
     );
 };
 
-export const isServiceListAttributeWithErrors = (
-    serviceListAttribute: ServiceListAttribute | ServiceListAttributeWithErrors,
-): serviceListAttribute is ServiceListAttributeWithErrors =>
-    (serviceListAttribute as ServiceListAttributeWithErrors).errors !== undefined;
-
 export const getServerSideProps = async (ctx: NextPageContextWithSession): Promise<{ props: ServiceListProps }> => {
     const csrfToken = getCsrfToken(ctx);
     const nocCode = getAndValidateNoc(ctx);
     const serviceListAttribute = getSessionAttribute(ctx.req, SERVICE_LIST_ATTRIBUTE);
+    const exemptStopsAttribute = getSessionAttribute(ctx.req, STOPS_EXEMPTION_ATTRIBUTE);
     let dataSourceAttribute = getSessionAttribute(ctx.req, TXC_SOURCE_ATTRIBUTE);
     const modesAttribute = getSessionAttribute(ctx.req, MULTI_MODAL_ATTRIBUTE);
 
@@ -179,8 +394,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
                 throw new Error(`No services found for NOC Code: ${nocCode}`);
             }
         }
-        // removed as TNDS is being disabled until further notice
-        // const hasTndsServices = services.some((service) => service.dataSource && service.dataSource === 'tnds');
+
         updateSessionAttribute(ctx.req, TXC_SOURCE_ATTRIBUTE, {
             source: hasBodsServices ? 'bods' : 'tnds',
             hasBods: true,
@@ -189,28 +403,22 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
         dataSourceAttribute = getSessionAttribute(ctx.req, TXC_SOURCE_ATTRIBUTE) as TxcSourceAttribute;
     }
 
-    const { selectAll } = ctx.query;
-
-    let chosenDataSourceServices;
-    if (modesAttribute) {
-        chosenDataSourceServices = await getTndsServicesByNocAndModes(nocCode, modesAttribute.modes);
-    }
-    chosenDataSourceServices = await getServicesByNocCodeAndDataSource(nocCode, dataSourceAttribute.source);
-
-    const serviceList: ServicesInfo[] = chosenDataSourceServices.map((service) => {
-        return {
-            ...service,
-            checked: !selectAll || (selectAll !== 'true' && selectAll !== 'false') ? false : selectAll !== 'false',
-        };
-    });
+    const chosenDataSourceServices = await getServicesByNocCodeAndDataSource(nocCode, dataSourceAttribute.source);
 
     const ticketJson = getSessionAttribute(ctx.req, MATCHING_JSON_ATTRIBUTE);
     const matchingJsonMetaData = getSessionAttribute(ctx.req, MATCHING_JSON_META_DATA_ATTRIBUTE);
 
+    const errors = [
+        ...(!!serviceListAttribute && isServiceListAttributeWithErrors(serviceListAttribute)
+            ? serviceListAttribute.errors
+            : []),
+        ...(!!exemptStopsAttribute && isExemptStopsAttributeWithErrors(exemptStopsAttribute)
+            ? exemptStopsAttribute.errors
+            : []),
+    ];
+
     if (ticketJson && matchingJsonMetaData) {
-        const backHref = `/products/productDetails?productId=${matchingJsonMetaData?.productId}${
-            matchingJsonMetaData.serviceId ? `&serviceId=${matchingJsonMetaData?.serviceId}` : ''
-        }`;
+        const backHref = `/products/productDetails?productId=${matchingJsonMetaData?.productId}`;
 
         let services: string[] = [];
         if ('selectedServices' in ticketJson) {
@@ -222,26 +430,32 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
         const serviceListEdit: ServicesInfo[] = chosenDataSourceServices.map((service) => {
             return {
                 ...service,
-                checked:
-                    !selectAll || (selectAll !== 'true' && selectAll !== 'false')
-                        ? services.includes(service.lineName)
-                        : selectAll !== 'false',
+                checked: services.includes(service.lineName),
             };
         });
+
+        const exemptStops: string =
+            'exemptStops' in ticketJson && !!ticketJson.exemptStops
+                ? ticketJson.exemptStops.map((stop) => `${stop.atcoCode} - ${stop.stopName}`).join(', ')
+                : '';
 
         return {
             props: {
                 serviceList: serviceListEdit,
-                buttonText: selectAll === 'true' ? 'Unselect All Services' : 'Select All Services',
-                errors:
-                    serviceListAttribute && isServiceListAttributeWithErrors(serviceListAttribute)
-                        ? serviceListAttribute.errors
-                        : [],
+                errors,
                 multiOperator: false,
                 dataSourceAttribute,
                 csrfToken,
                 additional: false,
                 backHref,
+                selectedYesToExempt:
+                    serviceListAttribute &&
+                    isServiceListAttributeWithErrors(serviceListAttribute) &&
+                    containsErrorForExempt(serviceListAttribute.errors)
+                        ? true
+                        : false,
+                exemptStops,
+                isEditMode: true,
             },
         };
     }
@@ -251,19 +465,33 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
 
     const ticket = getSessionAttribute(ctx.req, TICKET_REPRESENTATION_ATTRIBUTE);
     const additional = !!ticket && 'name' in ticket && ticket.name === 'hybrid';
+
+    const checkForSelectedServices =
+        serviceListAttribute && !isServiceListAttributeWithErrors(serviceListAttribute)
+            ? chosenDataSourceServices.map((service) => {
+                  const checked = !!serviceListAttribute.selectedServices.find(
+                      (selService) => selService.lineId === service.lineId,
+                  );
+                  return {
+                      ...service,
+                      checked,
+                  };
+              })
+            : chosenDataSourceServices;
+
     return {
         props: {
-            serviceList,
-            buttonText: selectAll === 'true' ? 'Unselect All Services' : 'Select All Services',
-            errors:
-                serviceListAttribute && isServiceListAttributeWithErrors(serviceListAttribute)
-                    ? serviceListAttribute.errors
-                    : [],
+            serviceList: checkForSelectedServices,
+            errors,
             multiOperator,
             dataSourceAttribute,
             csrfToken,
             additional,
             backHref: '',
+            selectedYesToExempt:
+                exemptStopsAttribute && isExemptStopsAttributeWithErrors(exemptStopsAttribute) ? true : false,
+            exemptStops: '',
+            isEditMode: false,
         },
     };
 };

--- a/repos/fdbt-site/src/utils/apiUtils/fileUpload.ts
+++ b/repos/fdbt-site/src/utils/apiUtils/fileUpload.ts
@@ -63,6 +63,35 @@ export const getFormData = async (req: NextApiRequest): Promise<FileData> => {
     };
 };
 
+export const getServiceListFormData = async (req: NextApiRequest): Promise<FileData> => {
+    const { files, fields } = await formParse(req);
+    if (!files) {
+        return {
+            files,
+            fileContents: '',
+            fields,
+            name: '',
+        };
+    }
+    const { type, name } = files['csv-upload'];
+    let fileContents = '';
+
+    if (ALLOWED_CSV_FILE_TYPES.includes(type)) {
+        fileContents = await fs.promises.readFile(files['csv-upload'].path, 'utf-8');
+    } else if (ALLOWED_XLSX_FILE_TYPES.includes(type)) {
+        const workBook = XLSX.readFile(files['csv-upload'].path);
+        const sheetName = workBook.SheetNames[0];
+        fileContents = XLSX.utils.sheet_to_csv(workBook.Sheets[sheetName]);
+    }
+
+    return {
+        files,
+        fileContents,
+        fields,
+        name,
+    };
+};
+
 export const validateFile = (fileData: formidable.File, fileContents: string): string => {
     const { size, type, name } = fileData;
 

--- a/repos/fdbt-site/src/utils/sessions.ts
+++ b/repos/fdbt-site/src/utils/sessions.ts
@@ -78,6 +78,7 @@ import {
     EDIT_FARE_STAGE_MATCHING_ATTRIBUTE,
     MULTI_MODAL_ATTRIBUTE,
     SERVICE_LIST_EXEMPTION_ATTRIBUTE,
+    STOPS_EXEMPTION_ATTRIBUTE,
 } from '../constants/attributes';
 import {
     CsvUploadAttributeWithErrors,
@@ -116,7 +117,6 @@ import {
     SelectSalesOfferPackageWithError,
     Service,
     ServiceListAttribute,
-    ServiceListAttributeWithErrors,
     ServiceWithErrors,
     TermTimeAttribute,
     TicketPeriodWithErrors,
@@ -142,6 +142,7 @@ import {
     AdditionalPricing,
     CapDetails,
     EditFareStageMatchingWithErrors,
+    ExemptedStopsAttribute,
 } from '../interfaces';
 import { InboundMatchingInfo, MatchingInfo, MatchingWithErrors } from '../interfaces/matchingInterface';
 import {
@@ -185,7 +186,7 @@ export interface SessionAttributeTypes {
     [TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE]: TimeRestriction | TimeRestrictionsDefinitionWithErrors;
     [FARE_ZONE_ATTRIBUTE]: string | FareZoneWithErrors;
     [CSV_UPLOAD_ATTRIBUTE]: CsvUploadAttributeWithErrors;
-    [SERVICE_LIST_ATTRIBUTE]: ServiceListAttribute | ServiceListAttributeWithErrors;
+    [SERVICE_LIST_ATTRIBUTE]: ServiceListAttribute | { errors: ErrorInfo[] };
     [NUMBER_OF_STAGES_ATTRIBUTE]: NumberOfStagesAttributeWithError;
     [MULTIPLE_PRODUCT_ATTRIBUTE]: MultipleProductAttribute | MultipleProductAttributeWithErrors;
     [NUMBER_OF_PRODUCTS_ATTRIBUTE]: number;
@@ -246,7 +247,8 @@ export interface SessionAttributeTypes {
         | AdditionalPricing
         | { clickedYes: boolean; additionalPricingStructures: WithErrors<AdditionalPricing> };
     [MULTI_MODAL_ATTRIBUTE]: { modes: string[] };
-    [SERVICE_LIST_EXEMPTION_ATTRIBUTE]: ServiceListAttribute | ServiceListAttributeWithErrors;
+    [SERVICE_LIST_EXEMPTION_ATTRIBUTE]: ServiceListAttribute | { errors: ErrorInfo[] };
+    [STOPS_EXEMPTION_ATTRIBUTE]: ExemptedStopsAttribute | { errors: ErrorInfo[] };
 }
 
 export type SessionAttribute<T extends string> = T extends keyof SessionAttributeTypes

--- a/repos/fdbt-site/tests/pages/__snapshots__/csvUpload.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/csvUpload.test.tsx.snap
@@ -47,6 +47,12 @@ exports[`pages csvUpload should render correctly 1`] = `
           errors={Array []}
           showPriceOption={true}
         />
+        <input
+          className="govuk-button"
+          id="submit-button"
+          type="submit"
+          value="Upload and continue"
+        />
       </CsrfForm>
     </div>
     <div

--- a/repos/fdbt-site/tests/pages/__snapshots__/csvZoneUpload.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/csvZoneUpload.test.tsx.snap
@@ -176,6 +176,12 @@ exports[`pages csvzoneupload should render correctly 1`] = `
             </fieldset>
           </div>
         </div>
+        <input
+          className="govuk-button"
+          id="submit-button"
+          type="submit"
+          value="Upload and continue"
+        />
       </CsrfForm>
     </div>
     <div

--- a/repos/fdbt-site/tests/pages/__snapshots__/serviceList.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/serviceList.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`pages serviceList should render an error when the error flag is set to 
   <CsrfForm
     action="/api/serviceList"
     csrfToken=""
+    encType="multipart/form-data"
     method="post"
   >
     <ErrorSummary
@@ -21,7 +22,7 @@ exports[`pages serviceList should render an error when the error flag is set to 
       }
     />
     <div
-      className="govuk-form-group govuk-form-group--error"
+      className="govuk-form-group "
     >
       <legend
         className="govuk-fieldset__legend govuk-fieldset__legend--s"
@@ -47,8 +48,9 @@ exports[`pages serviceList should render an error when the error flag is set to 
           className="govuk-button govuk-button--secondary"
           id="select-all-button"
           name="selectAll"
-          type="submit"
-          value="Select All"
+          onClick={[Function]}
+          type="button"
+          value="Unselect All Services"
         />
         <span
           className="govuk-hint"
@@ -71,20 +73,180 @@ exports[`pages serviceList should render an error when the error flag is set to 
           addFormGroupError={false}
           errorClass=""
           errorId="checkbox-0"
-          errors={
-            Array [
-              Object {
-                "errorMessage": "Choose at least one service from the list",
-                "id": "service-list-error",
-              },
-            ]
-          }
+          errors={Array []}
         >
           <div
             className="govuk-checkboxes"
           />
         </FormElementWrapper>
       </fieldset>
+    </div>
+    <div
+      className=""
+    >
+      <div
+        className="govuk-warning-text"
+      >
+        <span
+          aria-hidden="true"
+          className="govuk-warning-text__icon"
+        >
+          !
+        </span>
+        <strong
+          className="govuk-warning-text__text"
+        >
+          <span
+            className="govuk-warning-text__assistive"
+          >
+            Warning
+          </span>
+          If there are stops exempt, you can omit them by selecting yes below and uploading the stops you want to omit.
+        </strong>
+      </div>
+      <div
+        className="govuk-form-group"
+      >
+        <fieldset
+          className="govuk-fieldset"
+        >
+          <legend
+            className="govuk-fieldset__legend govuk-fieldset__legend--m"
+          >
+            <h2
+              className="govuk-fieldset__heading"
+            >
+              Are there stops which are not included?
+            </h2>
+          </legend>
+          <FormElementWrapper
+            errorClass="govuk-form-group--error"
+            errorId="csv-upload"
+            errors={Array []}
+          >
+            <div
+              className="govuk-radios"
+              data-module="govuk-radios"
+            >
+              <div
+                className="govuk-radios__item"
+              >
+                <input
+                  className="govuk-radios__input"
+                  data-aria-controls="conditional-yes"
+                  defaultChecked={true}
+                  id="yes"
+                  name="exempt"
+                  type="radio"
+                  value="yes"
+                />
+                <label
+                  className="govuk-label govuk-radios__label"
+                  htmlFor="yes"
+                >
+                  Yes
+                </label>
+              </div>
+              <div
+                className="govuk-radios__conditional govuk-radios__conditional--hidden"
+                id="conditional-yes"
+              >
+                <div
+                  className="govuk-form-group "
+                >
+                  <label
+                    htmlFor="csv-upload"
+                  >
+                    <h1
+                      className="govuk-heading-m"
+                    >
+                      Upload exempt stops
+                    </h1>
+                  </label>
+                  <span
+                    className="govuk-hint govuk-!-margin-bottom-5"
+                    id="csv-upload-hint"
+                  >
+                    Upload exempt stops as a .csv or MS Excel file. Exempt stops are all of the relevant NaPTAN or ATCO codes that the service(s) you selected do not stop at.
+                  </span>
+                  <FormGroupWrapper
+                    errorIds={
+                      Array [
+                        "csv-upload",
+                      ]
+                    }
+                    errors={Array []}
+                  >
+                    <fieldset
+                      className="govuk-fieldset"
+                    >
+                      <FormElementWrapper
+                        errorClass="govuk-file-upload--error"
+                        errorId="csv-upload"
+                        errors={Array []}
+                      >
+                        <input
+                          accept=".csv,.xlsx,.xls"
+                          aria-describedby="csv-upload-hint"
+                          className="govuk-file-upload"
+                          id="csv-upload"
+                          name="csv-upload"
+                          type="file"
+                        />
+                      </FormElementWrapper>
+                    </fieldset>
+                  </FormGroupWrapper>
+                </div>
+                <details
+                  className="govuk-details govuk-!-margin-top-2"
+                  data-module="govuk-details"
+                >
+                  <summary
+                    className="govuk-details__summary"
+                  >
+                    <span
+                      className="govuk-details__summary-text"
+                    >
+                      My exempt stops won't upload
+                    </span>
+                  </summary>
+                  <div
+                    className="govuk-details__text"
+                  >
+                    <p>
+                      Use the below template to upload your exempt stops. This is the same template as used for fare zones, but just include ATCO/NaPTAN codes of the stops that you wish to exempt.
+                    </p>
+                    <FileAttachment
+                      attachmentUrl="[object Object]"
+                      displayName="Download fare zone CSV template - File Type CSV - File Size 673B"
+                      imageUrl={Object {}}
+                      size="673B"
+                    />
+                  </div>
+                </details>
+              </div>
+              <div
+                className="govuk-radios__item"
+              >
+                <input
+                  className="govuk-radios__input"
+                  defaultChecked={false}
+                  id="no"
+                  name="exempt"
+                  type="radio"
+                  value="no"
+                />
+                <label
+                  className="govuk-label govuk-radios__label"
+                  htmlFor="no"
+                >
+                  No
+                </label>
+              </div>
+            </div>
+          </FormElementWrapper>
+        </fieldset>
+      </div>
     </div>
     <input
       className="govuk-button"
@@ -104,6 +266,7 @@ exports[`pages serviceList should render correctly for multiOperator 1`] = `
   <CsrfForm
     action="/api/serviceList"
     csrfToken=""
+    encType="multipart/form-data"
     method="post"
   >
     <ErrorSummary
@@ -138,8 +301,9 @@ exports[`pages serviceList should render correctly for multiOperator 1`] = `
           className="govuk-button govuk-button--secondary"
           id="select-all-button"
           name="selectAll"
-          type="submit"
-          value="Select All"
+          onClick={[Function]}
+          type="button"
+          value="Select All Services"
         />
         <span
           className="govuk-hint"
@@ -172,10 +336,12 @@ exports[`pages serviceList should render correctly for multiOperator 1`] = `
               key="checkbox-item-123"
             >
               <input
+                checked={false}
                 className="govuk-checkboxes__input"
                 defaultChecked={false}
                 id="checkbox-0"
                 name="123#3h3vb32ik#NW_05_BLAC_123_1"
+                onChange={[Function]}
                 type="checkbox"
                 value="IW Bus Service 123"
               />
@@ -189,6 +355,173 @@ exports[`pages serviceList should render correctly for multiOperator 1`] = `
           </div>
         </FormElementWrapper>
       </fieldset>
+    </div>
+    <div
+      className=""
+    >
+      <div
+        className="govuk-warning-text"
+      >
+        <span
+          aria-hidden="true"
+          className="govuk-warning-text__icon"
+        >
+          !
+        </span>
+        <strong
+          className="govuk-warning-text__text"
+        >
+          <span
+            className="govuk-warning-text__assistive"
+          >
+            Warning
+          </span>
+          If there are stops exempt, you can omit them by selecting yes below and uploading the stops you want to omit.
+        </strong>
+      </div>
+      <div
+        className="govuk-form-group"
+      >
+        <fieldset
+          className="govuk-fieldset"
+        >
+          <legend
+            className="govuk-fieldset__legend govuk-fieldset__legend--m"
+          >
+            <h2
+              className="govuk-fieldset__heading"
+            >
+              Are there stops which are not included?
+            </h2>
+          </legend>
+          <FormElementWrapper
+            errorClass="govuk-form-group--error"
+            errorId="csv-upload"
+            errors={Array []}
+          >
+            <div
+              className="govuk-radios"
+              data-module="govuk-radios"
+            >
+              <div
+                className="govuk-radios__item"
+              >
+                <input
+                  className="govuk-radios__input"
+                  data-aria-controls="conditional-yes"
+                  defaultChecked={true}
+                  id="yes"
+                  name="exempt"
+                  type="radio"
+                  value="yes"
+                />
+                <label
+                  className="govuk-label govuk-radios__label"
+                  htmlFor="yes"
+                >
+                  Yes
+                </label>
+              </div>
+              <div
+                className="govuk-radios__conditional govuk-radios__conditional--hidden"
+                id="conditional-yes"
+              >
+                <div
+                  className="govuk-form-group "
+                >
+                  <label
+                    htmlFor="csv-upload"
+                  >
+                    <h1
+                      className="govuk-heading-m"
+                    >
+                      Upload exempt stops
+                    </h1>
+                  </label>
+                  <span
+                    className="govuk-hint govuk-!-margin-bottom-5"
+                    id="csv-upload-hint"
+                  >
+                    Upload exempt stops as a .csv or MS Excel file. Exempt stops are all of the relevant NaPTAN or ATCO codes that the service(s) you selected do not stop at.
+                  </span>
+                  <FormGroupWrapper
+                    errorIds={
+                      Array [
+                        "csv-upload",
+                      ]
+                    }
+                    errors={Array []}
+                  >
+                    <fieldset
+                      className="govuk-fieldset"
+                    >
+                      <FormElementWrapper
+                        errorClass="govuk-file-upload--error"
+                        errorId="csv-upload"
+                        errors={Array []}
+                      >
+                        <input
+                          accept=".csv,.xlsx,.xls"
+                          aria-describedby="csv-upload-hint"
+                          className="govuk-file-upload"
+                          id="csv-upload"
+                          name="csv-upload"
+                          type="file"
+                        />
+                      </FormElementWrapper>
+                    </fieldset>
+                  </FormGroupWrapper>
+                </div>
+                <details
+                  className="govuk-details govuk-!-margin-top-2"
+                  data-module="govuk-details"
+                >
+                  <summary
+                    className="govuk-details__summary"
+                  >
+                    <span
+                      className="govuk-details__summary-text"
+                    >
+                      My exempt stops won't upload
+                    </span>
+                  </summary>
+                  <div
+                    className="govuk-details__text"
+                  >
+                    <p>
+                      Use the below template to upload your exempt stops. This is the same template as used for fare zones, but just include ATCO/NaPTAN codes of the stops that you wish to exempt.
+                    </p>
+                    <FileAttachment
+                      attachmentUrl="[object Object]"
+                      displayName="Download fare zone CSV template - File Type CSV - File Size 673B"
+                      imageUrl={Object {}}
+                      size="673B"
+                    />
+                  </div>
+                </details>
+              </div>
+              <div
+                className="govuk-radios__item"
+              >
+                <input
+                  className="govuk-radios__input"
+                  defaultChecked={false}
+                  id="no"
+                  name="exempt"
+                  type="radio"
+                  value="no"
+                />
+                <label
+                  className="govuk-label govuk-radios__label"
+                  htmlFor="no"
+                >
+                  No
+                </label>
+              </div>
+            </div>
+          </FormElementWrapper>
+        </fieldset>
+      </div>
     </div>
     <input
       className="govuk-button"
@@ -211,6 +544,7 @@ exports[`pages serviceList should render correctly when in edit mode 1`] = `
   <CsrfForm
     action="/api/serviceList"
     csrfToken=""
+    encType="multipart/form-data"
     method="post"
   >
     <ErrorSummary
@@ -243,8 +577,9 @@ exports[`pages serviceList should render correctly when in edit mode 1`] = `
           className="govuk-button govuk-button--secondary"
           id="select-all-button"
           name="selectAll"
-          type="submit"
-          value="Select All"
+          onClick={[Function]}
+          type="button"
+          value="Select All Services"
         />
         <span
           className="govuk-hint"
@@ -277,10 +612,12 @@ exports[`pages serviceList should render correctly when in edit mode 1`] = `
               key="checkbox-item-123"
             >
               <input
+                checked={false}
                 className="govuk-checkboxes__input"
                 defaultChecked={false}
                 id="checkbox-0"
                 name="123#3h3vb32ik#NW_05_BLAC_123_1"
+                onChange={[Function]}
                 type="checkbox"
                 value="IW Bus Service 123"
               />
@@ -294,6 +631,233 @@ exports[`pages serviceList should render correctly when in edit mode 1`] = `
           </div>
         </FormElementWrapper>
       </fieldset>
+    </div>
+    <div
+      className="govuk-!-margin-bottom-6"
+    >
+      <legend
+        className="govuk-fieldset__legend govuk-fieldset__legend--m"
+      >
+        <h2
+          className="govuk-fieldset__heading"
+        >
+          You previously uploaded
+           
+          no exempt stops
+          . Do you want to edit them?
+           
+        </h2>
+      </legend>
+      <div
+        className="govuk-radios"
+        data-module="govuk-radios"
+      >
+        <div
+          className="govuk-radios__item"
+        >
+          <input
+            className="govuk-radios__input"
+            data-aria-controls="conditional-yes"
+            id="exempt-yes"
+            name="edit-exempt"
+            onChange={[Function]}
+            type="radio"
+            value="yes"
+          />
+          <label
+            className="govuk-label govuk-radios__label"
+            htmlFor="exempt-yes"
+          >
+            Yes
+          </label>
+        </div>
+        <div
+          className="govuk-radios__item"
+        >
+          <input
+            className="govuk-radios__input"
+            defaultChecked={true}
+            id="exempt-no"
+            name="edit-exempt"
+            onChange={[Function]}
+            type="radio"
+            value="no"
+          />
+          <label
+            className="govuk-label govuk-radios__label"
+            htmlFor="exempt-no"
+          >
+            No
+          </label>
+        </div>
+      </div>
+    </div>
+    <div
+      className="govuk-visually-hidden"
+    >
+      <div
+        className="govuk-warning-text"
+      >
+        <span
+          aria-hidden="true"
+          className="govuk-warning-text__icon"
+        >
+          !
+        </span>
+        <strong
+          className="govuk-warning-text__text"
+        >
+          <span
+            className="govuk-warning-text__assistive"
+          >
+            Warning
+          </span>
+          If there are stops exempt, you can omit them by selecting yes below and uploading the stops you want to omit.
+        </strong>
+      </div>
+      <div
+        className="govuk-form-group"
+      >
+        <fieldset
+          className="govuk-fieldset"
+        >
+          <legend
+            className="govuk-fieldset__legend govuk-fieldset__legend--m"
+          >
+            <h2
+              className="govuk-fieldset__heading"
+            >
+              Are there stops which are not included?
+            </h2>
+          </legend>
+          <FormElementWrapper
+            errorClass="govuk-form-group--error"
+            errorId="csv-upload"
+            errors={Array []}
+          >
+            <div
+              className="govuk-radios"
+              data-module="govuk-radios"
+            >
+              <div
+                className="govuk-radios__item"
+              >
+                <input
+                  className="govuk-radios__input"
+                  data-aria-controls="conditional-yes"
+                  defaultChecked={true}
+                  id="yes"
+                  name="exempt"
+                  type="radio"
+                  value="yes"
+                />
+                <label
+                  className="govuk-label govuk-radios__label"
+                  htmlFor="yes"
+                >
+                  Yes
+                </label>
+              </div>
+              <div
+                className="govuk-radios__conditional govuk-radios__conditional--hidden"
+                id="conditional-yes"
+              >
+                <div
+                  className="govuk-form-group "
+                >
+                  <label
+                    htmlFor="csv-upload"
+                  >
+                    <h1
+                      className="govuk-heading-m"
+                    >
+                      Upload exempt stops
+                    </h1>
+                  </label>
+                  <span
+                    className="govuk-hint govuk-!-margin-bottom-5"
+                    id="csv-upload-hint"
+                  >
+                    Upload exempt stops as a .csv or MS Excel file. Exempt stops are all of the relevant NaPTAN or ATCO codes that the service(s) you selected do not stop at.
+                  </span>
+                  <FormGroupWrapper
+                    errorIds={
+                      Array [
+                        "csv-upload",
+                      ]
+                    }
+                    errors={Array []}
+                  >
+                    <fieldset
+                      className="govuk-fieldset"
+                    >
+                      <FormElementWrapper
+                        errorClass="govuk-file-upload--error"
+                        errorId="csv-upload"
+                        errors={Array []}
+                      >
+                        <input
+                          accept=".csv,.xlsx,.xls"
+                          aria-describedby="csv-upload-hint"
+                          className="govuk-file-upload"
+                          id="csv-upload"
+                          name="csv-upload"
+                          type="file"
+                        />
+                      </FormElementWrapper>
+                    </fieldset>
+                  </FormGroupWrapper>
+                </div>
+                <details
+                  className="govuk-details govuk-!-margin-top-2"
+                  data-module="govuk-details"
+                >
+                  <summary
+                    className="govuk-details__summary"
+                  >
+                    <span
+                      className="govuk-details__summary-text"
+                    >
+                      My exempt stops won't upload
+                    </span>
+                  </summary>
+                  <div
+                    className="govuk-details__text"
+                  >
+                    <p>
+                      Use the below template to upload your exempt stops. This is the same template as used for fare zones, but just include ATCO/NaPTAN codes of the stops that you wish to exempt.
+                    </p>
+                    <FileAttachment
+                      attachmentUrl="[object Object]"
+                      displayName="Download fare zone CSV template - File Type CSV - File Size 673B"
+                      imageUrl={Object {}}
+                      size="673B"
+                    />
+                  </div>
+                </details>
+              </div>
+              <div
+                className="govuk-radios__item"
+              >
+                <input
+                  className="govuk-radios__input"
+                  defaultChecked={false}
+                  id="no"
+                  name="exempt"
+                  type="radio"
+                  value="no"
+                />
+                <label
+                  className="govuk-label govuk-radios__label"
+                  htmlFor="no"
+                >
+                  No
+                </label>
+              </div>
+            </div>
+          </FormElementWrapper>
+        </fieldset>
+      </div>
     </div>
     <input
       className="govuk-button"
@@ -313,6 +877,7 @@ exports[`pages serviceList should render correctly with bods data source 1`] = `
   <CsrfForm
     action="/api/serviceList"
     csrfToken=""
+    encType="multipart/form-data"
     method="post"
   >
     <ErrorSummary
@@ -345,8 +910,9 @@ exports[`pages serviceList should render correctly with bods data source 1`] = `
           className="govuk-button govuk-button--secondary"
           id="select-all-button"
           name="selectAll"
-          type="submit"
-          value="Select All"
+          onClick={[Function]}
+          type="button"
+          value="Select All Services"
         />
         <span
           className="govuk-hint"
@@ -379,10 +945,12 @@ exports[`pages serviceList should render correctly with bods data source 1`] = `
               key="checkbox-item-123"
             >
               <input
+                checked={false}
                 className="govuk-checkboxes__input"
                 defaultChecked={false}
                 id="checkbox-0"
                 name="123#3h3vb32ik#NW_05_BLAC_123_1"
+                onChange={[Function]}
                 type="checkbox"
                 value="IW Bus Service 123"
               />
@@ -396,6 +964,173 @@ exports[`pages serviceList should render correctly with bods data source 1`] = `
           </div>
         </FormElementWrapper>
       </fieldset>
+    </div>
+    <div
+      className=""
+    >
+      <div
+        className="govuk-warning-text"
+      >
+        <span
+          aria-hidden="true"
+          className="govuk-warning-text__icon"
+        >
+          !
+        </span>
+        <strong
+          className="govuk-warning-text__text"
+        >
+          <span
+            className="govuk-warning-text__assistive"
+          >
+            Warning
+          </span>
+          If there are stops exempt, you can omit them by selecting yes below and uploading the stops you want to omit.
+        </strong>
+      </div>
+      <div
+        className="govuk-form-group"
+      >
+        <fieldset
+          className="govuk-fieldset"
+        >
+          <legend
+            className="govuk-fieldset__legend govuk-fieldset__legend--m"
+          >
+            <h2
+              className="govuk-fieldset__heading"
+            >
+              Are there stops which are not included?
+            </h2>
+          </legend>
+          <FormElementWrapper
+            errorClass="govuk-form-group--error"
+            errorId="csv-upload"
+            errors={Array []}
+          >
+            <div
+              className="govuk-radios"
+              data-module="govuk-radios"
+            >
+              <div
+                className="govuk-radios__item"
+              >
+                <input
+                  className="govuk-radios__input"
+                  data-aria-controls="conditional-yes"
+                  defaultChecked={true}
+                  id="yes"
+                  name="exempt"
+                  type="radio"
+                  value="yes"
+                />
+                <label
+                  className="govuk-label govuk-radios__label"
+                  htmlFor="yes"
+                >
+                  Yes
+                </label>
+              </div>
+              <div
+                className="govuk-radios__conditional govuk-radios__conditional--hidden"
+                id="conditional-yes"
+              >
+                <div
+                  className="govuk-form-group "
+                >
+                  <label
+                    htmlFor="csv-upload"
+                  >
+                    <h1
+                      className="govuk-heading-m"
+                    >
+                      Upload exempt stops
+                    </h1>
+                  </label>
+                  <span
+                    className="govuk-hint govuk-!-margin-bottom-5"
+                    id="csv-upload-hint"
+                  >
+                    Upload exempt stops as a .csv or MS Excel file. Exempt stops are all of the relevant NaPTAN or ATCO codes that the service(s) you selected do not stop at.
+                  </span>
+                  <FormGroupWrapper
+                    errorIds={
+                      Array [
+                        "csv-upload",
+                      ]
+                    }
+                    errors={Array []}
+                  >
+                    <fieldset
+                      className="govuk-fieldset"
+                    >
+                      <FormElementWrapper
+                        errorClass="govuk-file-upload--error"
+                        errorId="csv-upload"
+                        errors={Array []}
+                      >
+                        <input
+                          accept=".csv,.xlsx,.xls"
+                          aria-describedby="csv-upload-hint"
+                          className="govuk-file-upload"
+                          id="csv-upload"
+                          name="csv-upload"
+                          type="file"
+                        />
+                      </FormElementWrapper>
+                    </fieldset>
+                  </FormGroupWrapper>
+                </div>
+                <details
+                  className="govuk-details govuk-!-margin-top-2"
+                  data-module="govuk-details"
+                >
+                  <summary
+                    className="govuk-details__summary"
+                  >
+                    <span
+                      className="govuk-details__summary-text"
+                    >
+                      My exempt stops won't upload
+                    </span>
+                  </summary>
+                  <div
+                    className="govuk-details__text"
+                  >
+                    <p>
+                      Use the below template to upload your exempt stops. This is the same template as used for fare zones, but just include ATCO/NaPTAN codes of the stops that you wish to exempt.
+                    </p>
+                    <FileAttachment
+                      attachmentUrl="[object Object]"
+                      displayName="Download fare zone CSV template - File Type CSV - File Size 673B"
+                      imageUrl={Object {}}
+                      size="673B"
+                    />
+                  </div>
+                </details>
+              </div>
+              <div
+                className="govuk-radios__item"
+              >
+                <input
+                  className="govuk-radios__input"
+                  defaultChecked={false}
+                  id="no"
+                  name="exempt"
+                  type="radio"
+                  value="no"
+                />
+                <label
+                  className="govuk-label govuk-radios__label"
+                  htmlFor="no"
+                >
+                  No
+                </label>
+              </div>
+            </div>
+          </FormElementWrapper>
+        </fieldset>
+      </div>
     </div>
     <input
       className="govuk-button"

--- a/repos/fdbt-site/tests/pages/api/csvZoneUpload.test.ts
+++ b/repos/fdbt-site/tests/pages/api/csvZoneUpload.test.ts
@@ -7,7 +7,7 @@ import * as virusCheck from '../../../src/utils/apiUtils/virusScan';
 import * as csvData from '../../testData/csvZoneData';
 import * as s3 from '../../../src/data/s3';
 import * as sessions from '../../../src/utils/sessions';
-import * as dynamo from '../../../src/data/auroradb';
+import * as auroradb from '../../../src/data/auroradb';
 import {
     FARE_ZONE_ATTRIBUTE,
     FARE_TYPE_ATTRIBUTE,
@@ -69,7 +69,7 @@ describe('csvZoneUpload', () => {
 
             jest.spyOn(virusCheck, 'containsViruses').mockImplementation().mockResolvedValue(false);
 
-            jest.spyOn(dynamo, 'getAtcoCodesByNaptanCodes')
+            jest.spyOn(auroradb, 'getAtcoCodesByNaptanCodes')
                 .mockImplementation()
                 .mockResolvedValue([{ atcoCode: 'TestATCO-TC5', naptanCode: 'TestNaptan-TC5' }]);
 
@@ -266,7 +266,7 @@ describe('csvZoneUpload', () => {
                 },
             });
 
-        jest.spyOn(dynamo, 'batchGetStopsByAtcoCode').mockImplementation().mockResolvedValue(stops);
+        jest.spyOn(auroradb, 'batchGetStopsByAtcoCode').mockImplementation().mockResolvedValue(stops);
 
         jest.spyOn(virusCheck, 'containsViruses').mockImplementation().mockResolvedValue(false);
 
@@ -333,7 +333,7 @@ describe('csvZoneUpload', () => {
                 },
             },
         };
-        const dynamoError = 'Could not fetch data from dynamo in test';
+        const auroradbError = 'Could not fetch data from auroradb in test';
 
         jest.spyOn(fileUpload, 'getFormData').mockImplementation().mockResolvedValue({
             name: 'file',
@@ -343,8 +343,8 @@ describe('csvZoneUpload', () => {
 
         jest.spyOn(virusCheck, 'containsViruses').mockImplementation().mockResolvedValue(false);
 
-        jest.spyOn(dynamo, 'getAtcoCodesByNaptanCodes').mockImplementation(() => {
-            throw new Error(dynamoError);
+        jest.spyOn(auroradb, 'getAtcoCodesByNaptanCodes').mockImplementation(() => {
+            throw new Error(auroradbError);
         });
 
         await csvZoneUpload.default(req, res);
@@ -558,7 +558,7 @@ describe('csvZoneUpload', () => {
             [csvData.testCsvWithEmptyLines, csvData.processedTestCsvWithEmptyLines.Body],
             [csvData.testCsvWithEmptyLinesAndEmptyCells, csvData.processedTestCsvWithEmptyLinesAndEmptyCells.Body],
         ])('should skip empty lines in the csv', async (fileContent, expectedProcessed) => {
-            jest.spyOn(dynamo, 'getAtcoCodesByNaptanCodes')
+            jest.spyOn(auroradb, 'getAtcoCodesByNaptanCodes')
                 .mockImplementation()
                 .mockResolvedValue([{ atcoCode: 'TestATCO-TC4', naptanCode: 'TestNaptan-TC4' }]);
 
@@ -569,7 +569,7 @@ describe('csvZoneUpload', () => {
 
         it('returns null when a csv upload contains no stops info', async () => {
             const fileContent = csvData.testCsvWithNoStopsInfo;
-            jest.spyOn(dynamo, 'getAtcoCodesByNaptanCodes').mockImplementation().mockResolvedValue([]);
+            jest.spyOn(auroradb, 'getAtcoCodesByNaptanCodes').mockImplementation().mockResolvedValue([]);
 
             const result = await csvZoneUpload.processCsv(fileContent, req, res);
 
@@ -583,7 +583,7 @@ describe('csvZoneUpload', () => {
             const mockNaptanCodesToQuery: string[] = ['TestNaptan-TC5'];
             const expectedUserFareZones = csvData.processedTestCsvWithEmptyCells.Body;
 
-            jest.spyOn(dynamo, 'getAtcoCodesByNaptanCodes')
+            jest.spyOn(auroradb, 'getAtcoCodesByNaptanCodes')
                 .mockImplementation()
                 .mockResolvedValue([{ atcoCode: 'TestATCO-TC5', naptanCode: 'TestNaptan-TC5' }]);
 

--- a/repos/fdbt-site/tests/pages/api/serviceList.test.ts
+++ b/repos/fdbt-site/tests/pages/api/serviceList.test.ts
@@ -1,20 +1,43 @@
 import {
     expectedPeriodMultipleServicesTicketWithMultipleProducts,
     getMockRequestAndResponse,
+    zoneStops,
 } from '../../testData/mockData';
 import serviceList from '../../../src/pages/api/serviceList';
 import {
     FARE_TYPE_ATTRIBUTE,
     MATCHING_JSON_ATTRIBUTE,
     MATCHING_JSON_META_DATA_ATTRIBUTE,
+    SERVICE_LIST_ATTRIBUTE,
+    STOPS_EXEMPTION_ATTRIBUTE,
 } from '../../../src/constants/attributes';
 import * as userData from '../../../src/utils/apiUtils/userData';
+import * as fileUpload from '../../../src/utils/apiUtils/fileUpload';
+import * as sessions from '../../../src/utils/sessions';
+import * as virusCheck from '../../../src/utils/apiUtils/virusScan';
+import * as auroradb from '../../../src/data/auroradb';
+import { secondTestCsv } from '../../testData/csvZoneData';
 
 describe('serviceList', () => {
-    const selectAllFalseUrl = '/serviceList?selectAll=false';
     const writeHeadMock = jest.fn();
     const s3Spy = jest.spyOn(userData, 'putUserDataInProductsBucketWithFilePath');
     s3Spy.mockImplementation(() => Promise.resolve('pathToFile'));
+    const getServiceListFormDataSpy = jest.spyOn(fileUpload, 'getServiceListFormData');
+    const updateSessionAttributeSpy = jest.spyOn(sessions, 'updateSessionAttribute');
+    const batchGetStopsByAtcoCodeSpy = jest.spyOn(auroradb, 'batchGetStopsByAtcoCode');
+
+    const file = {
+        'csv-upload': {
+            size: 999,
+            path: 'string',
+            name: 'string',
+            type: 'text/csv',
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            toJSON(): any {
+                return '';
+            },
+        },
+    };
 
     afterEach(() => {
         jest.resetAllMocks();
@@ -22,59 +45,54 @@ describe('serviceList', () => {
 
     it('redirects back to /serviceList if there are errors', async () => {
         const { req, res } = getMockRequestAndResponse({
-            body: {},
+            body: null,
             uuid: {},
             mockWriteHeadFn: writeHeadMock,
-            mockEndFn: jest.fn(),
-            requestHeaders: {
-                referer: `http://localhost:5000${selectAllFalseUrl}`,
-            },
             session: { [FARE_TYPE_ATTRIBUTE]: { fareType: 'period' } },
+        });
+
+        getServiceListFormDataSpy.mockImplementation().mockResolvedValue({
+            name: '',
+            files: file,
+            fileContents: '',
+            fields: {
+                exempt: 'no',
+            },
         });
 
         await serviceList(req, res);
 
         expect(writeHeadMock).toBeCalledWith(302, {
-            Location: selectAllFalseUrl,
-        });
-    });
-
-    it('should change the query string for select all to true when select all button is selected', async () => {
-        const selectAllTrueUrl = '/serviceList?selectAll=true';
-        const { req, res } = getMockRequestAndResponse({
-            body: { selectAll: 'Select All Services' },
-            uuid: {},
-            mockWriteHeadFn: writeHeadMock,
-            mockEndFn: jest.fn(),
-            requestHeaders: {
-                referer: `http://localhost:5000${selectAllFalseUrl}`,
-            },
-            session: { [FARE_TYPE_ATTRIBUTE]: { fareType: 'period' } },
+            Location: '/serviceList',
         });
 
-        await serviceList(req, res);
-
-        expect(writeHeadMock).toBeCalledWith(302, {
-            Location: selectAllTrueUrl,
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, SERVICE_LIST_ATTRIBUTE, {
+            errors: [{ errorMessage: 'Choose at least one service from the options', id: 'checkbox-0' }],
         });
     });
 
     it('redirects to /multipleProducts if input is valid and the user is entering details for a period ticket', async () => {
-        const serviceInfo = {
-            '237#11-237-_-y08-1#07/04/2020': 'Ashton Under Lyne - Glossop',
-            '391#NW_01_MCT_391_1#23/04/2019': 'Macclesfield - Bollington - Poynton - Stockport',
-            '232#NW_04_MCTR_232_1#06/04/2020': 'Ashton - Hurst Cross - Broadoak Circular',
-        };
-
         const { req, res } = getMockRequestAndResponse({
-            body: { ...serviceInfo },
+            body: {
+                '237#YpQjUw#11-237-_-y08-1#07/04/2020': 'Ashton Under Lyne - Glossop',
+                '391#Y2ejUw#NW_01_MCT_391_1#23/04/2019': 'Macclesfield - Bollington - Poynton - Stockport',
+                '232#YfsjUw#NW_04_MCTR_232_1#06/04/2020': 'Ashton - Hurst Cross - Broadoak Circular',
+            },
             uuid: {},
             mockWriteHeadFn: writeHeadMock,
-            mockEndFn: jest.fn(),
-            requestHeaders: {
-                referer: `http://localhost:5000${selectAllFalseUrl}`,
-            },
             session: { [FARE_TYPE_ATTRIBUTE]: { fareType: 'period' } },
+        });
+
+        getServiceListFormDataSpy.mockImplementation().mockResolvedValue({
+            name: '',
+            files: file,
+            fileContents: '',
+            fields: {
+                exempt: 'no',
+                '237#YpQjUw#11-237-_-y08-1#07/04/2020': 'Ashton Under Lyne - Glossop',
+                '391#Y2ejUw#NW_01_MCT_391_1#23/04/2019': 'Macclesfield - Bollington - Poynton - Stockport',
+                '232#YfsjUw#NW_04_MCTR_232_1#06/04/2020': 'Ashton - Hurst Cross - Broadoak Circular',
+            },
         });
 
         await serviceList(req, res);
@@ -82,24 +100,122 @@ describe('serviceList', () => {
         expect(writeHeadMock).toBeCalledWith(302, {
             Location: '/multipleProducts',
         });
+
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, SERVICE_LIST_ATTRIBUTE, {
+            selectedServices: [
+                {
+                    lineId: 'YpQjUw',
+                    lineName: '237',
+                    serviceCode: '11-237-_-y08-1',
+                    serviceDescription: 'Ashton Under Lyne - Glossop',
+                    startDate: '07/04/2020',
+                },
+                {
+                    lineId: 'Y2ejUw',
+                    lineName: '391',
+                    serviceCode: 'NW_01_MCT_391_1',
+                    serviceDescription: 'Macclesfield - Bollington - Poynton - Stockport',
+                    startDate: '23/04/2019',
+                },
+                {
+                    lineId: 'YfsjUw',
+                    lineName: '232',
+                    serviceCode: 'NW_04_MCTR_232_1',
+                    serviceDescription: 'Ashton - Hurst Cross - Broadoak Circular',
+                    startDate: '06/04/2020',
+                },
+            ],
+        });
+    });
+
+    it('redirects to /multipleProducts if input is valid and the user is entering details for a period ticket, and there are exempt stops', async () => {
+        const { req, res } = getMockRequestAndResponse({
+            body: {
+                '237#YpQjUw#11-237-_-y08-1#07/04/2020': 'Ashton Under Lyne - Glossop',
+                '391#Y2ejUw#NW_01_MCT_391_1#23/04/2019': 'Macclesfield - Bollington - Poynton - Stockport',
+                '232#YfsjUw#NW_04_MCTR_232_1#06/04/2020': 'Ashton - Hurst Cross - Broadoak Circular',
+            },
+            uuid: {},
+            mockWriteHeadFn: writeHeadMock,
+            session: { [FARE_TYPE_ATTRIBUTE]: { fareType: 'period' } },
+        });
+
+        getServiceListFormDataSpy.mockImplementation().mockResolvedValue({
+            name: '',
+            files: file,
+            fileContents: secondTestCsv,
+            fields: {
+                exempt: 'yes',
+                '237#YpQjUw#11-237-_-y08-1#07/04/2020': 'Ashton Under Lyne - Glossop',
+                '391#Y2ejUw#NW_01_MCT_391_1#23/04/2019': 'Macclesfield - Bollington - Poynton - Stockport',
+                '232#YfsjUw#NW_04_MCTR_232_1#06/04/2020': 'Ashton - Hurst Cross - Broadoak Circular',
+            },
+        });
+
+        jest.spyOn(virusCheck, 'containsViruses').mockImplementation().mockResolvedValue(false);
+        batchGetStopsByAtcoCodeSpy.mockImplementation(() => Promise.resolve(zoneStops));
+
+        await serviceList(req, res);
+
+        expect(writeHeadMock).toBeCalledWith(302, {
+            Location: '/multipleProducts',
+        });
+
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, SERVICE_LIST_ATTRIBUTE, {
+            selectedServices: [
+                {
+                    lineId: 'YpQjUw',
+                    lineName: '237',
+                    serviceCode: '11-237-_-y08-1',
+                    serviceDescription: 'Ashton Under Lyne - Glossop',
+                    startDate: '07/04/2020',
+                },
+                {
+                    lineId: 'Y2ejUw',
+                    lineName: '391',
+                    serviceCode: 'NW_01_MCT_391_1',
+                    serviceDescription: 'Macclesfield - Bollington - Poynton - Stockport',
+                    startDate: '23/04/2019',
+                },
+                {
+                    lineId: 'YfsjUw',
+                    lineName: '232',
+                    serviceCode: 'NW_04_MCTR_232_1',
+                    serviceDescription: 'Ashton - Hurst Cross - Broadoak Circular',
+                    startDate: '06/04/2020',
+                },
+            ],
+        });
+
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, STOPS_EXEMPTION_ATTRIBUTE, { exemptStops: zoneStops });
     });
 
     it('redirects to /searchOperators if input is valid and the user is entering details for a multi-operator ticket', async () => {
-        const serviceInfo = {
-            '64': 'Leeds-Bradford#12/02/12',
-            '45': 'gggggg#02/03/91',
-            '47': 'hhhhhh#23/04/20',
-        };
-
         const { req, res } = getMockRequestAndResponse({
-            body: { ...serviceInfo },
+            body: {
+                '237#YpQjUw#11-237-_-y08-1#07/04/2020': 'Ashton Under Lyne - Glossop',
+                '391#Y2ejUw#NW_01_MCT_391_1#23/04/2019': 'Macclesfield - Bollington - Poynton - Stockport',
+                '232#YfsjUw#NW_04_MCTR_232_1#06/04/2020': 'Ashton - Hurst Cross - Broadoak Circular',
+            },
             uuid: {},
             mockWriteHeadFn: writeHeadMock,
             mockEndFn: jest.fn(),
             requestHeaders: {
-                referer: `http://localhost:5000${selectAllFalseUrl}`,
+                referer: 'http://localhost:5000/serviceList',
             },
             session: { [FARE_TYPE_ATTRIBUTE]: { fareType: 'multiOperator' } },
+        });
+
+        getServiceListFormDataSpy.mockImplementation().mockResolvedValue({
+            name: '',
+            files: file,
+            fileContents: '',
+            fields: {
+                exempt: 'no',
+                '237#YpQjUw#11-237-_-y08-1#07/04/2020': 'Ashton Under Lyne - Glossop',
+                '391#Y2ejUw#NW_01_MCT_391_1#23/04/2019': 'Macclesfield - Bollington - Poynton - Stockport',
+                '232#YfsjUw#NW_04_MCTR_232_1#06/04/2020': 'Ashton - Hurst Cross - Broadoak Circular',
+            },
         });
 
         await serviceList(req, res);
@@ -110,21 +226,31 @@ describe('serviceList', () => {
     });
 
     it('redirects to /multipleProducts if input is valid and the user is entering details for a flat fare ticket', async () => {
-        const serviceInfo = {
-            '64': 'Leeds-Bradford#12/02/12',
-            '45': 'gggggg#02/03/91',
-            '47': 'hhhhhh#23/04/20',
-        };
-
         const { req, res } = getMockRequestAndResponse({
-            body: { ...serviceInfo },
+            body: {
+                '237#YpQjUw#11-237-_-y08-1#07/04/2020': 'Ashton Under Lyne - Glossop',
+                '391#Y2ejUw#NW_01_MCT_391_1#23/04/2019': 'Macclesfield - Bollington - Poynton - Stockport',
+                '232#YfsjUw#NW_04_MCTR_232_1#06/04/2020': 'Ashton - Hurst Cross - Broadoak Circular',
+            },
             uuid: {},
             mockWriteHeadFn: writeHeadMock,
             mockEndFn: jest.fn(),
             requestHeaders: {
-                referer: `http://localhost:5000${selectAllFalseUrl}`,
+                referer: 'http://localhost:5000/serviceList',
             },
             session: { [FARE_TYPE_ATTRIBUTE]: { fareType: 'flatFare' } },
+        });
+
+        getServiceListFormDataSpy.mockImplementation().mockResolvedValue({
+            name: '',
+            files: file,
+            fileContents: '',
+            fields: {
+                exempt: 'no',
+                '237#YpQjUw#11-237-_-y08-1#07/04/2020': 'Ashton Under Lyne - Glossop',
+                '391#Y2ejUw#NW_01_MCT_391_1#23/04/2019': 'Macclesfield - Bollington - Poynton - Stockport',
+                '232#YfsjUw#NW_04_MCTR_232_1#06/04/2020': 'Ashton - Hurst Cross - Broadoak Circular',
+            },
         });
 
         await serviceList(req, res);
@@ -135,28 +261,34 @@ describe('serviceList', () => {
     });
 
     it('should update the service list when in edit mode and redirect back to products/productDetails', async () => {
-        const serviceInfo = {
-            '2#YpQjUw#NW_05_BLAC_2_1#05/04/2020': 'POULTON - BLACKPOOL via Victoria Hospital Outpatients',
-        };
-
         const { req, res } = getMockRequestAndResponse({
             cookieValues: {},
-            body: { serviceInfo },
+            body: { '2#YpQjUw#NW_05_BLAC_2_1#05/04/2020': 'POULTON - BLACKPOOL via Victoria Hospital Outpatients' },
             uuid: {},
             session: {
                 [MATCHING_JSON_ATTRIBUTE]: expectedPeriodMultipleServicesTicketWithMultipleProducts,
                 [MATCHING_JSON_META_DATA_ATTRIBUTE]: {
                     productId: '2',
-                    serviceId: '22D',
                     matchingJsonLink: 'test/path',
                 },
             },
             mockWriteHeadFn: writeHeadMock,
         });
+
+        getServiceListFormDataSpy.mockImplementation().mockResolvedValue({
+            name: '',
+            files: file,
+            fileContents: '',
+            fields: {
+                exempt: 'no',
+                '2#YpQjUw#NW_05_BLAC_2_1#05/04/2020': 'POULTON - BLACKPOOL via Victoria Hospital Outpatients',
+            },
+        });
+
         await serviceList(req, res);
 
         expect(res.writeHead).toBeCalledWith(302, {
-            Location: '/products/productDetails?productId=2&serviceId=22D',
+            Location: '/products/productDetails?productId=2',
         });
     });
 });

--- a/repos/fdbt-site/tests/pages/api/ticketRepresentation.test.ts
+++ b/repos/fdbt-site/tests/pages/api/ticketRepresentation.test.ts
@@ -70,7 +70,7 @@ describe('ticketRepresentation', () => {
         });
     });
 
-    it('should return 302 redirect to /serviceList (with selectAll=false) when the user selects the service selection option', () => {
+    it('should return 302 redirect to /serviceList when the user selects the service selection option', () => {
         const { req, res } = getMockRequestAndResponse({
             cookieValues: {},
             body: { ticketType: 'multipleServices' },
@@ -81,11 +81,11 @@ describe('ticketRepresentation', () => {
         ticketRepresentation(req, res);
 
         expect(writeHeadMock).toBeCalledWith(302, {
-            Location: '/serviceList?selectAll=false',
+            Location: '/serviceList',
         });
     });
 
-    it('should return 302 redirect to /serviceList (with selectAll=false) when the user selects the service selection multipleServicesPricedByDistance  option', () => {
+    it('should return 302 redirect to /serviceList when the user selects the service selection multipleServicesPricedByDistance  option', () => {
         const { req, res } = getMockRequestAndResponse({
             cookieValues: {},
             body: { ticketType: 'multipleServicesPricedByDistance' },
@@ -96,7 +96,7 @@ describe('ticketRepresentation', () => {
         ticketRepresentation(req, res);
 
         expect(writeHeadMock).toBeCalledWith(302, {
-            Location: '/serviceList?selectAll=false',
+            Location: '/serviceList',
         });
     });
 
@@ -130,7 +130,7 @@ describe('ticketRepresentation', () => {
         });
     });
 
-    it('should return 302 redirect to /serviceList (with selectAll=false) when user selects a multipleServicesFlatFareMultiOperator option', () => {
+    it('should return 302 redirect to /serviceList when user selects a multipleServicesFlatFareMultiOperator option', () => {
         const { req, res } = getMockRequestAndResponse({
             cookieValues: {},
             body: { ticketType: 'multipleServicesFlatFareMultiOperator' },
@@ -141,7 +141,7 @@ describe('ticketRepresentation', () => {
         ticketRepresentation(req, res);
 
         expect(writeHeadMock).toBeCalledWith(302, {
-            Location: '/serviceList?selectAll=false',
+            Location: '/serviceList',
         });
     });
 });

--- a/repos/fdbt-site/tests/pages/csvZoneUpload.test.tsx
+++ b/repos/fdbt-site/tests/pages/csvZoneUpload.test.tsx
@@ -55,7 +55,6 @@ describe('pages', () => {
                     serviceList={mockServiceList}
                     clickedYes={false}
                     dataSourceAttribute={{ source: 'bods', hasBods: true, hasTnds: false }}
-                    buttonText="Select All Services"
                 />,
             );
             expect(tree).toMatchSnapshot();

--- a/repos/fdbt-site/tests/pages/products/productDetails.test.tsx
+++ b/repos/fdbt-site/tests/pages/products/productDetails.test.tsx
@@ -671,7 +671,7 @@ describe('myfares pages', () => {
                             editLink: '/csvZoneUpload',
                         },
                         {
-                            id: 'exempt-services',
+                            id: 'exempted-services',
                             name: 'Exempt services',
                             content: ['N/A'],
                             editLink: '/csvZoneUpload',
@@ -754,7 +754,7 @@ describe('myfares pages', () => {
                             editLink: '/csvZoneUpload',
                         },
                         {
-                            id: 'exempt-services',
+                            id: 'exempted-services',
                             name: 'Exempt services',
                             content: ['N/A'],
                             editLink: '/csvZoneUpload',
@@ -917,7 +917,7 @@ describe('myfares pages', () => {
                             editLink: '/csvZoneUpload',
                         },
                         {
-                            id: 'exempt-services',
+                            id: 'exempted-services',
                             name: 'Exempt services',
                             content: ['N/A'],
                             editLink: '/csvZoneUpload',
@@ -1074,7 +1074,7 @@ describe('myfares pages', () => {
                             editLink: '/csvZoneUpload',
                         },
                         {
-                            id: 'exempt-services',
+                            id: 'exempted-services',
                             name: 'Exempt services',
                             content: ['100, 101, 102'],
                             editLink: '/csvZoneUpload',

--- a/repos/fdbt-site/tests/pages/products/productDetails.test.tsx
+++ b/repos/fdbt-site/tests/pages/products/productDetails.test.tsx
@@ -671,8 +671,8 @@ describe('myfares pages', () => {
                             editLink: '/csvZoneUpload',
                         },
                         {
-                            id: 'exempted-services',
-                            name: 'Exempted Services',
+                            id: 'exempt-services',
+                            name: 'Exempt services',
                             content: ['N/A'],
                             editLink: '/csvZoneUpload',
                         },
@@ -754,8 +754,8 @@ describe('myfares pages', () => {
                             editLink: '/csvZoneUpload',
                         },
                         {
-                            id: 'exempted-services',
-                            name: 'Exempted Services',
+                            id: 'exempt-services',
+                            name: 'Exempt services',
                             content: ['N/A'],
                             editLink: '/csvZoneUpload',
                         },
@@ -917,8 +917,8 @@ describe('myfares pages', () => {
                             editLink: '/csvZoneUpload',
                         },
                         {
-                            id: 'exempted-services',
-                            name: 'Exempted Services',
+                            id: 'exempt-services',
+                            name: 'Exempt services',
                             content: ['N/A'],
                             editLink: '/csvZoneUpload',
                         },
@@ -1074,8 +1074,8 @@ describe('myfares pages', () => {
                             editLink: '/csvZoneUpload',
                         },
                         {
-                            id: 'exempted-services',
-                            name: 'Exempted Services',
+                            id: 'exempt-services',
+                            name: 'Exempt services',
                             content: ['100, 101, 102'],
                             editLink: '/csvZoneUpload',
                         },

--- a/repos/fdbt-site/tests/pages/serviceList.test.tsx
+++ b/repos/fdbt-site/tests/pages/serviceList.test.tsx
@@ -118,7 +118,6 @@ describe('pages', () => {
             const tree = shallow(
                 <ServiceList
                     serviceList={mockServiceList}
-                    buttonText="Select All"
                     errors={[]}
                     csrfToken=""
                     multiOperator={false}
@@ -129,6 +128,9 @@ describe('pages', () => {
                     }}
                     additional={false}
                     backHref=""
+                    selectedYesToExempt={false}
+                    exemptStops=""
+                    isEditMode={false}
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -138,7 +140,6 @@ describe('pages', () => {
             const tree = shallow(
                 <ServiceList
                     serviceList={mockServiceList}
-                    buttonText="Select All"
                     errors={[]}
                     csrfToken=""
                     multiOperator
@@ -149,6 +150,9 @@ describe('pages', () => {
                     }}
                     additional={false}
                     backHref=""
+                    selectedYesToExempt={false}
+                    exemptStops=""
+                    isEditMode={false}
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -159,7 +163,6 @@ describe('pages', () => {
                 <ServiceList
                     serviceList={[]}
                     errors={mockError}
-                    buttonText="Select All"
                     csrfToken=""
                     multiOperator={false}
                     dataSourceAttribute={{
@@ -169,6 +172,9 @@ describe('pages', () => {
                     }}
                     additional={false}
                     backHref=""
+                    selectedYesToExempt={false}
+                    exemptStops=""
+                    isEditMode={false}
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -178,7 +184,6 @@ describe('pages', () => {
             const tree = shallow(
                 <ServiceList
                     serviceList={mockServiceList}
-                    buttonText="Select All"
                     errors={[]}
                     csrfToken=""
                     multiOperator={false}
@@ -189,6 +194,9 @@ describe('pages', () => {
                     }}
                     additional={false}
                     backHref="/product/productDetails?id=99"
+                    selectedYesToExempt={false}
+                    exemptStops=""
+                    isEditMode
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -198,13 +206,9 @@ describe('pages', () => {
             it('should return expected props to the page when the page is first visited by the user', async () => {
                 const ctx = getMockContext({ session: { [SERVICE_LIST_ATTRIBUTE]: null } });
                 const result = await getServerSideProps(ctx);
-                const expectedCheckedServiceList: ServicesInfo[] = mockServices.map((mockService) => ({
-                    ...mockService,
-                    checked: false,
-                }));
+
                 expect(result.props.errors.length).toBe(0);
-                expect(result.props.serviceList).toEqual(expectedCheckedServiceList);
-                expect(result.props.buttonText).toEqual('Select All Services');
+                expect(result.props.serviceList).toEqual(mockServices);
             });
 
             it('should return expected props to the page when the page when multi modal attribute is present', async () => {
@@ -213,6 +217,7 @@ describe('pages', () => {
                         [MULTI_MODAL_ATTRIBUTE]: {
                             modes: ['ferry', 'tram', 'coach'],
                         },
+                        [SERVICE_LIST_ATTRIBUTE]: undefined,
                     },
                 });
                 (getAllServicesByNocCode as jest.Mock).mockImplementation(() => []);
@@ -221,11 +226,9 @@ describe('pages', () => {
                 const result = await getServerSideProps(ctx);
                 const expectedCheckedServiceList: ServicesInfo[] = mockServices.map((mockService) => ({
                     ...mockService,
-                    checked: false,
                 }));
 
                 expect(result.props.serviceList).toEqual(expectedCheckedServiceList);
-                expect(result.props.buttonText).toEqual('Select All Services');
             });
 
             it('should return props containing errors when the user has previously selected no checkboxes', async () => {
@@ -237,13 +240,9 @@ describe('pages', () => {
                     },
                 });
                 const result = await getServerSideProps(ctx);
-                const expectedCheckedServiceList: ServicesInfo[] = mockServices.map((mockService) => ({
-                    ...mockService,
-                    checked: false,
-                }));
+
                 expect(result.props.errors).toEqual(mockError);
-                expect(result.props.serviceList).toEqual(expectedCheckedServiceList);
-                expect(result.props.buttonText).toEqual('Select All Services');
+                expect(result.props.serviceList).toEqual(mockServices);
             });
 
             it('should throw an error if noc invalid', async () => {

--- a/repos/fdbt-site/tests/pages/ticketConfirmation.test.tsx
+++ b/repos/fdbt-site/tests/pages/ticketConfirmation.test.tsx
@@ -305,7 +305,7 @@ describe('pages', () => {
                 });
                 const confirmationElements = buildPeriodOrMultiOpTicketConfirmationElements(ctx);
                 expect(confirmationElements).toContainEqual(confirmationElementStructure);
-                expect(confirmationElements).toHaveLength(6);
+                expect(confirmationElements).toHaveLength(7);
             });
 
             it('should build confirmation elements for a period hybrid ticket with a single product', () => {
@@ -326,7 +326,7 @@ describe('pages', () => {
                 });
                 const confirmationElements = buildPeriodOrMultiOpTicketConfirmationElements(ctx);
                 expect(confirmationElements).toContainEqual(confirmationElementStructure);
-                expect(confirmationElements).toHaveLength(8);
+                expect(confirmationElements).toHaveLength(9);
             });
 
             it('should build confirmation elements for a multi operator multiService ticket with multiple products', () => {
@@ -351,7 +351,7 @@ describe('pages', () => {
                 const numberOfElementsDueToProducts = ctx.req.session[MULTIPLE_PRODUCT_ATTRIBUTE].products.length;
                 const numberOfElementsDueToAdditionalOperators = mockAdditionalOperators.length;
                 const totalExpectedLength =
-                    4 + numberOfElementsDueToProducts + numberOfElementsDueToAdditionalOperators;
+                    5 + numberOfElementsDueToProducts + numberOfElementsDueToAdditionalOperators;
                 const confirmationElements = buildPeriodOrMultiOpTicketConfirmationElements(ctx);
                 expect(confirmationElements).toContainEqual(confirmationElementStructure);
                 expect(confirmationElements).toHaveLength(totalExpectedLength);
@@ -378,7 +378,7 @@ describe('pages', () => {
                         },
                     },
                 });
-                const totalExpectedLength = 3;
+                const totalExpectedLength = 4;
                 const confirmationElements = buildFlatFareTicketConfirmationElements(ctx);
                 expect(confirmationElements).toContainEqual(confirmationElementStructure);
                 expect(confirmationElements).toHaveLength(totalExpectedLength);


### PR DESCRIPTION
## Description

Users can upload csv's of exempt stops when they create multi service tickets. Also made some minor changes like updating select all services button to use state etc.

## Testing instructions

Create a multi service ticket and use page extensively, trying different error states etc. Editing exempt stops also.
