### PR TITLE
fix: Not showing the export button after the select export

### DIFF
--- a/repos/fdbt-site/src/constants/attributes.ts
+++ b/repos/fdbt-site/src/constants/attributes.ts
@@ -165,3 +165,5 @@ export const SERVICE_LIST_EXEMPTION_ATTRIBUTE = 'fdbt-exemption-services';
 export const CAPS_DEFINITION_ATTRIBUTE = 'fdbt-caps-definition-attribute';
 
 export const STOPS_EXEMPTION_ATTRIBUTE = 'fdbt-exemption-stops';
+
+export const SELECT_EXPORTS_ATTRIBUTE = 'fdbt-select-exports';

--- a/repos/fdbt-site/src/pages/api/getExportProgress.ts
+++ b/repos/fdbt-site/src/pages/api/getExportProgress.ts
@@ -1,5 +1,5 @@
 import { NextApiResponse } from 'next';
-import { dateIsOverThirtyMinutesAgo, getAndValidateNoc, redirectToError } from '../../utils/apiUtils';
+import { dateIsOverThirtyMinutesAgo, exportHasStarted, getAndValidateNoc, redirectToError } from '../../utils/apiUtils';
 import { NextApiRequestWithSession } from '../../interfaces';
 import {
     checkIfMetaDataExists,
@@ -30,9 +30,8 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
 
         const exportNames = await getS3Exports(noc);
         const selectExportAttribute = getSessionAttribute(req, SELECT_EXPORTS_ATTRIBUTE);
-        const currTime = new Date().getTime() / 1000;
 
-        if (!!selectExportAttribute && currTime - Number(selectExportAttribute.exportStarted) > 5) {
+        if (!!selectExportAttribute && exportHasStarted(selectExportAttribute.exportStarted)) {
             updateSessionAttribute(req, SELECT_EXPORTS_ATTRIBUTE, undefined);
         }
 

--- a/repos/fdbt-site/src/pages/api/selectExports.ts
+++ b/repos/fdbt-site/src/pages/api/selectExports.ts
@@ -43,7 +43,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
 
     await triggerExport({ noc, paths: links, exportPrefix: exportName });
     const currTime = new Date().getTime() / 1000;
-    updateSessionAttribute(req, SELECT_EXPORTS_ATTRIBUTE, { exportStarted: currTime.toString() });
+    updateSessionAttribute(req, SELECT_EXPORTS_ATTRIBUTE, { exportStarted: currTime });
     redirectTo(res, '/products/exports');
     return;
 };

--- a/repos/fdbt-site/src/pages/api/selectExports.ts
+++ b/repos/fdbt-site/src/pages/api/selectExports.ts
@@ -44,6 +44,6 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
     await triggerExport({ noc, paths: links, exportPrefix: exportName });
     const currTime = new Date().getTime() / 1000;
     updateSessionAttribute(req, SELECT_EXPORTS_ATTRIBUTE, { exportStarted: currTime.toString() });
-    redirectTo(res, '/products/exports?exportStarted=true');
+    redirectTo(res, '/products/exports');
     return;
 };

--- a/repos/fdbt-site/src/pages/api/selectExports.ts
+++ b/repos/fdbt-site/src/pages/api/selectExports.ts
@@ -41,6 +41,6 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
 
     await triggerExport({ noc, paths: links, exportPrefix: exportName });
 
-    redirectTo(res, '/products/exports');
+    redirectTo(res, '/products/exports?exportStarted=true');
     return;
 };

--- a/repos/fdbt-site/src/pages/api/selectExports.ts
+++ b/repos/fdbt-site/src/pages/api/selectExports.ts
@@ -4,6 +4,8 @@ import { NextApiRequestWithSession } from '../../interfaces';
 import { getS3Exports } from '../../data/s3';
 import { getProductById } from '../../data/auroradb';
 import { triggerExport } from '../../utils/apiUtils/export';
+import { updateSessionAttribute } from '../../utils/sessions';
+import { SELECT_EXPORTS_ATTRIBUTE } from '../../constants/attributes';
 
 export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
     const noc = getAndValidateNoc(req, res);
@@ -40,7 +42,8 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
     const links = products.map((product) => product.matchingJsonLink);
 
     await triggerExport({ noc, paths: links, exportPrefix: exportName });
-
+    const currTime = new Date().getTime() / 1000;
+    updateSessionAttribute(req, SELECT_EXPORTS_ATTRIBUTE, { exportStarted: currTime.toString() });
     redirectTo(res, '/products/exports?exportStarted=true');
     return;
 };

