### PR TITLE
fix: focus on popups

### DIFF
--- a/repos/fdbt-site/package-lock.json
+++ b/repos/fdbt-site/package-lock.json
@@ -24,6 +24,7 @@
                 "express-session": "^1.17.1",
                 "express-winston": "^4.0.3",
                 "file-loader": "^6.2.0",
+                "focus-trap-react": "^10.2.3",
                 "formidable": "1.2.2",
                 "govuk-frontend": "^3.13.0",
                 "helmet": "^3.22.0",
@@ -7217,6 +7218,28 @@
             "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
             "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
         },
+        "node_modules/focus-trap": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
+            "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
+            "dependencies": {
+                "tabbable": "^6.2.0"
+            }
+        },
+        "node_modules/focus-trap-react": {
+            "version": "10.2.3",
+            "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-10.2.3.tgz",
+            "integrity": "sha512-YXBpFu/hIeSu6NnmV2xlXzOYxuWkoOtar9jzgp3lOmjWLWY59C/b8DtDHEAV4SPU07Nd/t+nS/SBNGkhUBFmEw==",
+            "dependencies": {
+                "focus-trap": "^7.5.4",
+                "tabbable": "^6.2.0"
+            },
+            "peerDependencies": {
+                "prop-types": "^15.8.1",
+                "react": ">=16.3.0",
+                "react-dom": ">=16.3.0"
+            }
+        },
         "node_modules/for-each": {
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -11987,7 +12010,6 @@
             "version": "15.8.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
             "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.4.0",
                 "object-assign": "^4.1.1",
@@ -13181,6 +13203,11 @@
             "version": "2.0.17",
             "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.17.tgz",
             "integrity": "sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g=="
+        },
+        "node_modules/tabbable": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+            "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
         },
         "node_modules/table": {
             "version": "6.8.1",

--- a/repos/fdbt-site/package.json
+++ b/repos/fdbt-site/package.json
@@ -51,6 +51,7 @@
         "express-session": "^1.17.1",
         "express-winston": "^4.0.3",
         "file-loader": "^6.2.0",
+        "focus-trap-react": "^10.2.3",
         "formidable": "1.2.2",
         "govuk-frontend": "^3.13.0",
         "helmet": "^3.22.0",

--- a/repos/fdbt-site/src/components/DeleteConfirmationPopup.tsx
+++ b/repos/fdbt-site/src/components/DeleteConfirmationPopup.tsx
@@ -1,10 +1,12 @@
 import React, { ReactElement } from 'react';
+import Trap from './Trap';
 
 interface PopUpProps {
     entityName: string;
     deleteUrl: string;
     cancelActionHandler: React.MouseEventHandler<HTMLButtonElement>;
     hintText?: string;
+    isOpen: boolean;
 }
 
 const DeleteConfirmationPopup = ({
@@ -12,38 +14,41 @@ const DeleteConfirmationPopup = ({
     deleteUrl,
     cancelActionHandler,
     hintText,
+    isOpen,
 }: PopUpProps): ReactElement | null => (
-    <div className="popup">
-        <div className="popup__content">
-            <form>
-                <h1 className="govuk-heading-m">Are you sure you want to delete {entityName.trim()}?</h1>
+    <Trap active={isOpen}>
+        <div className="popup">
+            <div className="popup__content">
+                <form>
+                    <h1 className="govuk-heading-m">Are you sure you want to delete {entityName.trim()}?</h1>
 
-                <span className="govuk-hint" id="delete-hint">
-                    {hintText && (
-                        <>
-                            <span className="govuk-hint" id="delete-hint">
-                                {hintText}
-                            </span>
-                        </>
-                    )}
-                </span>
+                    <span className="govuk-hint" id="delete-hint">
+                        {hintText && (
+                            <>
+                                <span className="govuk-hint" id="delete-hint">
+                                    {hintText}
+                                </span>
+                            </>
+                        )}
+                    </span>
 
-                <button className="govuk-button govuk-button--secondary" onClick={cancelActionHandler}>
-                    Cancel
-                </button>
+                    <button className="govuk-button govuk-button--secondary" onClick={cancelActionHandler}>
+                        Cancel
+                    </button>
 
-                <button
-                    className="govuk-button govuk-button--warning"
-                    formAction={deleteUrl}
-                    formMethod="post"
-                    type="submit"
-                    id="popup-delete-button"
-                >
-                    Delete
-                </button>
-            </form>
+                    <button
+                        className="govuk-button govuk-button--warning"
+                        formAction={deleteUrl}
+                        formMethod="post"
+                        type="submit"
+                        id="popup-delete-button"
+                    >
+                        Delete
+                    </button>
+                </form>
+            </div>
         </div>
-    </div>
+    </Trap>
 );
 
 export default DeleteConfirmationPopup;

--- a/repos/fdbt-site/src/components/GenerateReturnPopup.tsx
+++ b/repos/fdbt-site/src/components/GenerateReturnPopup.tsx
@@ -1,24 +1,28 @@
 import React, { ReactElement } from 'react';
+import Trap from './Trap';
 
 interface GenerateSinglePopupPopUpProps {
     cancelActionHandler: React.MouseEventHandler<HTMLButtonElement>;
+    isOpen: boolean;
 }
 
-const GenerateReturnPopup = ({ cancelActionHandler }: GenerateSinglePopupPopUpProps): ReactElement => {
+const GenerateReturnPopup = ({ cancelActionHandler, isOpen }: GenerateSinglePopupPopUpProps): ReactElement => {
     return (
-        <div className="popup">
-            <div className="popup__content">
-                <h1 className="govuk-heading-m">A return cannot be auto-generated for this product.</h1>
-                <span className="govuk-hint" id="delete-hint">
-                    Two singles must be created, one for inbound and one for outbound. They must have the same passenger
-                    type and not be expired. Services with one direction (circular services for example) cannot be used
-                    to generate returns.
-                </span>
-                <button className="govuk-button govuk-button--secondary" onClick={cancelActionHandler}>
-                    Close
-                </button>
+        <Trap active={isOpen}>
+            <div className="popup">
+                <div className="popup__content">
+                    <h1 className="govuk-heading-m">A return cannot be auto-generated for this product.</h1>
+                    <span className="govuk-hint" id="delete-hint">
+                        Two singles must be created, one for inbound and one for outbound. They must have the same
+                        passenger type and not be expired. Services with one direction (circular services for example)
+                        cannot be used to generate returns.
+                    </span>
+                    <button className="govuk-button govuk-button--secondary" onClick={cancelActionHandler}>
+                        Close
+                    </button>
+                </div>
             </div>
-        </div>
+        </Trap>
     );
 };
 

--- a/repos/fdbt-site/src/components/GlobalSettingsViewPage.tsx
+++ b/repos/fdbt-site/src/components/GlobalSettingsViewPage.tsx
@@ -123,6 +123,7 @@ export const GlobalSettingsViewPage = <T extends Entity>({
                                 entityName={popUpState.entityName}
                                 deleteUrl={buildDeleteUrl(popUpState.entityId, csrfToken)}
                                 cancelActionHandler={cancelActionHandler}
+                                isOpen={!!popUpState.entityId}
                             />
                         )}
                     </div>

--- a/repos/fdbt-site/src/components/InfoPopup.tsx
+++ b/repos/fdbt-site/src/components/InfoPopup.tsx
@@ -1,25 +1,29 @@
 import React, { ReactElement } from 'react';
+import Trap from './Trap';
 
 interface PopUpProps {
     title: string;
     text: string;
     okActionHandler: React.MouseEventHandler<HTMLButtonElement>;
+    isOpen: boolean;
 }
 
-const InfoPopup = ({ title, text, okActionHandler }: PopUpProps): ReactElement | null => (
-    <div className="popup">
-        <div className="popup__content">
-            <h1 className="govuk-heading-m">{title}</h1>
+const InfoPopup = ({ title, text, okActionHandler, isOpen }: PopUpProps): ReactElement | null => (
+    <Trap active={isOpen}>
+        <div className="popup">
+            <div className="popup__content">
+                <h1 className="govuk-heading-m">{title}</h1>
 
-            <span className="govuk-hint" id="info-hint">
-                {text}
-            </span>
+                <span className="govuk-hint" id="info-hint">
+                    {text}
+                </span>
 
-            <button className="govuk-button" onClick={okActionHandler}>
-                Ok
-            </button>
+                <button className="govuk-button" onClick={okActionHandler}>
+                    Ok
+                </button>
+            </div>
         </div>
-    </div>
+    </Trap>
 );
 
 export default InfoPopup;

--- a/repos/fdbt-site/src/components/ProductNamePopup.tsx
+++ b/repos/fdbt-site/src/components/ProductNamePopup.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 import { checkProductOrCapNameIsValid, removeExcessWhiteSpace } from '../utils/apiUtils/validator';
+import Trap from './Trap';
 
 interface ProductNamePopupProps {
     defaultValue: string;
@@ -7,6 +8,7 @@ interface ProductNamePopupProps {
     serviceId?: string;
     cancelActionHandler: React.MouseEventHandler<HTMLButtonElement>;
     csrfToken: string;
+    isOpen: boolean;
 }
 
 export const buildEditUrl = (
@@ -26,6 +28,7 @@ const ProductNamePopup = ({
     csrfToken,
     productId,
     serviceId,
+    isOpen,
 }: ProductNamePopupProps): ReactElement | null => {
     const [popupError, setPopupError] = useState('');
     const [productName, updateProductName] = useState('');
@@ -47,52 +50,54 @@ const ProductNamePopup = ({
     }, [productName]);
 
     return (
-        <div className="popup">
-            <div className="popup__content">
-                <form>
-                    <h1 className="govuk-heading-m">Rename product</h1>
+        <Trap active={isOpen}>
+            <div className="popup">
+                <div className="popup__content">
+                    <form>
+                        <h1 className="govuk-heading-m">Rename product</h1>
 
-                    {popupError && <span className="govuk-error-message">{popupError}</span>}
+                        {popupError && <span className="govuk-error-message">{popupError}</span>}
 
-                    <div className={`govuk-form-group ${popupError ? 'govuk-form-group--error' : ''}`}>
-                        <input
-                            className="govuk-input"
-                            id="product-name"
-                            type="text"
-                            defaultValue={defaultValue}
-                            onChange={(e) => {
-                                updateProductName(e.target.value);
-                            }}
-                        />
-                    </div>
+                        <div className={`govuk-form-group ${popupError ? 'govuk-form-group--error' : ''}`}>
+                            <input
+                                className="govuk-input"
+                                id="product-name"
+                                type="text"
+                                defaultValue={defaultValue}
+                                onChange={(e) => {
+                                    updateProductName(e.target.value);
+                                }}
+                            />
+                        </div>
 
-                    <span className="govuk-hint" id="edit-product-hint">
-                        You can enter up to 50 characters
-                    </span>
+                        <span className="govuk-hint" id="edit-product-hint">
+                            You can enter up to 50 characters
+                        </span>
 
-                    <button className="govuk-button govuk-button--secondary" onClick={cancelActionHandler}>
-                        Cancel
-                    </button>
-
-                    {showSubmitButton && (
-                        <button
-                            className="govuk-button"
-                            formAction={buildEditUrl(
-                                productId,
-                                csrfToken,
-                                removeExcessWhiteSpace(productName),
-                                serviceId,
-                            )}
-                            formMethod="post"
-                            type="submit"
-                            id="popup-edit-product-name-button"
-                        >
-                            Save
+                        <button className="govuk-button govuk-button--secondary" onClick={cancelActionHandler}>
+                            Cancel
                         </button>
-                    )}
-                </form>
+
+                        {showSubmitButton && (
+                            <button
+                                className="govuk-button"
+                                formAction={buildEditUrl(
+                                    productId,
+                                    csrfToken,
+                                    removeExcessWhiteSpace(productName),
+                                    serviceId,
+                                )}
+                                formMethod="post"
+                                type="submit"
+                                id="popup-edit-product-name-button"
+                            >
+                                Save
+                            </button>
+                        )}
+                    </form>
+                </div>
             </div>
-        </div>
+        </Trap>
     );
 };
 

--- a/repos/fdbt-site/src/components/Trap.tsx
+++ b/repos/fdbt-site/src/components/Trap.tsx
@@ -1,0 +1,19 @@
+import FocusTrap from 'focus-trap-react';
+import React, { ReactElement, ReactNode } from 'react';
+
+interface TrapProps {
+    active: boolean;
+    children: ReactNode;
+}
+const Trap = ({ active, children }: TrapProps): ReactElement | null => {
+    return active ? (
+        <FocusTrap
+            focusTrapOptions={{
+                tabbableOptions: { displayCheck: 'none' },
+            }}
+        >
+            <div className="trap">{children}</div>
+        </FocusTrap>
+    ) : null;
+};
+export default Trap;

--- a/repos/fdbt-site/src/components/UnableToDeletePopup.tsx
+++ b/repos/fdbt-site/src/components/UnableToDeletePopup.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import Trap from './Trap';
 
 interface PopUpProps {
     csrfToken: string;
@@ -6,29 +7,33 @@ interface PopUpProps {
     passengerTypeName: string;
     cancelActionHandler: React.MouseEventHandler<HTMLButtonElement>;
     groupsInUse?: string[];
+    isOpen: boolean;
 }
 
 const UnableToDeletePopup = ({
     groupsInUse,
     passengerTypeName,
     cancelActionHandler,
+    isOpen,
 }: PopUpProps): ReactElement | null => (
-    <div className="popup">
-        <div className="popup__content">
-            <form>
-                <h1 className="govuk-heading-m">There is a problem</h1>
+    <Trap active={isOpen}>
+        <div className="popup">
+            <div className="popup__content">
+                <form>
+                    <h1 className="govuk-heading-m">There is a problem</h1>
 
-                <span className="govuk-hint" id="delete-hint">
-                    You cannot delete {passengerTypeName} because it is part of the following group(s):{' '}
-                    {groupsInUse?.join(', ')}
-                </span>
+                    <span className="govuk-hint" id="delete-hint">
+                        You cannot delete {passengerTypeName} because it is part of the following group(s):{' '}
+                        {groupsInUse?.join(', ')}
+                    </span>
 
-                <button className="govuk-button govuk-button" onClick={cancelActionHandler}>
-                    Ok
-                </button>
-            </form>
+                    <button className="govuk-button govuk-button" onClick={cancelActionHandler}>
+                        Ok
+                    </button>
+                </form>
+            </div>
         </div>
-    </div>
+    </Trap>
 );
 
 export default UnableToDeletePopup;

--- a/repos/fdbt-site/src/pages/manageFareDayEnd.tsx
+++ b/repos/fdbt-site/src/pages/manageFareDayEnd.tsx
@@ -80,6 +80,7 @@ const ManageFareDayEnd = ({ errors, csrfToken, fareDayEnd, referer, saved }: Man
                                     title="Success"
                                     text={`You have saved your fare day end time.`}
                                     okActionHandler={() => setShowSaved(false)}
+                                    isOpen={showSaved}
                                 />
                             )}
                         </CsrfForm>

--- a/repos/fdbt-site/src/pages/manageOperatorDetails.tsx
+++ b/repos/fdbt-site/src/pages/manageOperatorDetails.tsx
@@ -123,6 +123,7 @@ const ManageOperatorDetails = ({
                                     title="Success"
                                     text={`You have saved your operator details.`}
                                     okActionHandler={() => setShowSaved(false)}
+                                    isOpen={showSaved}
                                 />
                             )}
                         </CsrfForm>

--- a/repos/fdbt-site/src/pages/products/exports.tsx
+++ b/repos/fdbt-site/src/pages/products/exports.tsx
@@ -198,6 +198,7 @@ const Exports = ({ csrf, operatorHasProducts, initialExportStarted }: GlobalSett
                                 title="We are preparing your export"
                                 text="Your export will take a few seconds to show in the table below."
                                 okActionHandler={() => setShowExportPopup(false)}
+                                isOpen={showExportPopup}
                             />
                         )}
 

--- a/repos/fdbt-site/src/pages/products/multiOperatorProducts.tsx
+++ b/repos/fdbt-site/src/pages/products/multiOperatorProducts.tsx
@@ -57,6 +57,7 @@ const MultiOperatorProducts = ({ multiOperatorProducts, csrfToken }: MultiOperat
                                     setPopUpState(undefined);
                                 }}
                                 hintText="When you delete this product it will be removed from the system and will no longer be included in future exports."
+                                isOpen={!!popUpState.productId}
                             />
                         )}
                     </div>

--- a/repos/fdbt-site/src/pages/products/otherProducts.tsx
+++ b/repos/fdbt-site/src/pages/products/otherProducts.tsx
@@ -65,6 +65,7 @@ const OtherProducts = ({ otherProducts, csrfToken }: OtherProductsProps): ReactE
                                     setPopUpState(undefined);
                                 }}
                                 hintText="When you delete this product it will be removed from the system and will no longer be included in future exports."
+                                isOpen={!!popUpState.productId}
                             />
                         )}
                     </div>

