### PR TITLE
fix: Skip to main content button does not work

### DIFF
--- a/repos/fdbt-site/src/layout/Layout.tsx
+++ b/repos/fdbt-site/src/layout/Layout.tsx
@@ -60,7 +60,9 @@ export const BaseLayout = ({
             {referer && <GlobalSettingReturnHeader />}
 
             <div className="govuk-width-container">
-                <main className="govuk-main-wrapper">{children}</main>
+                <main className="govuk-main-wrapper" id="main-content">
+                    {children}
+                </main>
                 {!hideHelp && <Help />}
             </div>
             <Footer />


### PR DESCRIPTION
## Description

EXPECTED: Clicking tab after loading a landing page takes a user to the skip to main content button which should skip straight to the first header or actionable button in the main content. 

Open image-20240620-102948.png
image-20240620-102948.png
ACTUAL:

The link doesn't work either by clicking on the link with a cursor or pressing enter

STEPS TO REPRODUCE:

Load CFDS

click tab

click enter

 

What It Means
A skip navigation link exists, but the target for the link does not exist or the link is not keyboard accessible.

Why It Matters
A link to jump over navigation or jump to the main content of the page assists keyboard users only if the link is properly functioning and is keyboard accessible.

How to Fix It
Ensure that the target for the link exists and that the link is not hidden with CSS display:none or visibility:hidden.

The Algorithm... in English
An in-page link contains the words "skip" or "jump" and is hidden with CSS display:none or visibility:hidden, or the link has an href attribute that does not match the id value of another element within the page or the name attribute value of an anchor element within the page.

Standards and Guidelines
[2.1.1 Keyboard (Level A)](https://webaim.org/standards/wcag/checklist#sc2.1.1)

[2.4.1 Bypass Blocks (Level A)](https://webaim.org/standards/wcag/checklist#sc2.4.1)

## Testing instructions

Testing on homepage using wave tool or code review
