### PR TITLE
fix: using an onSubmit to prevent double clicking

### DIFF
--- a/fdbt-dev/sql/txcOperatorLine.sql
+++ b/fdbt-dev/sql/txcOperatorLine.sql
@@ -3,7 +3,7 @@ LOCK TABLES `txcOperatorLine` WRITE;
 
 TRUNCATE TABLE `txcOperatorLine`;
 
-INSERT INTO `txcOperatorLine` (id,nocCode,lineName,lineId,startDate,serviceCode,operatorShortName,serviceDescription,regionCode,dataSource,origin,destination,inboundDirectionDescription,outboundDirectionDescription, mode) VALUES
+INSERT INTO `txcOperatorLine` (id,nocCode,lineName,lineId,startDate,serviceCode,operatorShortName,serviceDescription,regionCode,dataSource,origin,destination,inboundDirectionDescription,outboundDirectionDescription,mode) VALUES
 (9379,"BLAC","2C","vySmfewe0","2020-04-05","NW_05_BLAC_2C_1","Blackpool Transport","KNOTT END - POULTON - BLACKPOOL","NW","bods","Zhaishi Miaozu Dongzuxiang","Bimbaletes Aguascalientes (El Álamo)","Prievidza","Sălcioara","bus"),
 (9716,"BLAC","17","vySmf0","2020-04-05","NW_05_BLAC_17_1","Blackpool Transport","BLACKPOOL - ST ANNES - LYTHAM","NW","bods","Warcq","Carrión de los Céspedes","Kinel’","Canlaon","bus"),
 (9798,"BLAC","4","dPWnHm","2020-04-05","NW_05_BLAC_4_1","Blackpool Transport","CLEVELEYS - MERESIDE via Blackpool","NW","bods","Saint-Aubin-Routot","La Manzanilla de la Paz","Nättraby","Saccolongo","bus"),