--- a/repos/fdbt-site/src/pages/products/pointToPointProducts.tsx
+++ b/repos/fdbt-site/src/pages/products/pointToPointProducts.tsx
@@ -86,6 +86,7 @@ const PointToPointProducts = ({
                                     setPopUpState(undefined);
                                 }}
                                 hintText="When you delete this product it will be removed from the system and will no longer be included in future exports."
+                                isOpen={!!popUpState.productId}
                             />
                         )}
                     </div>

--- a/repos/fdbt-site/src/pages/products/productDetails.tsx
+++ b/repos/fdbt-site/src/pages/products/productDetails.tsx
@@ -182,11 +182,15 @@ const ProductDetails = ({
                     productId={productId}
                     serviceId={serviceId}
                     csrfToken={csrfToken}
+                    isOpen={editNamePopupOpen}
                 />
             )}
 
             {generateReturnPopupOpen && lineId && (
-                <GenerateReturnPopup cancelActionHandler={generateReturnCancelActionHandler} />
+                <GenerateReturnPopup
+                    cancelActionHandler={generateReturnCancelActionHandler}
+                    isOpen={generateReturnPopupOpen && !!lineId}
+                />
             )}
         </TwoThirdsLayout>
     );

--- a/repos/fdbt-site/src/pages/products/productDetails.tsx
+++ b/repos/fdbt-site/src/pages/products/productDetails.tsx
@@ -138,6 +138,12 @@ const ProductDetails = ({
                                         })}
                                         {serviceId && isSingle && (
                                             <form>
+                                                {generateReturnPopupOpen && lineId && (
+                                                    <GenerateReturnPopup
+                                                        cancelActionHandler={generateReturnCancelActionHandler}
+                                                        isOpen={generateReturnPopupOpen && !!lineId}
+                                                    />
+                                                )}
                                                 <button
                                                     className="govuk-link govuk-body align-top button-link govuk-!-margin-left-2 govuk-!-margin-bottom-0"
                                                     formAction={createGenerateReturnUrl(
@@ -183,13 +189,6 @@ const ProductDetails = ({
                     serviceId={serviceId}
                     csrfToken={csrfToken}
                     isOpen={editNamePopupOpen}
-                />
-            )}
-
-            {generateReturnPopupOpen && lineId && (
-                <GenerateReturnPopup
-                    cancelActionHandler={generateReturnCancelActionHandler}
-                    isOpen={generateReturnPopupOpen && !!lineId}
                 />
             )}
         </TwoThirdsLayout>

--- a/repos/fdbt-site/src/pages/viewCaps.tsx
+++ b/repos/fdbt-site/src/pages/viewCaps.tsx
@@ -255,8 +255,8 @@ const CapExpiryCard = ({ capExpiry: capExpiry, fareDayEnd }: CapExpiryCardProps)
                             {capExpiry === 'endOfCalendarDay'
                                 ? 'At the end of a calendar day'
                                 : capExpiry === '24hr'
-                                    ? 'At the end of a 24 hour period'
-                                    : 'Fare day end'}
+                                ? 'At the end of a 24 hour period'
+                                : 'Fare day end'}
                         </h4>
                         <p className="govuk-body-s govuk-!-margin-bottom-2">{expiryHintText[capExpiry]}</p>
 

--- a/repos/fdbt-site/src/pages/viewCaps.tsx
+++ b/repos/fdbt-site/src/pages/viewCaps.tsx
@@ -126,6 +126,7 @@ const ViewCaps = ({ caps, referer, capExpiry, fareDayEnd, viewCapErrors = [], cs
                     entityName={popUpState.capName}
                     deleteUrl={buildDeleteUrl(popUpState.capId, csrfToken)}
                     cancelActionHandler={cancelActionHandler}
+                    isOpen={!!popUpState.capId}
                 />
             ) : null}
         </BaseLayout>
@@ -254,8 +255,8 @@ const CapExpiryCard = ({ capExpiry: capExpiry, fareDayEnd }: CapExpiryCardProps)
                             {capExpiry === 'endOfCalendarDay'
                                 ? 'At the end of a calendar day'
                                 : capExpiry === '24hr'
-                                ? 'At the end of a 24 hour period'
-                                : 'Fare day end'}
+                                    ? 'At the end of a 24 hour period'
+                                    : 'Fare day end'}
                         </h4>
                         <p className="govuk-body-s govuk-!-margin-bottom-2">{expiryHintText[capExpiry]}</p>
 

--- a/repos/fdbt-site/src/pages/viewOperatorGroups.tsx
+++ b/repos/fdbt-site/src/pages/viewOperatorGroups.tsx
@@ -116,6 +116,7 @@ const ViewOperatorGroups = ({
                         entityName={popUpState.operatorGroupName}
                         deleteUrl={buildDeleteUrl(popUpState.operatorGroupId, csrfToken)}
                         cancelActionHandler={cancelActionHandler}
+                        isOpen={!!popUpState.operatorGroupId}
                     />
                 )}
             </div>

--- a/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
+++ b/repos/fdbt-site/src/pages/viewPassengerTypes.tsx
@@ -120,12 +120,14 @@ const ViewPassengerTypes = ({
                                 {...popUpState}
                                 csrfToken={csrfToken}
                                 cancelActionHandler={cancelActionHandler}
+                                isOpen={popUpState.groupsInUse?.length > 0}
                             />
                         ) : (
                             <DeleteConfirmationPopup
                                 entityName={popUpState.passengerTypeName}
                                 deleteUrl={buildDeleteUrl(popUpState.isGroup, popUpState.passengerTypeId, csrfToken)}
                                 cancelActionHandler={cancelActionHandler}
+                                isOpen={!!popUpState.passengerTypeId}
                             />
                         ))}
                 </div>

--- a/repos/fdbt-site/src/pages/viewPurchaseMethods.tsx
+++ b/repos/fdbt-site/src/pages/viewPurchaseMethods.tsx
@@ -107,6 +107,7 @@ const ViewPurchaseMethods = ({
                                 entityName={popUpState.entityName}
                                 deleteUrl={buildDeleteUrl(popUpState.entityId, csrfToken)}
                                 cancelActionHandler={cancelActionHandler}
+                                isOpen={!!popUpState.entityId}
                             />
                         )}
                     </div>

--- a/repos/fdbt-site/tests/components/GenerateReturnPopup.test.tsx
+++ b/repos/fdbt-site/tests/components/GenerateReturnPopup.test.tsx
@@ -5,7 +5,7 @@ import GenerateReturnPopup from '../../src/components/GenerateReturnPopup';
 describe('GenerateReturnPopup', () => {
     it('should render the GenerateReturnPopup', () => {
         const cancelActionHandler = jest.fn();
-        const wrapper = shallow(<GenerateReturnPopup cancelActionHandler={cancelActionHandler} />);
+        const wrapper = shallow(<GenerateReturnPopup cancelActionHandler={cancelActionHandler} isOpen={true} />);
         expect(wrapper).toMatchSnapshot();
 
         expect(cancelActionHandler).not.toHaveBeenCalled();

--- a/repos/fdbt-site/tests/components/InfoPopup.test.tsx
+++ b/repos/fdbt-site/tests/components/InfoPopup.test.tsx
@@ -6,7 +6,7 @@ describe('InfoPopup', () => {
     it('should render the InfoPopup', () => {
         const okActionHandler = jest.fn();
         const wrapper = shallow(
-            <InfoPopup title="my title" text="this is my text" okActionHandler={okActionHandler} />,
+            <InfoPopup title="my title" text="this is my text" okActionHandler={okActionHandler} isOpen={true} />,
         );
         expect(wrapper).toMatchSnapshot();
 

--- a/repos/fdbt-site/tests/components/__snapshots__/GenerateReturnPopup.test.tsx.snap
+++ b/repos/fdbt-site/tests/components/__snapshots__/GenerateReturnPopup.test.tsx.snap
@@ -1,29 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`GenerateReturnPopup should render the GenerateReturnPopup 1`] = `
-<div
-  className="popup"
+<Trap
+  active={true}
 >
   <div
-    className="popup__content"
+    className="popup"
   >
-    <h1
-      className="govuk-heading-m"
+    <div
+      className="popup__content"
     >
-      A return cannot be auto-generated for this product.
-    </h1>
-    <span
-      className="govuk-hint"
-      id="delete-hint"
-    >
-      Two singles must be created, one for inbound and one for outbound. They must have the same passenger type and not be expired. Services with one direction (circular services for example) cannot be used to generate returns.
-    </span>
-    <button
-      className="govuk-button govuk-button--secondary"
-      onClick={[MockFunction]}
-    >
-      Close
-    </button>
+      <h1
+        className="govuk-heading-m"
+      >
+        A return cannot be auto-generated for this product.
+      </h1>
+      <span
+        className="govuk-hint"
+        id="delete-hint"
+      >
+        Two singles must be created, one for inbound and one for outbound. They must have the same passenger type and not be expired. Services with one direction (circular services for example) cannot be used to generate returns.
+      </span>
+      <button
+        className="govuk-button govuk-button--secondary"
+        onClick={[MockFunction]}
+      >
+        Close
+      </button>
+    </div>
   </div>
-</div>
+</Trap>
 `;

--- a/repos/fdbt-site/tests/components/__snapshots__/InfoPopup.test.tsx.snap
+++ b/repos/fdbt-site/tests/components/__snapshots__/InfoPopup.test.tsx.snap
@@ -1,29 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InfoPopup should render the InfoPopup 1`] = `
-<div
-  className="popup"
+<Trap
+  active={true}
 >
   <div
-    className="popup__content"
+    className="popup"
   >
-    <h1
-      className="govuk-heading-m"
+    <div
+      className="popup__content"
     >
-      my title
-    </h1>
-    <span
-      className="govuk-hint"
-      id="info-hint"
-    >
-      this is my text
-    </span>
-    <button
-      className="govuk-button"
-      onClick={[MockFunction]}
-    >
-      Ok
-    </button>
+      <h1
+        className="govuk-heading-m"
+      >
+        my title
+      </h1>
+      <span
+        className="govuk-hint"
+        id="info-hint"
+      >
+        this is my text
+      </span>
+      <button
+        className="govuk-button"
+        onClick={[MockFunction]}
+      >
+        Ok
+      </button>
+    </div>
   </div>
-</div>
+</Trap>
 `;

--- a/repos/fdbt-site/tests/pages/__snapshots__/manageFareDayEnd.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/manageFareDayEnd.test.tsx.snap
@@ -273,6 +273,7 @@ exports[`pages manage passenger types should render popup if saved 1`] = `
             value="Save"
           />
           <InfoPopup
+            isOpen={true}
             okActionHandler={[Function]}
             text="You have saved your fare day end time."
             title="Success"

--- a/repos/fdbt-site/tests/pages/__snapshots__/manageOperatorDetails.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/manageOperatorDetails.test.tsx.snap
@@ -1425,6 +1425,7 @@ exports[`pages manage operator details should render popup if saved 1`] = `
             value="Save"
           />
           <InfoPopup
+            isOpen={true}
             okActionHandler={[Function]}
             text="You have saved your operator details."
             title="Success"


### PR DESCRIPTION
## Description

EXPECTED - [3.2.2 On Input](https://www.w3.org/TR/WCAG22/#on-input)
When a user inputs information or interacts with a control, it does not result in a substantial change to the page, the spawning of a pop-up window, an additional change of keyboard focus, or any other change that could confuse or disorient the user unless the user is informed of the change ahead of time.

more about KB focus - [WebAIM: Keyboard Accessibility](https://webaim.org/techniques/keyboard/)

ACTUAL
OCCURENCE 1 - [Manage Fare Day End - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/manageFareDayEnd)
clicking save:

Open image-20240626-085018.png
image-20240626-085018.png
Clicking tab until user reaches save button

pressing enter

keyboard focus is lost

clicking tab once reveals focus at the top of the page:

Open image-20240626-085401.png
image-20240626-085401.png
OCCURENCE 2 - [Manage Operator Details - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/manageOperatorDetails)
Open image-20240626-094904.png
image-20240626-094904.png
OCCURENCE 3 - EXPORT [Exports (dft-cfd.com)](https://preprod.dft-cfd.com/products/exports)
Open image-20240626-114036.png
image-20240626-114036.png
PROPOSED SOLUTION
This might be helpful -  [Need to move tab focus to the popup element - Microsoft Q&A](https://learn.microsoft.com/en-us/answers/questions/27158/need-to-move-tab-focus-to-the-popup-element)

## Testing instructions

Check code or test pages
