### PR TITLE
fix: Header empty

### DIFF
--- a/repos/fdbt-site/src/pages/products/exports.tsx
+++ b/repos/fdbt-site/src/pages/products/exports.tsx
@@ -161,7 +161,9 @@ const Exports = ({ csrf, operatorHasProducts, initialExportStarted }: GlobalSett
                                         <th scope="col" className="govuk-table__header">
                                             Export status
                                         </th>
-                                        <th scope="col" className="govuk-table__header"></th>
+                                        <th scope="col" className="govuk-table__header">
+                                            <span className="govuk-visually-hidden">Actions</span>
+                                        </th>
                                     </tr>
                                 </thead>
 

--- a/repos/fdbt-site/src/pages/products/multiOperatorProducts.tsx
+++ b/repos/fdbt-site/src/pages/products/multiOperatorProducts.tsx
@@ -101,8 +101,12 @@ const MultiOperatorProductsTable = (
                         <th scope="col" className="govuk-table__header">
                             Product status
                         </th>
-                        <th scope="col" className="govuk-table__header" />
-                        <th scope="col" className="govuk-table__header" />
+                        <th scope="col" className="govuk-table__header">
+                            <span className="govuk-visually-hidden">Copy</span>
+                        </th>
+                        <th scope="col" className="govuk-table__header">
+                            <span className="govuk-visually-hidden">Delete</span>
+                        </th>
                     </tr>
                 </thead>
                 <tbody className="govuk-table__body">

--- a/repos/fdbt-site/tests/pages/products/__snapshots__/multiOperatorProducts.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/products/__snapshots__/multiOperatorProducts.test.tsx.snap
@@ -85,11 +85,23 @@ exports[`myfares pages multiOperatorProducts should render correctly when no non
                 <th
                   className="govuk-table__header"
                   scope="col"
-                />
+                >
+                  <span
+                    className="govuk-visually-hidden"
+                  >
+                    Copy
+                  </span>
+                </th>
                 <th
                   className="govuk-table__header"
                   scope="col"
-                />
+                >
+                  <span
+                    className="govuk-visually-hidden"
+                  >
+                    Delete
+                  </span>
+                </th>
               </tr>
             </thead>
             <tbody
@@ -195,11 +207,23 @@ exports[`myfares pages multiOperatorProducts should render correctly when some n
                 <th
                   className="govuk-table__header"
                   scope="col"
-                />
+                >
+                  <span
+                    className="govuk-visually-hidden"
+                  >
+                    Copy
+                  </span>
+                </th>
                 <th
                   className="govuk-table__header"
                   scope="col"
-                />
+                >
+                  <span
+                    className="govuk-visually-hidden"
+                  >
+                    Delete
+                  </span>
+                </th>
               </tr>
             </thead>
             <tbody


### PR DESCRIPTION
## Description

EXPECTED
The <th> element helps associate table cells with the correct row/column headers. A <th> that contains no text may result in cells with missing or incorrect header information.

ACTUAL
OCCURENCE 1 - [Exports (dft-cfd.com)](https://preprod.dft-cfd.com/products/exports)
Open image-20240625-141933.png
image-20240625-141933.png
<th scope="col" class="govuk-table__header"></th>

OCCURENCE 2 - [Multi-operator products - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/products/multiOperatorProducts)
Open image-20240625-145015.png
image-20240625-145015.png
<th scope="col" class="govuk-table__header"></th>

<th scope="col" class="govuk-table__header"></th>

OCCURENCE 3 - [Other products - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/products/otherProducts)

OCCURENCE 4 - 

SOLUTION
If the table cell is a header, provide text within the cell that describes the column or row. If the cell is not a header or must remain empty (such as the top-left cell in a data table), make the cell a <td> rather than a <th>.

## Testing instructions

Code review / going to pages and use wave tool
