### PR TITLE
fix: Change syntax on pymysql connection

### DIFF
--- a/repos/fdbt-reference-data-service/src/retrievers/txc_retriever/main.py
+++ b/repos/fdbt-reference-data-service/src/retrievers/txc_retriever/main.py
@@ -43,7 +43,7 @@ db_password = ssm.get_parameter(
     WithDecryption=True
 )['Parameter']['Value']
 
-db_connection = pymysql.connect(rds_host, user=db_username, passwd=db_password, db=db_name, connect_timeout=5)
+db_connection = pymysql.connect(host=rds_host, user=db_username, password=db_password, database=db_name, connect_timeout=5)
 
 queries = [
     'SET FOREIGN_KEY_CHECKS=0',

--- a/repos/fdbt-reference-data-service/src/uploaders/csv_uploader/main.py
+++ b/repos/fdbt-reference-data-service/src/uploaders/csv_uploader/main.py
@@ -22,7 +22,7 @@ password = ssm.get_parameter(
     WithDecryption=True
 )['Parameter']['Value']
 
-db_connection = pymysql.connect(rds_host, user=username, passwd=password, db=db_name, connect_timeout=5)
+db_connection = pymysql.connect(host=rds_host, user=username, password=password, database=db_name, connect_timeout=5)
 
 
 def lambda_handler(event, context):

--- a/repos/fdbt-reference-data-service/src/uploaders/txc_uploader/main.py
+++ b/repos/fdbt-reference-data-service/src/uploaders/txc_uploader/main.py
@@ -25,7 +25,7 @@ password = ssm_client.get_parameter(
 )["Parameter"]["Value"]
 
 db_connection = pymysql.connect(
-    rds_host, user=username, passwd=password, db=db_name, connect_timeout=5
+    host=rds_host, user=username, password=password, database=db_name, connect_timeout=5
 )
 
 


### PR DESCRIPTION
## Description

https://pymysql.readthedocs.io/en/latest/modules/connections.html 
Syntax was causing errorMessage": "Connection.__init__() got multiple values for argument 'user'", in the retriever for bods


