### PR TITLE
chore: Reverted ubunto image version to 18.04

### DIFF
--- a/.github/workflows/fdbt-netex-output_test_deployment.yml
+++ b/.github/workflows/fdbt-netex-output_test_deployment.yml
@@ -16,7 +16,7 @@ jobs:
 
   fdbt-netex-output_deploy_to_test:
     name: 'fdbt-netex-output_test'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     env:
       WORKSPACE: test
     environment:


### PR DESCRIPTION
## Description

Reverting back to 18.04 as 20.04 isnt working yet.

## Testing instructions

Run an export on test once deployed.
