### PR TITLE
fix: Showing the services when end type is null

### DIFF
--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -11,7 +11,6 @@ import {
     MyFaresService,
     ServiceWithOriginAndDestination,
     Cap,
-    DbServiceType,
 } from '../interfaces';
 import logger from '../utils/logger';
 import { convertDateFormat } from '../utils';

--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -434,7 +434,7 @@ export const getAllServicesByNocCode = async (nocCode: string): Promise<ServiceT
 
     try {
         const queryInput = `
-            SELECT id, lineName, lineId, startDate, serviceDescription AS description, serviceCode, dataSource, mode
+            SELECT id, lineName, lineId, startDate, serviceDescription AS description, serviceCode, dataSource, mode, endDate
             FROM txcOperatorLine
             WHERE nocCode = ?
             ORDER BY CAST(lineName AS UNSIGNED) = 0, CAST(lineName AS UNSIGNED), LEFT(lineName, 1), MID(lineName, 2), startDate;
@@ -446,6 +446,7 @@ export const getAllServicesByNocCode = async (nocCode: string): Promise<ServiceT
             queryResults.map((item) => ({
                 ...item,
                 startDate: convertDateFormat(item.startDate),
+                endDate: item.endDate ? convertDateFormat(item.endDate) : null,
             })) || []
         );
     } catch (error) {

--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -11,6 +11,7 @@ import {
     MyFaresService,
     ServiceWithOriginAndDestination,
     Cap,
+    DbServiceType,
 } from '../interfaces';
 import logger from '../utils/logger';
 import { convertDateFormat } from '../utils';
@@ -156,7 +157,7 @@ export const getServicesByNocCodeAndDataSource = async (nocCode: string, source:
             queryResults.map((item) => ({
                 ...item,
                 startDate: convertDateFormat(item.startDate),
-                endDate: item.endDate ? convertDateFormat(item.endDate) : undefined,
+                endDate: item.endDate ? convertDateFormat(item.endDate) : null,
             })) || []
         );
     } catch (error) {

--- a/repos/fdbt-site/src/interfaces/index.ts
+++ b/repos/fdbt-site/src/interfaces/index.ts
@@ -597,8 +597,9 @@ export interface ServiceType {
     serviceCode: string;
     dataSource?: string;
     mode?: string;
-    endDate?: string;
+    endDate?: string | null;
 }
+
 export interface ServiceCount {
     serviceCount: number;
 }

--- a/repos/fdbt-site/src/interfaces/index.ts
+++ b/repos/fdbt-site/src/interfaces/index.ts
@@ -597,7 +597,7 @@ export interface ServiceType {
     serviceCode: string;
     dataSource?: string;
     mode?: string;
-    endDate?: string | null;
+    endDate: string | null;
 }
 
 export interface ServiceCount {

--- a/repos/fdbt-site/tests/pages/api/fareType.test.ts
+++ b/repos/fdbt-site/tests/pages/api/fareType.test.ts
@@ -17,6 +17,7 @@ const services = [
         origin: 'Manchester',
         destination: 'Leeds',
         dataSource: 'tnds',
+        endDate: null,
     },
     {
         id: 12,
@@ -28,6 +29,7 @@ const services = [
         origin: 'Bolton',
         destination: 'Wigan',
         dataSource: 'bods',
+        endDate: null,
     },
     {
         id: 13,
@@ -39,6 +41,7 @@ const services = [
         origin: 'Manchester',
         destination: 'York',
         dataSource: 'tnds',
+        endDate: null,
     },
 ];
 

--- a/repos/fdbt-site/tests/pages/api/fareType.test.ts
+++ b/repos/fdbt-site/tests/pages/api/fareType.test.ts
@@ -29,7 +29,7 @@ const services = [
         origin: 'Bolton',
         destination: 'Wigan',
         dataSource: 'bods',
-        endDate: null,
+        endDate: '26/02/2020',
     },
     {
         id: 13,

--- a/repos/fdbt-site/tests/pages/api/register.test.ts
+++ b/repos/fdbt-site/tests/pages/api/register.test.ts
@@ -42,6 +42,7 @@ describe('register', () => {
                     startDate: '01012020',
                     description: 'linename for service ',
                     serviceCode: 'NW_05_BLAC_2C_1',
+                    endDate: null,
                 },
             ]),
         );
@@ -332,6 +333,7 @@ describe('nocsWithNoServices', () => {
                         startDate: '01012020',
                         description: 'linename for service ',
                         serviceCode: 'NW_05_BLAC_2C_1',
+                        endDate: null,
                     },
                 ]),
             )
@@ -352,6 +354,7 @@ describe('nocsWithNoServices', () => {
                         startDate: '01012020',
                         description: 'linename for service ',
                         serviceCode: 'NW_05_BLAC_2C_1',
+                        endDate: null,
                     },
                 ]),
             )
@@ -364,6 +367,7 @@ describe('nocsWithNoServices', () => {
                         startDate: '03012020',
                         description: 'another linename for service ',
                         serviceCode: 'NW_05_BLAC_2C_1',
+                        endDate: null,
                     },
                 ]),
             );

--- a/repos/fdbt-site/tests/pages/csvZoneUpload.test.tsx
+++ b/repos/fdbt-site/tests/pages/csvZoneUpload.test.tsx
@@ -16,6 +16,7 @@ describe('pages', () => {
                 destination: 'Leeds',
                 serviceCode: 'NW_05_BLAC_123_1',
                 checked: false,
+                endDate: null,
             },
             {
                 id: 12,
@@ -26,6 +27,7 @@ describe('pages', () => {
                 origin: 'Edinburgh',
                 serviceCode: 'NW_05_BLAC_X1_1',
                 checked: false,
+                endDate: null,
             },
             {
                 id: 13,
@@ -36,6 +38,7 @@ describe('pages', () => {
                 destination: 'London',
                 serviceCode: 'WY_13_IWBT_07_1',
                 checked: false,
+                endDate: null,
             },
         ];
         it('should render correctly', () => {

--- a/repos/fdbt-site/tests/pages/home.test.tsx
+++ b/repos/fdbt-site/tests/pages/home.test.tsx
@@ -18,6 +18,7 @@ const multiModalServices = [
         destination: 'Leeds',
         dataSource: 'tnds',
         mode: 'ferry',
+        endDate: null,
     },
     {
         id: 12,
@@ -30,6 +31,7 @@ const multiModalServices = [
         destination: 'Wigan',
         dataSource: 'tnds',
         mode: 'coach',
+        endDate: null,
     },
     {
         id: 13,
@@ -42,6 +44,7 @@ const multiModalServices = [
         destination: 'York',
         dataSource: 'tnds',
         mode: 'tram',
+        endDate: null,
     },
 ];
 
@@ -93,6 +96,7 @@ describe('pages', () => {
                     destination: 'Leeds',
                     dataSource: 'bods',
                     mode: 'ferry',
+                    endDate: null,
                 },
             ];
             const operatorData: OperatorAttribute = {
@@ -128,6 +132,7 @@ describe('pages', () => {
                     destination: 'Leeds',
                     dataSource: 'bods',
                     mode: 'ferry',
+                    endDate: null,
                 },
                 {
                     id: 12,
@@ -140,6 +145,7 @@ describe('pages', () => {
                     destination: 'Wigan',
                     dataSource: 'tnds',
                     mode: 'coach',
+                    endDate: null,
                 },
             ];
             const operatorData: OperatorAttribute = {

--- a/repos/fdbt-site/tests/pages/home.test.tsx
+++ b/repos/fdbt-site/tests/pages/home.test.tsx
@@ -96,7 +96,7 @@ describe('pages', () => {
                     destination: 'Leeds',
                     dataSource: 'bods',
                     mode: 'ferry',
-                    endDate: null,
+                    endDate: '15/02/2020',
                 },
             ];
             const operatorData: OperatorAttribute = {
@@ -132,7 +132,7 @@ describe('pages', () => {
                     destination: 'Leeds',
                     dataSource: 'bods',
                     mode: 'ferry',
-                    endDate: null,
+                    endDate: '25/02/2020',
                 },
                 {
                     id: 12,

--- a/repos/fdbt-site/tests/pages/returnService.test.tsx
+++ b/repos/fdbt-site/tests/pages/returnService.test.tsx
@@ -23,6 +23,7 @@ const mockServices: ServiceType[] = [
         origin: 'Manchester',
         destination: 'Leeds',
         serviceCode: 'NW_05_BLAC_123_1',
+        endDate: null,
     },
     {
         id: 12,
@@ -32,6 +33,7 @@ const mockServices: ServiceType[] = [
         description: 'this bus service is X1',
         origin: 'Edinburgh',
         serviceCode: 'NW_05_BLAC_X1_1',
+        endDate: null,
     },
     {
         id: 13,
@@ -41,6 +43,7 @@ const mockServices: ServiceType[] = [
         description: 'this bus service is Infinity Line',
         destination: 'London',
         serviceCode: 'WY_13_IWBT_07_1',
+        endDate: null,
     },
 ];
 
@@ -158,6 +161,7 @@ describe('pages', () => {
                             origin: 'Manchester',
                             destination: 'Leeds',
                             serviceCode: 'NW_05_BLAC_123_1',
+                            endDate: null,
                         },
                         {
                             id: 12,
@@ -167,6 +171,7 @@ describe('pages', () => {
                             description: 'this bus service is X1',
                             origin: 'Edinburgh',
                             serviceCode: 'NW_05_BLAC_X1_1',
+                            endDate: null,
                         },
                         {
                             id: 13,
@@ -176,6 +181,7 @@ describe('pages', () => {
                             description: 'this bus service is Infinity Line',
                             destination: 'London',
                             serviceCode: 'WY_13_IWBT_07_1',
+                            endDate: null,
                         },
                     ],
                     csrfToken: '',
@@ -222,6 +228,7 @@ describe('pages', () => {
                             origin: 'Manchester',
                             destination: 'Leeds',
                             serviceCode: 'NW_05_BLAC_123_1',
+                            endDate: null,
                         },
                         {
                             id: 12,
@@ -231,6 +238,7 @@ describe('pages', () => {
                             description: 'this bus service is X1',
                             origin: 'Edinburgh',
                             serviceCode: 'NW_05_BLAC_X1_1',
+                            endDate: null,
                         },
                         {
                             id: 13,
@@ -240,6 +248,7 @@ describe('pages', () => {
                             description: 'this bus service is Infinity Line',
                             destination: 'London',
                             serviceCode: 'WY_13_IWBT_07_1',
+                            endDate: null,
                         },
                     ],
                     csrfToken: '',

--- a/repos/fdbt-site/tests/pages/service.test.tsx
+++ b/repos/fdbt-site/tests/pages/service.test.tsx
@@ -23,6 +23,7 @@ const mockServices: ServiceType[] = [
         origin: 'Manchester',
         destination: 'Leeds',
         serviceCode: 'NW_05_BLAC_123_1',
+        endDate: null,
     },
     {
         id: 12,
@@ -32,6 +33,7 @@ const mockServices: ServiceType[] = [
         description: 'this bus service is X1',
         origin: 'Edinburgh',
         serviceCode: 'NW_05_BLAC_X1_1',
+        endDate: null,
     },
     {
         id: 13,
@@ -41,6 +43,7 @@ const mockServices: ServiceType[] = [
         description: 'this bus service is Infinity Line',
         destination: 'London',
         serviceCode: 'WY_13_IWBT_07_1',
+        endDate: null,
     },
 ];
 
@@ -183,6 +186,7 @@ describe('pages', () => {
                             origin: 'Manchester',
                             destination: 'Leeds',
                             serviceCode: 'NW_05_BLAC_123_1',
+                            endDate: null,
                         },
                         {
                             id: 12,
@@ -192,6 +196,7 @@ describe('pages', () => {
                             description: 'this bus service is X1',
                             origin: 'Edinburgh',
                             serviceCode: 'NW_05_BLAC_X1_1',
+                            endDate: null,
                         },
                         {
                             id: 13,
@@ -201,6 +206,7 @@ describe('pages', () => {
                             description: 'this bus service is Infinity Line',
                             destination: 'London',
                             serviceCode: 'WY_13_IWBT_07_1',
+                            endDate: null,
                         },
                     ],
                     dataSourceAttribute: {
@@ -239,6 +245,7 @@ describe('pages', () => {
                             origin: 'Manchester',
                             destination: 'Leeds',
                             serviceCode: 'NW_05_BLAC_123_1',
+                            endDate: null,
                         },
                         {
                             id: 12,
@@ -248,6 +255,7 @@ describe('pages', () => {
                             description: 'this bus service is X1',
                             origin: 'Edinburgh',
                             serviceCode: 'NW_05_BLAC_X1_1',
+                            endDate: null,
                         },
                         {
                             id: 13,
@@ -257,6 +265,7 @@ describe('pages', () => {
                             description: 'this bus service is Infinity Line',
                             destination: 'London',
                             serviceCode: 'WY_13_IWBT_07_1',
+                            endDate: null,
                         },
                     ],
                     dataSourceAttribute: {

--- a/repos/fdbt-site/tests/pages/serviceList.test.tsx
+++ b/repos/fdbt-site/tests/pages/serviceList.test.tsx
@@ -25,6 +25,7 @@ describe('pages', () => {
                 destination: 'Leeds',
                 serviceCode: 'NW_05_BLAC_123_1',
                 checked: false,
+                endDate: null,
             },
             {
                 id: 12,
@@ -35,6 +36,7 @@ describe('pages', () => {
                 origin: 'Edinburgh',
                 serviceCode: 'NW_05_BLAC_X1_1',
                 checked: false,
+                endDate: null,
             },
             {
                 id: 13,
@@ -45,6 +47,7 @@ describe('pages', () => {
                 destination: 'London',
                 serviceCode: 'WY_13_IWBT_07_1',
                 checked: false,
+                endDate: null,
             },
         ];
 
@@ -66,6 +69,7 @@ describe('pages', () => {
                 destination: 'Leeds',
                 serviceCode: 'NW_05_BLAC_123_1',
                 dataSource: 'tnds',
+                endDate: null,
             },
             {
                 id: 12,
@@ -76,6 +80,7 @@ describe('pages', () => {
                 origin: 'Edinburgh',
                 serviceCode: 'NW_05_BLAC_X1_1',
                 dataSource: 'tnds',
+                endDate: null,
             },
             {
                 id: 13,
@@ -86,6 +91,7 @@ describe('pages', () => {
                 destination: 'London',
                 serviceCode: 'WY_13_IWBT_07_1',
                 dataSource: 'tnds',
+                endDate: null,
             },
         ];
 

--- a/repos/fdbt-site/tests/utils/index.test.ts
+++ b/repos/fdbt-site/tests/utils/index.test.ts
@@ -279,7 +279,7 @@ describe('index', () => {
                 origin: 'Manchester',
                 destination: 'Leeds',
                 serviceCode: 'NW_05_BLAC_123_1',
-                endDate: undefined,
+                endDate: null,
             },
             {
                 id: 12,
@@ -289,7 +289,7 @@ describe('index', () => {
                 description: 'this bus service is X1',
                 origin: 'Edinburgh',
                 serviceCode: 'NW_05_BLAC_X1_1',
-                endDate: undefined,
+                endDate: null,
             },
             {
                 id: 13,
@@ -299,7 +299,7 @@ describe('index', () => {
                 description: 'this bus service is of X1',
                 origin: 'Edinburgh',
                 serviceCode: 'NW_05_BLAC_X1_1',
-                endDate: undefined,
+                endDate: null,
             },
         ];
 
@@ -346,6 +346,7 @@ describe('index', () => {
                     origin: 'Manchester',
                     destination: 'Leeds',
                     serviceCode: 'NW_05_BLAC_123_1',
+                    endDate: null,
                 },
                 {
                     id: 12,
@@ -355,6 +356,7 @@ describe('index', () => {
                     description: 'this bus service is X1',
                     origin: 'Edinburgh',
                     serviceCode: 'NW_05_BLAC_X1_1',
+                    endDate: null,
                 },
             ]);
         });


### PR DESCRIPTION
## Description

Display the services for operator having source of data as tnds and the end date as null

## Testing instructions

Find the ferry operator with the service whose end date is not populated in db.

