### PR TITLE
fix: stopping users firing 2 exports at once

### DIFF
--- a/.github/workflows/fdbt-site_test_deployment.yml
+++ b/.github/workflows/fdbt-site_test_deployment.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-    - 'fix/CFDS-234_two_exports_at_once'
+    - 'develop'
     paths:
     - repos/fdbt-site/**
   workflow_dispatch:
@@ -118,15 +118,15 @@ jobs:
         cluster: ${{ env.ECS_CLUSTER }}
         wait-for-service-stability: true
         
-    # - name: Sleep for 10 mins
-    #   run: sleep 10m
-    #   shell: bash
+    - name: Sleep for 10 mins
+      run: sleep 10m
+      shell: bash
 
-    # - name: run-ui-tests
-    #   env:
-    #     CYPRESS_BASE_URL: ${{ secrets.CYPRESS_BASE_URL }}
-    #   run: |
-    #     cd cypress_tests
-    #     cat cypress.config.ts | sed -e "s/baseUrl: '[^'].*'/baseUrl: '${CYPRESS_BASE_URL}'/g" >> cypress.config.ts2 && mv cypress.config.ts2 cypress.config.ts
-    #     cd ..
-    #     bash run_tests_in_browserstack.sh
+    - name: run-ui-tests
+      env:
+        CYPRESS_BASE_URL: ${{ secrets.CYPRESS_BASE_URL }}
+      run: |
+        cd cypress_tests
+        cat cypress.config.ts | sed -e "s/baseUrl: '[^'].*'/baseUrl: '${CYPRESS_BASE_URL}'/g" >> cypress.config.ts2 && mv cypress.config.ts2 cypress.config.ts
+        cd ..
+        bash run_tests_in_browserstack.sh

--- a/.github/workflows/fdbt-site_test_deployment.yml
+++ b/.github/workflows/fdbt-site_test_deployment.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-    - 'develop'
+    - 'fix/CFDS-234_two_exports_at_once'
     paths:
     - repos/fdbt-site/**
   workflow_dispatch:
@@ -118,15 +118,15 @@ jobs:
         cluster: ${{ env.ECS_CLUSTER }}
         wait-for-service-stability: true
         
-    - name: Sleep for 10 mins
-      run: sleep 10m
-      shell: bash
+    # - name: Sleep for 10 mins
+    #   run: sleep 10m
+    #   shell: bash
 
-    - name: run-ui-tests
-      env:
-        CYPRESS_BASE_URL: ${{ secrets.CYPRESS_BASE_URL }}
-      run: |
-        cd cypress_tests
-        cat cypress.config.ts | sed -e "s/baseUrl: '[^'].*'/baseUrl: '${CYPRESS_BASE_URL}'/g" >> cypress.config.ts2 && mv cypress.config.ts2 cypress.config.ts
-        cd ..
-        bash run_tests_in_browserstack.sh
+    # - name: run-ui-tests
+    #   env:
+    #     CYPRESS_BASE_URL: ${{ secrets.CYPRESS_BASE_URL }}
+    #   run: |
+    #     cd cypress_tests
+    #     cat cypress.config.ts | sed -e "s/baseUrl: '[^'].*'/baseUrl: '${CYPRESS_BASE_URL}'/g" >> cypress.config.ts2 && mv cypress.config.ts2 cypress.config.ts
+    #     cd ..
+    #     bash run_tests_in_browserstack.sh

--- a/repos/fdbt-site/src/constants/attributes.ts
+++ b/repos/fdbt-site/src/constants/attributes.ts
@@ -165,5 +165,3 @@ export const SERVICE_LIST_EXEMPTION_ATTRIBUTE = 'fdbt-exemption-services';
 export const CAPS_DEFINITION_ATTRIBUTE = 'fdbt-caps-definition-attribute';
 
 export const STOPS_EXEMPTION_ATTRIBUTE = 'fdbt-exemption-stops';
-
-export const SELECT_EXPORTS_ATTRIBUTE = 'fdbt-select-exports';

--- a/repos/fdbt-site/src/pages/api/getExportProgress.ts
+++ b/repos/fdbt-site/src/pages/api/getExportProgress.ts
@@ -1,5 +1,5 @@
 import { NextApiResponse } from 'next';
-import { dateIsOverThirtyMinutesAgo, exportHasStarted, getAndValidateNoc, redirectToError } from '../../utils/apiUtils';
+import { dateIsOverThirtyMinutesAgo, getAndValidateNoc, redirectToError } from '../../utils/apiUtils';
 import { NextApiRequestWithSession } from '../../interfaces';
 import {
     checkIfMetaDataExists,
@@ -12,8 +12,6 @@ import {
 import { MATCHING_DATA_BUCKET_NAME, NETEX_BUCKET_NAME } from '../../constants';
 import logger from '../../utils/logger';
 import { difference } from 'lodash';
-import { getSessionAttribute, updateSessionAttribute } from '../../utils/sessions';
-import { SELECT_EXPORTS_ATTRIBUTE } from '../../constants/attributes';
 
 export interface Export {
     name: string;
@@ -24,66 +22,67 @@ export interface Export {
     signedUrl?: string;
 }
 
+export const getAllExports = async (noc: string): Promise<Export[]> => {
+    const exportNames = await getS3Exports(noc);
+
+    const exports: Export[] = await Promise.all(
+        exportNames.map(async (name) => {
+            const prefix = `${noc}/exports/${name}/`;
+
+            logger.info('', {
+                context: 'api.getExportProgress',
+                message: 'Getting counts for matching data and netex',
+                exportName: name,
+            });
+
+            const matchingDataCount = await getS3FolderCount(MATCHING_DATA_BUCKET_NAME, prefix);
+            const netexCount = await getS3FolderCount(NETEX_BUCKET_NAME, prefix);
+
+            let numberOfFilesExpected = matchingDataCount;
+
+            let metadata = undefined;
+            const metaDataExists = await checkIfMetaDataExists(`${noc}/exports/${name}.json`);
+
+            if (metaDataExists) {
+                metadata = await getExportMetaData(`${noc}/exports/${name}.json`);
+                numberOfFilesExpected = metadata.numberOfExpectedNetexFiles;
+            }
+
+            let exportFailed = false;
+            let failedValidationFilenames: string[] = [];
+
+            if (
+                metadata &&
+                dateIsOverThirtyMinutesAgo(new Date(metadata.date)) &&
+                metadata.numberOfExpectedNetexFiles !== netexCount
+            ) {
+                exportFailed = true;
+            }
+
+            if (exportFailed) {
+                const unvalidatedNetexFileNames = await getNetexFileNames(prefix, false);
+                const validatedNetexFileNames = await getNetexFileNames(prefix, true);
+                failedValidationFilenames = difference(unvalidatedNetexFileNames, validatedNetexFileNames);
+            }
+
+            const complete = matchingDataCount === netexCount;
+            const signedUrl = complete ? await retrieveExportZip(noc, name) : undefined;
+
+            return { name, numberOfFilesExpected, netexCount, signedUrl, exportFailed, failedValidationFilenames };
+        }),
+    );
+
+    return exports.reverse();
+};
+
 export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
     try {
         const noc = getAndValidateNoc(req, res);
 
-        const exportNames = await getS3Exports(noc);
-        const selectExportAttribute = getSessionAttribute(req, SELECT_EXPORTS_ATTRIBUTE);
-
-        if (!!selectExportAttribute && exportHasStarted(selectExportAttribute.exportStarted)) {
-            updateSessionAttribute(req, SELECT_EXPORTS_ATTRIBUTE, undefined);
-        }
-
-        const exports: Export[] = await Promise.all(
-            exportNames.map(async (name) => {
-                const prefix = `${noc}/exports/${name}/`;
-
-                logger.info('', {
-                    context: 'api.getExportProgress',
-                    message: 'Getting counts for matching data and netex',
-                    exportName: name,
-                });
-
-                const matchingDataCount = await getS3FolderCount(MATCHING_DATA_BUCKET_NAME, prefix);
-                const netexCount = await getS3FolderCount(NETEX_BUCKET_NAME, prefix);
-
-                let numberOfFilesExpected = matchingDataCount;
-
-                let metadata = undefined;
-                const metaDataExists = await checkIfMetaDataExists(`${noc}/exports/${name}.json`);
-
-                if (metaDataExists) {
-                    metadata = await getExportMetaData(`${noc}/exports/${name}.json`);
-                    numberOfFilesExpected = metadata.numberOfExpectedNetexFiles;
-                }
-
-                let exportFailed = false;
-                let failedValidationFilenames: string[] = [];
-
-                if (
-                    metadata &&
-                    dateIsOverThirtyMinutesAgo(new Date(metadata.date)) &&
-                    metadata.numberOfExpectedNetexFiles !== netexCount
-                ) {
-                    exportFailed = true;
-                }
-
-                if (exportFailed) {
-                    const unvalidatedNetexFileNames = await getNetexFileNames(prefix, false);
-                    const validatedNetexFileNames = await getNetexFileNames(prefix, true);
-                    failedValidationFilenames = difference(unvalidatedNetexFileNames, validatedNetexFileNames);
-                }
-
-                const complete = matchingDataCount === netexCount;
-                const signedUrl = complete ? await retrieveExportZip(noc, name) : undefined;
-
-                return { name, numberOfFilesExpected, netexCount, signedUrl, exportFailed, failedValidationFilenames };
-            }),
-        );
+        const exports = await getAllExports(noc);
 
         res.status(200).json({
-            exports: exports.reverse(),
+            exports,
         });
     } catch (error) {
         redirectToError(res, 'There was a problem getting the export progress', 'api.getExportProgress', error);

--- a/repos/fdbt-site/src/pages/api/selectExports.ts
+++ b/repos/fdbt-site/src/pages/api/selectExports.ts
@@ -4,8 +4,6 @@ import { NextApiRequestWithSession } from '../../interfaces';
 import { getS3Exports } from '../../data/s3';
 import { getProductById } from '../../data/auroradb';
 import { triggerExport } from '../../utils/apiUtils/export';
-import { updateSessionAttribute } from '../../utils/sessions';
-import { SELECT_EXPORTS_ATTRIBUTE } from '../../constants/attributes';
 
 export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
     const noc = getAndValidateNoc(req, res);
@@ -42,8 +40,6 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
     const links = products.map((product) => product.matchingJsonLink);
 
     await triggerExport({ noc, paths: links, exportPrefix: exportName });
-    const currTime = new Date().getTime() / 1000;
-    updateSessionAttribute(req, SELECT_EXPORTS_ATTRIBUTE, { exportStarted: currTime });
     redirectTo(res, '/products/exports');
     return;
 };

--- a/repos/fdbt-site/src/pages/products/exports.tsx
+++ b/repos/fdbt-site/src/pages/products/exports.tsx
@@ -68,7 +68,11 @@ const Exports = ({ csrf, initialExportIsInProgress, operatorHasProducts }: Globa
 
     const anExportIsInProgress = !!exportInProgress;
     const exportAllowed: boolean =
-        operatorHasProducts && !anExportIsInProgress && !!exports && !buttonClicked && !initialExportIsInProgress;
+        operatorHasProducts &&
+        !anExportIsInProgress &&
+        !!exports &&
+        !buttonClicked &&
+        (!initialExportIsInProgress || !anExportIsInProgress);
     const showCancelButton: boolean = anExportIsInProgress && !!exportInProgress?.exportFailed;
     const failedExport: Export | undefined =
         anExportIsInProgress && exportInProgress?.exportFailed ? exportInProgress : undefined;

--- a/repos/fdbt-site/src/pages/products/exports.tsx
+++ b/repos/fdbt-site/src/pages/products/exports.tsx
@@ -68,11 +68,7 @@ const Exports = ({ csrf, initialExportIsInProgress, operatorHasProducts }: Globa
 
     const anExportIsInProgress = !!exportInProgress;
     const exportAllowed: boolean =
-        operatorHasProducts &&
-        !anExportIsInProgress &&
-        !!exports &&
-        !buttonClicked &&
-        (!initialExportIsInProgress || !anExportIsInProgress);
+        operatorHasProducts && !anExportIsInProgress && !!exports && !buttonClicked && !initialExportIsInProgress;
     const showCancelButton: boolean = anExportIsInProgress && !!exportInProgress?.exportFailed;
     const failedExport: Export | undefined =
         anExportIsInProgress && exportInProgress?.exportFailed ? exportInProgress : undefined;

--- a/repos/fdbt-site/src/utils/sessions.ts
+++ b/repos/fdbt-site/src/utils/sessions.ts
@@ -80,7 +80,6 @@ import {
     CAPS_DEFINITION_ATTRIBUTE,
     STOPS_EXEMPTION_ATTRIBUTE,
     VIEW_CAP_ERRORS,
-    SELECT_EXPORTS_ATTRIBUTE,
 } from '../constants/attributes';
 import {
     CsvUploadAttributeWithErrors,
@@ -252,7 +251,6 @@ export interface SessionAttributeTypes {
     [CAPS_DEFINITION_ATTRIBUTE]: CapSelection | { errors: ErrorInfo[] };
     [SERVICE_LIST_EXEMPTION_ATTRIBUTE]: ServiceListAttribute | { errors: ErrorInfo[] };
     [STOPS_EXEMPTION_ATTRIBUTE]: ExemptedStopsAttribute | { errors: ErrorInfo[] };
-    [SELECT_EXPORTS_ATTRIBUTE]: { exportStarted: number };
 }
 
 export type SessionAttribute<T extends string> = T extends keyof SessionAttributeTypes

--- a/repos/fdbt-site/tests/pages/products/exports.test.tsx
+++ b/repos/fdbt-site/tests/pages/products/exports.test.tsx
@@ -5,12 +5,17 @@ import Exports from '../../../src/pages/products/exports';
 describe('pages', () => {
     describe('exports', () => {
         it('should render correctly without data when operator has no products', () => {
-            const tree = shallow(<Exports csrf={''} operatorHasProducts={false} exportStarted />);
+            const tree = shallow(<Exports csrf={''} operatorHasProducts={false} initialExportIsInProgress={false} />);
             expect(tree).toMatchSnapshot();
         });
 
         it('should render the export button correctly when operator has products', () => {
-            const tree = shallow(<Exports csrf={''} operatorHasProducts={true} exportStarted />);
+            const tree = shallow(<Exports csrf={''} operatorHasProducts={true} initialExportIsInProgress={false} />);
+            expect(tree).toMatchSnapshot();
+        });
+
+        it('should render the export button correctly when operator has products and an export is in progress', () => {
+            const tree = shallow(<Exports csrf={''} operatorHasProducts={true} initialExportIsInProgress />);
             expect(tree).toMatchSnapshot();
         });
     });


### PR DESCRIPTION
## Description

Due to a race condition, users could fire 2 exports at once by using the /selectExports page first. This has been stopped via a check in the server side props.

## Testing instructions

Once deployed, attempt to run 2 exports at once.