@@ -298,6 +298,10 @@ INSERT INTO `txcOperatorLine` (id,nocCode,lineName,lineId,startDate,serviceCode,
 (11560,"WBTR","48","q8TOE0","2020-04-13","NW_07_NW_48_2","Warrington''s Own Buses","Frodsham - Northwich","NW","bods","Melilla","Chandra","Alton","Massa","bus"),
 (11766,"WBTR","H20","zMR1aZ","2020-04-13","NW_07_NW_H20_2","Warrington''s Own Buses","Murdishaw - Murdishaw","NW","bods","Aschau im Zillertal","Genaro Estrada","Dărăști-Vlașca","Williamstown","bus"),
 (11871,"WBTR","H20A","U5oPWj","2020-04-13","NW_07_NW_H20A_2","Warrington''s Own Buses","Murdishaw - Murdishaw","NW","bods","Dukinfield","Trzebnica","Aydın","Paso Blanco","bus");
+
+-- ensuring every row has an end date
+
+UPDATE txcOperatorLine SET endDate = "2025-04-05";
 
 -- update a few rows to test end date logic for services
 

--- a/repos/fdbt-site/src/pages/products/selectExports.tsx
+++ b/repos/fdbt-site/src/pages/products/selectExports.tsx
@@ -123,11 +123,15 @@ const SelectExports = ({ productsToDisplay, servicesToDisplay, csrf }: SelectExp
     const otherProducts = productsToDisplay.filter((product) => !product.serviceLineId);
     const formattedProducts = formatOtherProducts(otherProducts);
 
+    const handleSubmit = () => {
+        setIsSubmitting(true);
+    };
+
     return (
         <>
             <BaseLayout title={title} description={description}>
                 <BackButton href="/products/exports" />
-                <CsrfForm csrfToken={csrf} method={'post'} action={'/api/selectExports'}>
+                <CsrfForm onSubmit={handleSubmit} csrfToken={csrf} method={'post'} action={'/api/selectExports'}>
                     <div className="govuk-grid-row">
                         <div className="govuk-grid-column-full">
                             <div className="dft-flex dft-flex-justify-space-between">
@@ -139,9 +143,6 @@ const SelectExports = ({ productsToDisplay, servicesToDisplay, csrf }: SelectExp
                                             productsToDisplay.length === 0 ? ' govuk-visually-hidden' : ''
                                         }`}
                                         disabled={isSubmitting}
-                                        onClick={() => {
-                                            setIsSubmitting(true);
-                                        }}
                                     >
                                         Export selected products
                                     </button>

--- a/repos/fdbt-site/src/pages/salesConfirmation.tsx
+++ b/repos/fdbt-site/src/pages/salesConfirmation.tsx
@@ -123,9 +123,14 @@ const SalesConfirmation = ({
     selectedCap,
 }: SalesConfirmationProps): ReactElement => {
     const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const handleSubmit = () => {
+        setIsSubmitting(true);
+    };
+
     return (
         <TwoThirdsLayout title={title} description={description} errors={[]}>
-            <CsrfForm action="/api/salesConfirmation" method="post" csrfToken={csrfToken}>
+            <CsrfForm onSubmit={handleSubmit} action="/api/salesConfirmation" method="post" csrfToken={csrfToken}>
                 <>
                     <h1 className="govuk-heading-l">Check your sales information answers before submitting</h1>
                     <ConfirmationTable
@@ -151,9 +156,6 @@ const SalesConfirmation = ({
                         id="continue-button"
                         className="govuk-button"
                         disabled={isSubmitting}
-                        onClick={() => {
-                            setIsSubmitting(true);
-                        }}
                     />
                 </>
             </CsrfForm>

--- a/repos/fdbt-site/tests/pages/__snapshots__/salesConfirmation.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/salesConfirmation.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`pages confirmation should render correctly 1`] = `
     action="/api/salesConfirmation"
     csrfToken=""
     method="post"
+    onSubmit={[Function]}
   >
     <h1
       className="govuk-heading-l"
@@ -52,7 +53,6 @@ exports[`pages confirmation should render correctly 1`] = `
       className="govuk-button"
       disabled={false}
       id="continue-button"
-      onClick={[Function]}
       type="submit"
       value="Accept and submit"
     />

--- a/repos/fdbt-site/tests/pages/products/__snapshots__/selectExports.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/products/__snapshots__/selectExports.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`selectExports renders appropriately when the user has no products 1`] =
       action="/api/selectExports"
       csrfToken=""
       method="post"
+      onSubmit={[Function]}
     >
       <div
         className="govuk-grid-row"
@@ -35,7 +36,6 @@ exports[`selectExports renders appropriately when the user has no products 1`] =
               <button
                 className="govuk-button govuk-visually-hidden"
                 disabled={false}
-                onClick={[Function]}
                 type="submit"
               >
                 Export selected products
@@ -94,6 +94,7 @@ exports[`selectExports renders fully when the user has products they can export 
       action="/api/selectExports"
       csrfToken=""
       method="post"
+      onSubmit={[Function]}
     >
       <div
         className="govuk-grid-row"
@@ -116,7 +117,6 @@ exports[`selectExports renders fully when the user has products they can export 
               <button
                 className="govuk-button"
                 disabled={false}
-                onClick={[Function]}
                 type="submit"
               >
                 Export selected products
@@ -517,6 +517,7 @@ exports[`selectExports renders fully when the user has products they can export,
       action="/api/selectExports"
       csrfToken=""
       method="post"
+      onSubmit={[Function]}
     >
       <div
         className="govuk-grid-row"
@@ -539,7 +540,6 @@ exports[`selectExports renders fully when the user has products they can export,
               <button
                 className="govuk-button"
                 disabled={false}
-                onClick={[Function]}
                 type="submit"
               >
                 Export selected products


### PR DESCRIPTION
## Description

Double clicking on form submission buttons caused products to be created twice, or exports to 'double up'. Using an onSubmit to make the button disabled, we can prevent this.

## Testing instructions

Attempt to double click the final button when creating a products, or the export all button on the /selectExports page.
