### PR TITLE
fix: Fixed defaulting of the exempt stops radio buttons

### DIFF
--- a/repos/fdbt-site/src/pages/serviceList.tsx
+++ b/repos/fdbt-site/src/pages/serviceList.tsx
@@ -91,7 +91,7 @@ const ServiceList = ({
 
     const multiOperatorText = multiOperator ? 'of your ' : '';
 
-    const defaultCheckedYes = !userWantsToEditExemptStops || selectedYesToExempt || !!exemptStops;
+    const defaultCheckedYes = (!userWantsToEditExemptStops && isEditMode) || selectedYesToExempt || !!exemptStops;
     const defaultCheckedNo = !defaultCheckedYes;
 
     return (

--- a/repos/fdbt-site/tests/pages/__snapshots__/serviceList.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/serviceList.test.tsx.snap
@@ -134,7 +134,7 @@ exports[`pages serviceList should render an error when the error flag is set to 
                 <input
                   className="govuk-radios__input"
                   data-aria-controls="conditional-yes"
-                  defaultChecked={true}
+                  defaultChecked={false}
                   id="yes"
                   name="exempt"
                   type="radio"
@@ -230,7 +230,7 @@ exports[`pages serviceList should render an error when the error flag is set to 
               >
                 <input
                   className="govuk-radios__input"
-                  defaultChecked={false}
+                  defaultChecked={true}
                   id="no"
                   name="exempt"
                   type="radio"
@@ -409,7 +409,7 @@ exports[`pages serviceList should render correctly for multiOperator 1`] = `
                 <input
                   className="govuk-radios__input"
                   data-aria-controls="conditional-yes"
-                  defaultChecked={true}
+                  defaultChecked={false}
                   id="yes"
                   name="exempt"
                   type="radio"
@@ -505,7 +505,7 @@ exports[`pages serviceList should render correctly for multiOperator 1`] = `
               >
                 <input
                   className="govuk-radios__input"
-                  defaultChecked={false}
+                  defaultChecked={true}
                   id="no"
                   name="exempt"
                   type="radio"
@@ -1018,7 +1018,7 @@ exports[`pages serviceList should render correctly with bods data source 1`] = `
                 <input
                   className="govuk-radios__input"
                   data-aria-controls="conditional-yes"
-                  defaultChecked={true}
+                  defaultChecked={false}
                   id="yes"
                   name="exempt"
                   type="radio"
@@ -1114,7 +1114,7 @@ exports[`pages serviceList should render correctly with bods data source 1`] = `
               >
                 <input
                   className="govuk-radios__input"
-                  defaultChecked={false}
+                  defaultChecked={true}
                   id="no"
                   name="exempt"
                   type="radio"


### PR DESCRIPTION
## Description

Exempt stops was defaulting to yes instead of no.

## Testing instructions

Ensure the radio button defaults to no instead of yes.
