### PR TITLE
fix: Downgrade urllib3 to v2

### DIFF
--- a/repos/fdbt-reference-data-service/src/retrievers/requirements.txt
+++ b/repos/fdbt-reference-data-service/src/retrievers/requirements.txt
@@ -1,3 +1,3 @@
 PyMySQL==1.0.1
 Requests==2.31.0
-urllib3==2.0.0
+urllib3>=1.25.4,<2

--- a/repos/fdbt-reference-data-service/src/retrievers/requirements.txt
+++ b/repos/fdbt-reference-data-service/src/retrievers/requirements.txt
@@ -1,2 +1,3 @@
 PyMySQL==1.0.1
 Requests==2.31.0
+urllib3==2.0.0

--- a/repos/fdbt-reference-data-service/src/uploaders/requirements.test.txt
+++ b/repos/fdbt-reference-data-service/src/uploaders/requirements.test.txt
@@ -4,4 +4,4 @@ PyMySQL==1.0.1
 xmltodict==0.13.0
 pytest==7.4.0
 moto==4.1.14
-urllib3==2.0.0
+urllib3>=1.25.4,<2

--- a/repos/fdbt-reference-data-service/src/uploaders/requirements.test.txt
+++ b/repos/fdbt-reference-data-service/src/uploaders/requirements.test.txt
@@ -4,3 +4,4 @@ PyMySQL==1.0.1
 xmltodict==0.13.0
 pytest==7.4.0
 moto==4.1.14
+urllib3==2.0.0

--- a/repos/fdbt-reference-data-service/src/uploaders/requirements.txt
+++ b/repos/fdbt-reference-data-service/src/uploaders/requirements.txt
@@ -2,4 +2,4 @@ boto3==1.26.90
 botocore==1.29.90
 PyMySQL==1.0.1
 xmltodict==0.13.0
-urllib3==2.0.0
+urllib3>=1.25.4,<2

--- a/repos/fdbt-reference-data-service/src/uploaders/requirements.txt
+++ b/repos/fdbt-reference-data-service/src/uploaders/requirements.txt
@@ -2,3 +2,4 @@ boto3==1.26.90
 botocore==1.29.90
 PyMySQL==1.0.1
 xmltodict==0.13.0
+urllib3==2.0.0


### PR DESCRIPTION
## Description

[Urrllib3 docs](https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html#migrating-as-an-application-developer)

As shown above botocore and requests need v2 of urllib

