### PR TITLE
fix: search operators fix

### DIFF
--- a/repos/fdbt-site/src/pages/searchOperators.tsx
+++ b/repos/fdbt-site/src/pages/searchOperators.tsx
@@ -54,11 +54,7 @@ export const ShowSelectedOperators = (
         }
     });
 
-    const removeOperator = (
-        event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-        nocCode: string,
-        removeAll?: boolean,
-    ) => {
+    const removeOperator = (nocCode: string, removeAll?: boolean) => {
         if (removeAll) {
             setSelectedOperators([]);
             setSearchResults(alphabetiseOperatorList(databaseSearchResults));
@@ -68,8 +64,6 @@ export const ShowSelectedOperators = (
             setSelectedOperators(newSelectedOperators);
             setSearchResults(alphabetiseOperatorList([...searchResults, operatorToRemove]));
         }
-
-        event.preventDefault();
     };
 
     return (
@@ -117,7 +111,10 @@ export const ShowSelectedOperators = (
                             <button
                                 id="removeAll"
                                 className="selectedOperators-button button-link govuk-!-margin-left-2"
-                                onClick={(event) => removeOperator(event, '', true)}
+                                onClick={(event) => {
+                                    event.preventDefault();
+                                    removeOperator('', true);
+                                }}
                                 name="removeOperator"
                             >
                                 Remove all
@@ -135,7 +132,10 @@ export const ShowSelectedOperators = (
                                 <button
                                     id={`remove-${index}`}
                                     className="govuk-link button-link"
-                                    onClick={(event) => removeOperator(event, operator.nocCode)}
+                                    onClick={(event) => {
+                                        event.preventDefault();
+                                        removeOperator(operator.nocCode);
+                                    }}
                                     name="removeOperator"
                                     value={operator.name}
                                 >

--- a/repos/fdbt-site/src/pages/searchOperators.tsx
+++ b/repos/fdbt-site/src/pages/searchOperators.tsx
@@ -54,7 +54,11 @@ export const ShowSelectedOperators = (
         }
     });
 
-    const removeOperator = (nocCode: string, removeAll?: boolean) => {
+    const removeOperator = (
+        event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+        nocCode: string,
+        removeAll?: boolean,
+    ) => {
         if (removeAll) {
             setSelectedOperators([]);
             setSearchResults(alphabetiseOperatorList(databaseSearchResults));
@@ -63,6 +67,9 @@ export const ShowSelectedOperators = (
             const operatorToRemove = databaseSearchResults.find((operator) => operator.nocCode === nocCode) as Operator;
             setSelectedOperators(newSelectedOperators);
             setSearchResults(alphabetiseOperatorList([...searchResults, operatorToRemove]));
+        }
+        if (event) {
+            event.preventDefault();
         }
     };
 
@@ -111,10 +118,7 @@ export const ShowSelectedOperators = (
                             <button
                                 id="removeAll"
                                 className="selectedOperators-button button-link govuk-!-margin-left-2"
-                                onClick={(event) => {
-                                    event.preventDefault();
-                                    removeOperator('', true);
-                                }}
+                                onClick={(event) => removeOperator(event, '', true)}
                                 name="removeOperator"
                             >
                                 Remove all
@@ -132,10 +136,7 @@ export const ShowSelectedOperators = (
                                 <button
                                     id={`remove-${index}`}
                                     className="govuk-link button-link"
-                                    onClick={(event) => {
-                                        event.preventDefault();
-                                        removeOperator(operator.nocCode);
-                                    }}
+                                    onClick={(event) => removeOperator(event, operator.nocCode)}
                                     name="removeOperator"
                                     value={operator.name}
                                 >

--- a/repos/fdbt-site/tests/pages/__snapshots__/searchOperators.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/searchOperators.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`pages searchOperator should render a selection error when the user trie
               </p>
               <div
                 className="govuk-checkboxes__item"
-                key="checkbox-item-Blackpool"
+                key="checkbox-item-BLAC"
               >
                 <label
                   className="govuk-label govuk-checkboxes__label"
@@ -293,18 +293,21 @@ exports[`pages searchOperator should render a selection error when the user trie
             />
             <input
               id="add-operator-0"
+              key="input-WBTR"
               name="userSelectedOperators"
               type="hidden"
               value="WBTR#Warrington's Own Buses"
             />
             <input
               id="add-operator-1"
+              key="input-BLAC"
               name="userSelectedOperators"
               type="hidden"
               value="BLAC#Blackpool Transport"
             />
             <input
               id="add-operator-2"
+              key="input-IWBusCo"
               name="userSelectedOperators"
               type="hidden"
               value="IWBusCo#IW Bus Co"
@@ -933,18 +936,21 @@ exports[`pages searchOperator should render the page in edit mode 1`] = `
             />
             <input
               id="add-operator-0"
+              key="input-WBTR"
               name="userSelectedOperators"
               type="hidden"
               value="WBTR#Warrington's Own Buses"
             />
             <input
               id="add-operator-1"
+              key="input-BLAC"
               name="userSelectedOperators"
               type="hidden"
               value="BLAC#Blackpool Transport"
             />
             <input
               id="add-operator-2"
+              key="input-IWBusCo"
               name="userSelectedOperators"
               type="hidden"
               value="IWBusCo#IW Bus Co"
@@ -1011,7 +1017,7 @@ exports[`pages searchOperator should render the page in edit mode 1`] = `
               </p>
               <div
                 className="govuk-checkboxes__item"
-                key="checkbox-item-Warrington's Own Buses"
+                key="checkbox-item-WBTR"
               >
                 <label
                   className="govuk-label govuk-checkboxes__label"
@@ -1285,18 +1291,21 @@ exports[`pages searchOperator should render the search input and a list of selec
             />
             <input
               id="add-operator-0"
+              key="input-WBTR"
               name="userSelectedOperators"
               type="hidden"
               value="WBTR#Warrington's Own Buses"
             />
             <input
               id="add-operator-1"
+              key="input-BLAC"
               name="userSelectedOperators"
               type="hidden"
               value="BLAC#Blackpool Transport"
             />
             <input
               id="add-operator-2"
+              key="input-IWBusCo"
               name="userSelectedOperators"
               type="hidden"
               value="IWBusCo#IW Bus Co"
@@ -1626,7 +1635,7 @@ exports[`pages searchOperator should render the search input and search results 
               </p>
               <div
                 className="govuk-checkboxes__item"
-                key="checkbox-item-Blackpool"
+                key="checkbox-item-BLAC"
               >
                 <label
                   className="govuk-label govuk-checkboxes__label"
@@ -1802,18 +1811,21 @@ exports[`pages searchOperator should render the search input, search results and
             />
             <input
               id="add-operator-0"
+              key="input-WBTR"
               name="userSelectedOperators"
               type="hidden"
               value="WBTR#Warrington's Own Buses"
             />
             <input
               id="add-operator-1"
+              key="input-BLAC"
               name="userSelectedOperators"
               type="hidden"
               value="BLAC#Blackpool Transport"
             />
             <input
               id="add-operator-2"
+              key="input-IWBusCo"
               name="userSelectedOperators"
               type="hidden"
               value="IWBusCo#IW Bus Co"
@@ -1881,7 +1893,7 @@ exports[`pages searchOperator should render the search input, search results and
               </p>
               <div
                 className="govuk-checkboxes__item"
-                key="checkbox-item-Warrington's Own Buses"
+                key="checkbox-item-WBTR"
               >
                 <label
                   className="govuk-label govuk-checkboxes__label"

--- a/repos/fdbt-site/tests/pages/searchOperators.test.tsx
+++ b/repos/fdbt-site/tests/pages/searchOperators.test.tsx
@@ -5,8 +5,8 @@ import * as aurora from '../../src/data/auroradb';
 import SearchOperators, {
     getServerSideProps,
     SearchOperatorProps,
-    ShowSelectedOperators,
-    ShowSearchResults,
+    showSelectedOperators,
+    showSearchResults,
     alphabetiseOperatorList,
 } from '../../src/pages/searchOperators';
 import { MULTIPLE_OPERATOR_ATTRIBUTE, OPERATOR_ATTRIBUTE } from '../../src/constants/attributes';
@@ -321,7 +321,7 @@ describe('pages', () => {
                 const mocErrors: ErrorInfo[] = [];
                 const operatorGroupName = '';
                 const wrapper = shallow(
-                    ShowSelectedOperators(
+                    showSelectedOperators(
                         mocSelectedOperators,
                         setSelectedOperators,
                         mocErrors,
@@ -348,7 +348,7 @@ describe('pages', () => {
                 const operatorGroupName = '';
                 const setSearchResults = jest.fn();
                 const wrapper = shallow(
-                    ShowSelectedOperators(
+                    showSelectedOperators(
                         mocSelectedOperators,
                         setSelectedOperators,
                         mocErrors,
@@ -374,7 +374,7 @@ describe('pages', () => {
                 const setSearchResults = jest.fn();
 
                 const wrapper = shallow(
-                    ShowSearchResults(
+                    showSearchResults(
                         mocksearchText,
                         mockErrors,
                         mockDatabaseSearchResultsCount,

--- a/repos/fdbt-site/tests/pages/searchOperators.test.tsx
+++ b/repos/fdbt-site/tests/pages/searchOperators.test.tsx
@@ -7,27 +7,28 @@ import SearchOperators, {
     SearchOperatorProps,
     ShowSelectedOperators,
     ShowSearchResults,
+    alphabetiseOperatorList,
 } from '../../src/pages/searchOperators';
 import { MULTIPLE_OPERATOR_ATTRIBUTE, OPERATOR_ATTRIBUTE } from '../../src/constants/attributes';
 import { ErrorInfo, Operator, OperatorAttribute, OperatorGroup } from '../../src/interfaces';
 
+const mockOperators: Operator[] = [
+    {
+        name: "Warrington's Own Buses",
+        nocCode: 'WBTR',
+    },
+    {
+        name: 'Blackpool Transport',
+        nocCode: 'BLAC',
+    },
+    {
+        name: 'IW Bus Co',
+        nocCode: 'IWBusCo',
+    },
+];
+
 describe('pages', () => {
     describe('searchOperator', () => {
-        const mockOperators: Operator[] = [
-            {
-                name: "Warrington's Own Buses",
-                nocCode: 'WBTR',
-            },
-            {
-                name: 'Blackpool Transport',
-                nocCode: 'BLAC',
-            },
-            {
-                name: 'IW Bus Co',
-                nocCode: 'IWBusCo',
-            },
-        ];
-
         const mockOperatorGroup: OperatorGroup = {
             id: 1,
             name: 'OperatorG Group',
@@ -312,10 +313,23 @@ describe('pages', () => {
                     { nocCode: 'BLAC', name: 'Blackpool Transport' },
                     { nocCode: 'LNUD', name: 'The Blackburn Bus Company' },
                 ];
+                const mockSearchResults: Operator[] = [
+                    { nocCode: 'BLAC', name: 'Blackpool Transport' },
+                    { nocCode: 'LNUD', name: 'The Blackburn Bus Company' },
+                ];
+                const setSearchResults = jest.fn();
                 const mocErrors: ErrorInfo[] = [];
                 const operatorGroupName = '';
                 const wrapper = shallow(
-                    ShowSelectedOperators(mocSelectedOperators, setSelectedOperators, mocErrors, operatorGroupName),
+                    ShowSelectedOperators(
+                        mocSelectedOperators,
+                        setSelectedOperators,
+                        mocErrors,
+                        operatorGroupName,
+                        mockSearchResults,
+                        setSearchResults,
+                        mockSearchResults,
+                    ),
                 );
                 wrapper.find('#remove-0').simulate('click');
                 expect(setSelectedOperators).toBeCalledWith([{ nocCode: 'LNUD', name: 'The Blackburn Bus Company' }]);
@@ -326,10 +340,23 @@ describe('pages', () => {
                     { nocCode: 'BLAC', name: 'Blackpool Transport' },
                     { nocCode: 'LNUD', name: 'The Blackburn Bus Company' },
                 ];
+                const mockSearchResults: Operator[] = [
+                    { nocCode: 'BLAC', name: 'Blackpool Transport' },
+                    { nocCode: 'LNUD', name: 'The Blackburn Bus Company' },
+                ];
                 const mocErrors: ErrorInfo[] = [];
                 const operatorGroupName = '';
+                const setSearchResults = jest.fn();
                 const wrapper = shallow(
-                    ShowSelectedOperators(mocSelectedOperators, setSelectedOperators, mocErrors, operatorGroupName),
+                    ShowSelectedOperators(
+                        mocSelectedOperators,
+                        setSelectedOperators,
+                        mocErrors,
+                        operatorGroupName,
+                        mockSearchResults,
+                        setSearchResults,
+                        mockSearchResults,
+                    ),
                 );
                 wrapper.find('#removeAll').simulate('click');
                 expect(setSelectedOperators).toBeCalledWith([]);
@@ -340,9 +367,7 @@ describe('pages', () => {
                 const mockDatabaseSearchResultsCount = 2;
                 const mockSelectedOperators: Operator[] = [];
                 const setSelectedOperators = jest.fn();
-                const mockSearchResultsCount = 2;
-                const setSearchResultsCount = jest.fn();
-                const mocksearchResults: Operator[] = [
+                const mockSearchResults: Operator[] = [
                     { nocCode: 'BLAC', name: 'Blackpool Transport' },
                     { nocCode: 'LNUD', name: 'The Blackburn Bus Company' },
                 ];
@@ -355,17 +380,35 @@ describe('pages', () => {
                         mockDatabaseSearchResultsCount,
                         mockSelectedOperators,
                         setSelectedOperators,
-                        mockSearchResultsCount,
-                        setSearchResultsCount,
-                        mocksearchResults,
+                        mockSearchResults,
                         setSearchResults,
                     ),
                 );
 
                 wrapper.find('#operator-to-add-0').simulate('click');
                 expect(setSelectedOperators).toBeCalledWith([{ nocCode: 'BLAC', name: 'Blackpool Transport' }]);
-                expect(setSearchResultsCount).toBeCalledWith(1);
                 expect(setSearchResults).toBeCalledWith([{ nocCode: 'LNUD', name: 'The Blackburn Bus Company' }]);
+            });
+        });
+
+        describe('alphabetiseOperatorList', () => {
+            it('takes an array of operators and sorts them according to their name', () => {
+                const result = alphabetiseOperatorList(mockOperators);
+
+                expect(result).toStrictEqual([
+                    {
+                        name: 'Blackpool Transport',
+                        nocCode: 'BLAC',
+                    },
+                    {
+                        name: 'IW Bus Co',
+                        nocCode: 'IWBusCo',
+                    },
+                    {
+                        name: "Warrington's Own Buses",
+                        nocCode: 'WBTR',
+                    },
+                ]);
             });
         });
     });


### PR DESCRIPTION
## Description

Duplicate keys in the html (during maps) was causing issues when operators had the same name. The fix was to move to use NOC as the unique key.

## Testing instructions

Use search operators page and add a group with operators of the same name.