--- a/repos/fdbt-site/src/pages/products/exports.tsx
+++ b/repos/fdbt-site/src/pages/products/exports.tsx
@@ -57,11 +57,13 @@ const Exports = ({ csrf, exportStarted, operatorHasProducts }: GlobalSettingsPro
     const [showExportPopup, setShowExportPopup] = useState(false);
     const [showFailedFilesPopup, setShowFailedFilesPopup] = useState(false);
     const [buttonClicked, setButtonClicked] = useState(false);
-    const [isExportStarted, setIsExportStarted] = useState(exportStarted);
+    const [hasExportStarted, setHasExportStarted] = useState(exportStarted);
 
     const { data } = useSWR('/api/getExportProgress', fetcher, { refreshInterval: 1500 });
 
-    setInterval(() => setIsExportStarted(false), 1000 * 1500);
+    if (hasExportStarted) {
+        setInterval(() => setHasExportStarted(false), 1000 * 1500);
+    }
 
     const exports: Export[] | undefined = data?.exports;
 
@@ -71,7 +73,7 @@ const Exports = ({ csrf, exportStarted, operatorHasProducts }: GlobalSettingsPro
 
     const anExportIsInProgress = !!exportInProgress;
     const exportAllowed: boolean =
-        operatorHasProducts && !anExportIsInProgress && !!exports && !buttonClicked && !isExportStarted;
+        operatorHasProducts && !anExportIsInProgress && !!exports && !buttonClicked && !hasExportStarted;
     const showCancelButton: boolean = anExportIsInProgress && !!exportInProgress?.exportFailed;
     const failedExport: Export | undefined =
         anExportIsInProgress && exportInProgress?.exportFailed ? exportInProgress : undefined;
@@ -227,7 +229,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     const noc = getAndValidateNoc(ctx);
 
     const operatorHasProducts = (await getAllProductsByNoc(noc)).length > 0;
-    const exportStarted = ctx.query.exportStarted && ctx.query.exportStarted === 'true' ? true : false;
+    const exportStarted = !!ctx.query.exportStarted && ctx.query.exportStarted === 'true' ? true : false;
 
     return {
         props: {

--- a/repos/fdbt-site/src/pages/products/exports.tsx
+++ b/repos/fdbt-site/src/pages/products/exports.tsx
@@ -10,6 +10,7 @@ import { Export } from '../api/getExportProgress';
 import InfoPopup from '../../components/InfoPopup';
 import { getSessionAttribute, updateSessionAttribute } from '../../utils/sessions';
 import { SELECT_EXPORTS_ATTRIBUTE } from '../../constants/attributes';
+import { exportHasStarted } from '../../utils/apiUtils';
 
 const title = 'Exports';
 const description = 'Export your products into NeTEx.';
@@ -227,11 +228,10 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
 
     const operatorHasProducts = (await getAllProductsByNoc(noc)).length > 0;
     const selectExportAttribute = getSessionAttribute(ctx.req, SELECT_EXPORTS_ATTRIBUTE);
-    const currTime = new Date().getTime() / 1000;
 
-    const exportStarted = !!selectExportAttribute && currTime - Number(selectExportAttribute.exportStarted) > 5;
+    const exportStarted = !!selectExportAttribute && exportHasStarted(selectExportAttribute.exportStarted);
 
-    if (!!selectExportAttribute && currTime - Number(selectExportAttribute.exportStarted) > 5) {
+    if (exportStarted) {
         updateSessionAttribute(ctx.req, SELECT_EXPORTS_ATTRIBUTE, undefined);
     }
 

--- a/repos/fdbt-site/src/utils/apiUtils/index.ts
+++ b/repos/fdbt-site/src/utils/apiUtils/index.ts
@@ -270,3 +270,9 @@ export const dateIsOverThirtyMinutesAgo = (inputDate: Date): boolean => {
 export const isADayOfTheWeek = (input: string | undefined): boolean => {
     return !!input && daysOfWeek.includes(input);
 };
+
+export const exportHasStarted = (exportStarted: number): boolean => {
+    const currTime = new Date().getTime() / 1000;
+
+    return currTime - exportStarted > 5;
+};

--- a/repos/fdbt-site/src/utils/sessions.ts
+++ b/repos/fdbt-site/src/utils/sessions.ts
@@ -80,6 +80,7 @@ import {
     CAPS_DEFINITION_ATTRIBUTE,
     STOPS_EXEMPTION_ATTRIBUTE,
     VIEW_CAP_ERRORS,
+    SELECT_EXPORTS_ATTRIBUTE,
 } from '../constants/attributes';
 import {
     CsvUploadAttributeWithErrors,
@@ -251,6 +252,7 @@ export interface SessionAttributeTypes {
     [CAPS_DEFINITION_ATTRIBUTE]: CapSelection | { errors: ErrorInfo[] };
     [SERVICE_LIST_EXEMPTION_ATTRIBUTE]: ServiceListAttribute | { errors: ErrorInfo[] };
     [STOPS_EXEMPTION_ATTRIBUTE]: ExemptedStopsAttribute | { errors: ErrorInfo[] };
+    [SELECT_EXPORTS_ATTRIBUTE]: { exportStarted: string };
 }
 
 export type SessionAttribute<T extends string> = T extends keyof SessionAttributeTypes

--- a/repos/fdbt-site/src/utils/sessions.ts
+++ b/repos/fdbt-site/src/utils/sessions.ts
@@ -252,7 +252,7 @@ export interface SessionAttributeTypes {
     [CAPS_DEFINITION_ATTRIBUTE]: CapSelection | { errors: ErrorInfo[] };
     [SERVICE_LIST_EXEMPTION_ATTRIBUTE]: ServiceListAttribute | { errors: ErrorInfo[] };
     [STOPS_EXEMPTION_ATTRIBUTE]: ExemptedStopsAttribute | { errors: ErrorInfo[] };
-    [SELECT_EXPORTS_ATTRIBUTE]: { exportStarted: string };
+    [SELECT_EXPORTS_ATTRIBUTE]: { exportStarted: number };
 }
 
 export type SessionAttribute<T extends string> = T extends keyof SessionAttributeTypes

--- a/repos/fdbt-site/tests/pages/api/selectExports.test.ts
+++ b/repos/fdbt-site/tests/pages/api/selectExports.test.ts
@@ -72,7 +72,7 @@ describe('fareType', () => {
         });
 
         expect(res.writeHead).toBeCalledWith(302, {
-            Location: '/products/exports?exportStarted=true',
+            Location: '/products/exports',
         });
     });
 
@@ -92,7 +92,7 @@ describe('fareType', () => {
         });
 
         expect(res.writeHead).toBeCalledWith(302, {
-            Location: '/products/exports?exportStarted=true',
+            Location: '/products/exports',
         });
     });
 });

--- a/repos/fdbt-site/tests/pages/api/selectExports.test.ts
+++ b/repos/fdbt-site/tests/pages/api/selectExports.test.ts
@@ -72,7 +72,7 @@ describe('fareType', () => {
         });
 
         expect(res.writeHead).toBeCalledWith(302, {
-            Location: '/products/exports',
+            Location: '/products/exports?exportStarted=true',
         });
     });
 
@@ -92,7 +92,7 @@ describe('fareType', () => {
         });
 
         expect(res.writeHead).toBeCalledWith(302, {
-            Location: '/products/exports',
+            Location: '/products/exports?exportStarted=true',
         });
     });
 });

--- a/repos/fdbt-site/tests/pages/products/exports.test.tsx
+++ b/repos/fdbt-site/tests/pages/products/exports.test.tsx
@@ -5,12 +5,12 @@ import Exports from '../../../src/pages/products/exports';
 describe('pages', () => {
     describe('exports', () => {
         it('should render correctly without data when operator has no products', () => {
-            const tree = shallow(<Exports csrf={''} operatorHasProducts={false} />);
+            const tree = shallow(<Exports csrf={''} operatorHasProducts={false} exportStarted />);
             expect(tree).toMatchSnapshot();
         });
 
         it('should render the export button correctly when operator has products', () => {
-            const tree = shallow(<Exports csrf={''} operatorHasProducts={true} />);
+            const tree = shallow(<Exports csrf={''} operatorHasProducts={true} exportStarted />);
             expect(tree).toMatchSnapshot();
         });
     });

--- a/repos/fdbt-site/tests/utils/index.test.ts
+++ b/repos/fdbt-site/tests/utils/index.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../../src/utils';
 import { getMockContext, mockSchemOpIdToken } from '../testData/mockData';
 import { OPERATOR_ATTRIBUTE } from '../../src/constants/attributes';
-import { dateIsOverThirtyMinutesAgo, isADayOfTheWeek } from '../../src/utils/apiUtils';
+import { dateIsOverThirtyMinutesAgo, isADayOfTheWeek, exportHasStarted } from '../../src/utils/apiUtils';
 import { Stop } from '../../src/interfaces/matchingJsonTypes';
 import { MyFaresService, ServiceType } from '../../src/interfaces';
 
@@ -382,6 +382,20 @@ describe('index', () => {
                     endDate: '16/9/2021',
                 },
             ]);
+        });
+    });
+
+    describe('exportHasStarted', () => {
+        it('returns true if current time is more than 5 seconds', () => {
+            const exportStarted = new Date().getTime() / 1000 - 6;
+            const result = exportHasStarted(exportStarted);
+            expect(result).toBeTruthy();
+        });
+
+        it('returns false if the current time is less than 5 seconds', () => {
+            const exportStarted = new Date().getTime() / 1000 - 2;
+            const result = exportHasStarted(exportStarted);
+            expect(result).toBeFalsy();
         });
     });
 });


### PR DESCRIPTION
## Description

Users should be unable to see the export button just after selecting the products to export

## Testing instructions

Click on few products to export and just after that, click on the Export all products. Now, the export all products button will not appear just after the select product export completed.
