### PR TITLE
fix: Elements missing from labels

### DIFF
--- a/repos/fdbt-site/src/components/ExpirySelector.tsx
+++ b/repos/fdbt-site/src/components/ExpirySelector.tsx
@@ -54,7 +54,7 @@ const ExpirySelector = ({
                         name={quantityName}
                         type="text"
                         id={quantityId}
-                        aria-describedby={hintId || ''}
+                        aria-labelledby={hintId || ''}
                         defaultValue={defaultDuration || ''}
                     />
                 </FormElementWrapper>
@@ -63,6 +63,7 @@ const ExpirySelector = ({
                         className="govuk-select govuk-select--width-3 expiry-selector-units"
                         name={unitName}
                         id={unitId}
+                        aria-labelledby={hintId || ''}
                         defaultValue={defaultUnit || ''}
                     >
                         <option value="" disabled key="select-one">

--- a/repos/fdbt-site/src/components/ProductRow.tsx
+++ b/repos/fdbt-site/src/components/ProductRow.tsx
@@ -28,21 +28,21 @@ export const renderTable = (
             <div className="govuk-!-margin-left-4 govuk-!-margin-right-2">
                 <FormGroupWrapper errors={errors} errorIds={[`multiple-product-name-${index}`]} hideErrorBar>
                     <>
-                        {index === 0 ? (
-                            <>
-                                <label className="govuk-label" htmlFor={`multiple-product-name-${index}`}>
-                                    <span className="govuk-visually-hidden">{`Product Name - Product ${
-                                        index + 1
-                                    }`}</span>
-                                    <span aria-hidden>Product name</span>
-                                </label>
-                                <span className="govuk-hint" id={`product-name-hint-${index}`}>
-                                    50 characters max
-                                </span>{' '}
-                            </>
-                        ) : (
-                            ''
-                        )}
+                        <>
+                            <label
+                                className={`govuk-label ${index > 0 ? 'govuk-visually-hidden' : ''}`}
+                                htmlFor={`multiple-product-name-${index}`}
+                            >
+                                <span className="govuk-visually-hidden">{`Product Name - Product ${index + 1}`}</span>
+                                <span aria-hidden>Product name</span>
+                            </label>
+                            <span
+                                className={`govuk-hint ${index > 0 ? 'govuk-visually-hidden' : ''}`}
+                                id={`product-name-hint-${index}`}
+                            >
+                                50 characters max
+                            </span>{' '}
+                        </>
 
                         <FormElementWrapper
                             errors={errors}
@@ -56,7 +56,7 @@ export const renderTable = (
                                 id={`multiple-product-name-${index}`}
                                 name={`multipleProductNameInput${index}`}
                                 type="text"
-                                aria-describedby={`product-name-hint-${index}`}
+                                aria-labelledby={`product-name-hint-${index}`}
                                 maxLength={50}
                                 defaultValue={userInput[index]?.productName ?? ''}
                             />
@@ -67,21 +67,23 @@ export const renderTable = (
             <div className="govuk-!-margin-left-2 govuk-!-margin-right-2">
                 <FormGroupWrapper errors={errors} errorIds={[`multiple-product-price-${index}`]} hideErrorBar>
                     <>
-                        {index === 0 ? (
-                            <>
-                                <label className="govuk-label" htmlFor={`multiple-product-price-${index}`}>
-                                    <span className="govuk-visually-hidden">{`Product Price, in pounds - Product ${
-                                        index + 1
-                                    }`}</span>
-                                    <span aria-hidden>Price</span>
-                                </label>
-                                <span className="govuk-hint" id={`product-price-hint-${index}`}>
-                                    e.g. 2.99
-                                </span>
-                            </>
-                        ) : (
-                            ''
-                        )}
+                        <>
+                            <label
+                                className={`govuk-label ${index > 0 ? 'govuk-visually-hidden' : ''}`}
+                                htmlFor={`multiple-product-price-${index}`}
+                            >
+                                <span className="govuk-visually-hidden">{`Product Price, in pounds - Product ${
+                                    index + 1
+                                }`}</span>
+                                <span aria-hidden>Price</span>
+                            </label>
+                            <span
+                                className={`govuk-hint ${index > 0 ? 'govuk-visually-hidden' : ''}`}
+                                id={`product-price-hint-${index}`}
+                            >
+                                e.g. 2.99
+                            </span>
+                        </>
 
                         <div className="govuk-currency-input">
                             <div className="govuk-currency-input__inner">
@@ -98,7 +100,7 @@ export const renderTable = (
                                         name={`multipleProductPriceInput${index}`}
                                         data-non-numeric
                                         type="text"
-                                        aria-describedby={`product-price-hint-${index}`}
+                                        aria-labelledby={`product-price-hint-${index}`}
                                         id={`multiple-product-price-${index}`}
                                         defaultValue={userInput[index]?.productPrice ?? ''}
                                     />
@@ -119,25 +121,24 @@ export const renderTable = (
                         hideErrorBar
                     >
                         <>
-                            {index === 0 ? (
-                                <>
-                                    <label className="govuk-label" htmlFor="product-details-period-duration">
-                                        Period duration
-                                    </label>
-                                    <span className="govuk-hint" id="product-period-duration-hint">
-                                        For example, 3 days
-                                    </span>
-                                </>
-                            ) : (
-                                ''
-                            )}
+                            <>
+                                <p className={`govuk-label ${index > 0 ? 'govuk-visually-hidden' : ''}`}>
+                                    Period duration
+                                </p>
+                                <span
+                                    className={`govuk-hint ${index > 0 ? 'govuk-visually-hidden' : ''}`}
+                                    id={`product-period-duration-hint-${index}`}
+                                >
+                                    For example, 3 days
+                                </span>
+                            </>
 
                             <ExpirySelector
                                 defaultDuration={userInput[index]?.productDuration ?? ''}
                                 defaultUnit={userInput[index]?.productDurationUnits ?? undefined}
                                 quantityName={`multipleProductDurationInput${index}`}
                                 quantityId={`product-details-period-duration-quantity-${index}`}
-                                hintId="product-period-duration-hint"
+                                hintId={`product-period-duration-hint-${index}`}
                                 unitName={`multipleProductDurationUnitsInput${index}`}
                                 unitId={`product-details-period-duration-unit-${index}`}
                                 carnet={false}
@@ -203,10 +204,8 @@ export const renderTable = (
                             <>
                                 {index === 0 ? (
                                     <>
-                                        <label className="govuk-label" htmlFor="product-details-carnet-expiry">
-                                            Carnet expiry
-                                        </label>
-                                        <span className="govuk-hint" id="product-carnet-expiry-hint">
+                                        <p className="govuk-label">Carnet expiry</p>
+                                        <span className="govuk-hint" id={`product-carnet-expiry-hint-${index}`}>
                                             e.g. 2 months
                                         </span>
                                     </>
@@ -219,7 +218,7 @@ export const renderTable = (
                                     defaultUnit={userInput[index]?.carnetDetails?.expiryUnit ?? undefined}
                                     quantityName={`carnetExpiryDurationInput${index}`}
                                     quantityId={`product-details-carnet-expiry-quantity-${index}`}
-                                    hintId="product-carnet-expiry-hint"
+                                    hintId={`product-carnet-expiry-hint-${index}`}
                                     unitName={`carnetExpiryUnitInput${index}`}
                                     unitId={`product-details-carnet-expiry-unit-${index}`}
                                     carnet

--- a/repos/fdbt-site/src/pages/feedback.tsx
+++ b/repos/fdbt-site/src/pages/feedback.tsx
@@ -56,6 +56,7 @@ const Feedback = ({ csrfToken, feedbackSubmitted }: FeedbackProps): ReactElement
                             id="hear-about-service-question"
                             name="hearAboutServiceQuestion"
                             rows={3}
+                            aria-labelledby="hear-about-service-header"
                         />
                     </fieldset>
                 </div>
@@ -73,6 +74,7 @@ const Feedback = ({ csrfToken, feedbackSubmitted }: FeedbackProps): ReactElement
                             id="general-feedback-question"
                             name="generalFeedbackQuestion"
                             rows={6}
+                            aria-labelledby="general-feedback-header"
                         />
                     </fieldset>
                 </div>

--- a/repos/fdbt-site/src/pages/manageFareDayEnd.tsx
+++ b/repos/fdbt-site/src/pages/manageFareDayEnd.tsx
@@ -57,22 +57,20 @@ const ManageFareDayEnd = ({ errors, csrfToken, fareDayEnd, referer, saved }: Man
 
                         <CsrfForm action="/api/manageFareDayEnd" method="post" csrfToken={csrfToken}>
                             <FormGroupWrapper errorIds={[fareDayEndInputId]} errors={errors}>
-                                <fieldset className="govuk-fieldset">
-                                    <FormElementWrapper
-                                        errors={errors}
-                                        errorId={fareDayEndInputId}
-                                        errorClass="govuk-input--error"
-                                    >
-                                        <input
-                                            className={`govuk-input govuk-input--width-5 govuk-!-margin-right-4`}
-                                            id={fareDayEndInputId}
-                                            name={`fareDayEnd`}
-                                            aria-describedby="fare-day-text"
-                                            type="text"
-                                            defaultValue={fareDayEnd}
-                                        />
-                                    </FormElementWrapper>
-                                </fieldset>
+                                <FormElementWrapper
+                                    errors={errors}
+                                    errorId={fareDayEndInputId}
+                                    errorClass="govuk-input--error"
+                                >
+                                    <input
+                                        className={`govuk-input govuk-input--width-5 govuk-!-margin-right-4`}
+                                        id={fareDayEndInputId}
+                                        name={`fareDayEnd`}
+                                        aria-labelledby="fare-day-text"
+                                        type="text"
+                                        defaultValue={fareDayEnd}
+                                    />
+                                </FormElementWrapper>
                             </FormGroupWrapper>
                             <input type="submit" value={`Save`} className="govuk-button" />
                             {showSaved && (

--- a/repos/fdbt-site/src/pages/managePassengerTypes.tsx
+++ b/repos/fdbt-site/src/pages/managePassengerTypes.tsx
@@ -251,9 +251,9 @@ const ManagePassengerTypes = ({
                         </legend>
 
                         <div className={`govuk-form-group${hasError(errors, 'age-range-min')}`}>
-                            <div id="age-range-min" className="govuk-hint">
+                            <label id="age-range-min" className="govuk-hint" htmlFor="ageRangeMin">
                                 Minimum age (if applicable)
-                            </div>
+                            </label>
 
                             <FormElementWrapper
                                 errors={errors}
@@ -264,15 +264,16 @@ const ManagePassengerTypes = ({
                                     className="govuk-input govuk-input--width-5"
                                     name="ageRangeMin"
                                     type="text"
+                                    id="ageRangeMin"
                                     defaultValue={ageRangeMin}
                                 />
                             </FormElementWrapper>
                         </div>
 
                         <div className={`govuk-form-group${hasError(errors, 'age-range-max')}`}>
-                            <div id="age-range-max" className="govuk-hint">
+                            <label id="age-range-max" className="govuk-hint" htmlFor="ageRangeMax">
                                 Maximum age (if applicable)
-                            </div>
+                            </label>
 
                             <FormElementWrapper
                                 errors={errors}
@@ -283,6 +284,7 @@ const ManagePassengerTypes = ({
                                     className="govuk-input govuk-input--width-5"
                                     name="ageRangeMax"
                                     type="text"
+                                    id="ageRangeMax"
                                     defaultValue={ageRangeMax}
                                 />
                             </FormElementWrapper>

--- a/repos/fdbt-site/src/pages/searchOperators.tsx
+++ b/repos/fdbt-site/src/pages/searchOperators.tsx
@@ -79,7 +79,7 @@ export const showSelectedOperators = (
                     errors.length > 0 && errors[0].id == 'operator-group-name' ? 'govuk-form-group--error' : ''
                 }`}
             >
-                <fieldset className="govuk-fieldset" aria-describedby="selected-operators">
+                <fieldset className="govuk-fieldset">
                     <legend className="govuk-fieldset__legend--m">
                         <h3 className="govuk-fieldset__heading" id="operator-group-name-heading">
                             Enter a name for this group
@@ -96,6 +96,7 @@ export const showSelectedOperators = (
                         className={`govuk-input ${
                             errors.length > 0 && errors[0].id == 'operator-group-name' ? 'govuk-input--error' : ''
                         }`}
+                        aria-labelledby="operator-group-name-heading"
                         name="operatorGroupName"
                         type="text"
                         key="operator-group-name"
@@ -176,7 +177,7 @@ export const renderSearchBox = (
     });
     return (
         <div className={`govuk-form-group ${searchInputErrors.length > 0 ? 'govuk-form-group--error' : ''}`}>
-            <fieldset className="govuk-fieldset" aria-describedby={fieldsetProps.heading.id}>
+            <fieldset className="govuk-fieldset">
                 <legend className={fieldsetProps.legend.className}>
                     <h2 className={fieldsetProps.heading.className} id={fieldsetProps.heading.id}>
                         {fieldsetProps.heading.content}

--- a/repos/fdbt-site/src/pages/selectTimeRestrictions.tsx
+++ b/repos/fdbt-site/src/pages/selectTimeRestrictions.tsx
@@ -79,7 +79,7 @@ const SelectTimeRestrictions = ({
                                             (!!selectedId && isEditing)
                                         }
                                     />
-                                    <label className="govuk-label govuk-radios__label" htmlFor="yes-choice">
+                                    <label className="govuk-label govuk-radios__label" htmlFor="valid-days-required">
                                         Yes
                                     </label>
                                 </div>
@@ -117,7 +117,10 @@ const SelectTimeRestrictions = ({
                                         data-aria-controls="conditional-time-restriction-2"
                                         defaultChecked={!selectedId}
                                     />
-                                    <label className="govuk-label govuk-radios__label" htmlFor="no-choice">
+                                    <label
+                                        className="govuk-label govuk-radios__label"
+                                        htmlFor="valid-days-not-required"
+                                    >
                                         No
                                     </label>
                                 </div>

--- a/repos/fdbt-site/tests/components/__snapshots__/ExpirySelector.test.tsx.snap
+++ b/repos/fdbt-site/tests/components/__snapshots__/ExpirySelector.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`ExpirySelector should render the selector for a carnet 1`] = `
     hideText={true}
   >
     <input
-      aria-describedby=""
+      aria-labelledby=""
       className="govuk-input govuk-input--width-3"
       defaultValue=""
       id="test-quantity-id"
@@ -27,6 +27,7 @@ exports[`ExpirySelector should render the selector for a carnet 1`] = `
     hideText={true}
   >
     <select
+      aria-labelledby=""
       className="govuk-select govuk-select--width-3 expiry-selector-units"
       defaultValue=""
       id="test-unit-id"
@@ -92,7 +93,7 @@ exports[`ExpirySelector should render the selector for a non-carnet 1`] = `
     hideText={true}
   >
     <input
-      aria-describedby=""
+      aria-labelledby=""
       className="govuk-input govuk-input--width-3"
       defaultValue=""
       id="test-quantity-id"
@@ -107,6 +108,7 @@ exports[`ExpirySelector should render the selector for a non-carnet 1`] = `
     hideText={true}
   >
     <select
+      aria-labelledby=""
       className="govuk-select govuk-select--width-3 expiry-selector-units"
       defaultValue=""
       id="test-unit-id"
@@ -166,7 +168,7 @@ exports[`ExpirySelector should render the selector for a school ticket 1`] = `
     hideText={true}
   >
     <input
-      aria-describedby=""
+      aria-labelledby=""
       className="govuk-input govuk-input--width-3"
       defaultValue=""
       id="test-quantity-id"
@@ -181,6 +183,7 @@ exports[`ExpirySelector should render the selector for a school ticket 1`] = `
     hideText={true}
   >
     <select
+      aria-labelledby=""
       className="govuk-select govuk-select--width-3 expiry-selector-units"
       defaultValue=""
       id="test-unit-id"

--- a/repos/fdbt-site/tests/components/__snapshots__/ProductRow.test.tsx.snap
+++ b/repos/fdbt-site/tests/components/__snapshots__/ProductRow.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`product row renders the right amount of rows for a flatFare ticket 1`] 
           hideErrorBar={true}
         >
           <label
-            className="govuk-label"
+            className="govuk-label "
             htmlFor="multiple-product-name-0"
           >
             <span
@@ -42,7 +42,7 @@ exports[`product row renders the right amount of rows for a flatFare ticket 1`] 
             </span>
           </label>
           <span
-            className="govuk-hint"
+            className="govuk-hint "
             id="product-name-hint-0"
           >
             50 characters max
@@ -56,7 +56,7 @@ exports[`product row renders the right amount of rows for a flatFare ticket 1`] 
             hideText={true}
           >
             <input
-              aria-describedby="product-name-hint-0"
+              aria-labelledby="product-name-hint-0"
               className="govuk-input govuk-input--width-40 govuk-product-name-input__inner__input"
               defaultValue=""
               id="multiple-product-name-0"
@@ -80,7 +80,7 @@ exports[`product row renders the right amount of rows for a flatFare ticket 1`] 
           hideErrorBar={true}
         >
           <label
-            className="govuk-label"
+            className="govuk-label "
             htmlFor="multiple-product-price-0"
           >
             <span
@@ -95,7 +95,7 @@ exports[`product row renders the right amount of rows for a flatFare ticket 1`] 
             </span>
           </label>
           <span
-            className="govuk-hint"
+            className="govuk-hint "
             id="product-price-hint-0"
           >
             e.g. 2.99
@@ -119,7 +119,7 @@ exports[`product row renders the right amount of rows for a flatFare ticket 1`] 
                 hideText={true}
               >
                 <input
-                  aria-describedby="product-price-hint-0"
+                  aria-labelledby="product-price-hint-0"
                   className="govuk-input govuk-input--width-4 govuk-currency-input__inner__input"
                   data-non-numeric={true}
                   defaultValue=""
@@ -158,6 +158,28 @@ exports[`product row renders the right amount of rows for a flatFare ticket 1`] 
           errors={Array []}
           hideErrorBar={true}
         >
+          <label
+            className="govuk-label govuk-visually-hidden"
+            htmlFor="multiple-product-name-1"
+          >
+            <span
+              className="govuk-visually-hidden"
+            >
+              Product Name - Product 2
+            </span>
+            <span
+              aria-hidden={true}
+            >
+              Product name
+            </span>
+          </label>
+          <span
+            className="govuk-hint govuk-visually-hidden"
+            id="product-name-hint-1"
+          >
+            50 characters max
+          </span>
+           
           <FormElementWrapper
             addFormGroupError={false}
             errorClass="govuk-input--error"
@@ -166,7 +188,7 @@ exports[`product row renders the right amount of rows for a flatFare ticket 1`] 
             hideText={true}
           >
             <input
-              aria-describedby="product-name-hint-1"
+              aria-labelledby="product-name-hint-1"
               className="govuk-input govuk-input--width-40 govuk-product-name-input__inner__input"
               defaultValue=""
               id="multiple-product-name-1"
@@ -189,6 +211,27 @@ exports[`product row renders the right amount of rows for a flatFare ticket 1`] 
           errors={Array []}
           hideErrorBar={true}
         >
+          <label
+            className="govuk-label govuk-visually-hidden"
+            htmlFor="multiple-product-price-1"
+          >
+            <span
+              className="govuk-visually-hidden"
+            >
+              Product Price, in pounds - Product 2
+            </span>
+            <span
+              aria-hidden={true}
+            >
+              Price
+            </span>
+          </label>
+          <span
+            className="govuk-hint govuk-visually-hidden"
+            id="product-price-hint-1"
+          >
+            e.g. 2.99
+          </span>
           <div
             className="govuk-currency-input"
           >
@@ -208,7 +251,7 @@ exports[`product row renders the right amount of rows for a flatFare ticket 1`] 
                 hideText={true}
               >
                 <input
-                  aria-describedby="product-price-hint-1"
+                  aria-labelledby="product-price-hint-1"
                   className="govuk-input govuk-input--width-4 govuk-currency-input__inner__input"
                   data-non-numeric={true}
                   defaultValue=""
@@ -247,6 +290,28 @@ exports[`product row renders the right amount of rows for a flatFare ticket 1`] 
           errors={Array []}
           hideErrorBar={true}
         >
+          <label
+            className="govuk-label govuk-visually-hidden"
+            htmlFor="multiple-product-name-2"
+          >
+            <span
+              className="govuk-visually-hidden"
+            >
+              Product Name - Product 3
+            </span>
+            <span
+              aria-hidden={true}
+            >
+              Product name
+            </span>
+          </label>
+          <span
+            className="govuk-hint govuk-visually-hidden"
+            id="product-name-hint-2"
+          >
+            50 characters max
+          </span>
+           
           <FormElementWrapper
             addFormGroupError={false}
             errorClass="govuk-input--error"
@@ -255,7 +320,7 @@ exports[`product row renders the right amount of rows for a flatFare ticket 1`] 
             hideText={true}
           >
             <input
-              aria-describedby="product-name-hint-2"
+              aria-labelledby="product-name-hint-2"
               className="govuk-input govuk-input--width-40 govuk-product-name-input__inner__input"
               defaultValue=""
               id="multiple-product-name-2"
@@ -278,6 +343,27 @@ exports[`product row renders the right amount of rows for a flatFare ticket 1`] 
           errors={Array []}
           hideErrorBar={true}
         >
+          <label
+            className="govuk-label govuk-visually-hidden"
+            htmlFor="multiple-product-price-2"
+          >
+            <span
+              className="govuk-visually-hidden"
+            >
+              Product Price, in pounds - Product 3
+            </span>
+            <span
+              aria-hidden={true}
+            >
+              Price
+            </span>
+          </label>
+          <span
+            className="govuk-hint govuk-visually-hidden"
+            id="product-price-hint-2"
+          >
+            e.g. 2.99
+          </span>
           <div
             className="govuk-currency-input"
           >
@@ -297,7 +383,7 @@ exports[`product row renders the right amount of rows for a flatFare ticket 1`] 
                 hideText={true}
               >
                 <input
-                  aria-describedby="product-price-hint-2"
+                  aria-labelledby="product-price-hint-2"
                   className="govuk-input govuk-input--width-4 govuk-currency-input__inner__input"
                   data-non-numeric={true}
                   defaultValue=""
@@ -342,7 +428,7 @@ exports[`product row renders the right amount of rows for a flatfare carnet 1`] 
           hideErrorBar={true}
         >
           <label
-            className="govuk-label"
+            className="govuk-label "
             htmlFor="multiple-product-name-0"
           >
             <span
@@ -357,7 +443,7 @@ exports[`product row renders the right amount of rows for a flatfare carnet 1`] 
             </span>
           </label>
           <span
-            className="govuk-hint"
+            className="govuk-hint "
             id="product-name-hint-0"
           >
             50 characters max
@@ -371,7 +457,7 @@ exports[`product row renders the right amount of rows for a flatfare carnet 1`] 
             hideText={true}
           >
             <input
-              aria-describedby="product-name-hint-0"
+              aria-labelledby="product-name-hint-0"
               className="govuk-input govuk-input--width-40 govuk-product-name-input__inner__input"
               defaultValue=""
               id="multiple-product-name-0"
@@ -395,7 +481,7 @@ exports[`product row renders the right amount of rows for a flatfare carnet 1`] 
           hideErrorBar={true}
         >
           <label
-            className="govuk-label"
+            className="govuk-label "
             htmlFor="multiple-product-price-0"
           >
             <span
@@ -410,7 +496,7 @@ exports[`product row renders the right amount of rows for a flatfare carnet 1`] 
             </span>
           </label>
           <span
-            className="govuk-hint"
+            className="govuk-hint "
             id="product-price-hint-0"
           >
             e.g. 2.99
@@ -434,7 +520,7 @@ exports[`product row renders the right amount of rows for a flatfare carnet 1`] 
                 hideText={true}
               >
                 <input
-                  aria-describedby="product-price-hint-0"
+                  aria-labelledby="product-price-hint-0"
                   className="govuk-input govuk-input--width-4 govuk-currency-input__inner__input"
                   data-non-numeric={true}
                   defaultValue=""
@@ -507,15 +593,14 @@ exports[`product row renders the right amount of rows for a flatfare carnet 1`] 
           errors={Array []}
           hideErrorBar={true}
         >
-          <label
+          <p
             className="govuk-label"
-            htmlFor="product-details-carnet-expiry"
           >
             Carnet expiry
-          </label>
+          </p>
           <span
             className="govuk-hint"
-            id="product-carnet-expiry-hint"
+            id="product-carnet-expiry-hint-0"
           >
             e.g. 2 months
           </span>
@@ -524,7 +609,7 @@ exports[`product row renders the right amount of rows for a flatfare carnet 1`] 
             defaultDuration=""
             errors={Array []}
             hideFormGroupError={true}
-            hintId="product-carnet-expiry-hint"
+            hintId="product-carnet-expiry-hint-0"
             quantityId="product-details-carnet-expiry-quantity-0"
             quantityName="carnetExpiryDurationInput0"
             unitId="product-details-carnet-expiry-unit-0"
@@ -558,6 +643,28 @@ exports[`product row renders the right amount of rows for a flatfare carnet 1`] 
           errors={Array []}
           hideErrorBar={true}
         >
+          <label
+            className="govuk-label govuk-visually-hidden"
+            htmlFor="multiple-product-name-1"
+          >
+            <span
+              className="govuk-visually-hidden"
+            >
+              Product Name - Product 2
+            </span>
+            <span
+              aria-hidden={true}
+            >
+              Product name
+            </span>
+          </label>
+          <span
+            className="govuk-hint govuk-visually-hidden"
+            id="product-name-hint-1"
+          >
+            50 characters max
+          </span>
+           
           <FormElementWrapper
             addFormGroupError={false}
             errorClass="govuk-input--error"
@@ -566,7 +673,7 @@ exports[`product row renders the right amount of rows for a flatfare carnet 1`] 
             hideText={true}
           >
             <input
-              aria-describedby="product-name-hint-1"
+              aria-labelledby="product-name-hint-1"
               className="govuk-input govuk-input--width-40 govuk-product-name-input__inner__input"
               defaultValue=""
               id="multiple-product-name-1"
@@ -589,6 +696,27 @@ exports[`product row renders the right amount of rows for a flatfare carnet 1`] 
           errors={Array []}
           hideErrorBar={true}
         >
+          <label
+            className="govuk-label govuk-visually-hidden"
+            htmlFor="multiple-product-price-1"
+          >
+            <span
+              className="govuk-visually-hidden"
+            >
+              Product Price, in pounds - Product 2
+            </span>
+            <span
+              aria-hidden={true}
+            >
+              Price
+            </span>
+          </label>
+          <span
+            className="govuk-hint govuk-visually-hidden"
+            id="product-price-hint-1"
+          >
+            e.g. 2.99
+          </span>
           <div
             className="govuk-currency-input"
           >
@@ -608,7 +736,7 @@ exports[`product row renders the right amount of rows for a flatfare carnet 1`] 
                 hideText={true}
               >
                 <input
-                  aria-describedby="product-price-hint-1"
+                  aria-labelledby="product-price-hint-1"
                   className="govuk-input govuk-input--width-4 govuk-currency-input__inner__input"
                   data-non-numeric={true}
                   defaultValue=""
@@ -670,7 +798,7 @@ exports[`product row renders the right amount of rows for a flatfare carnet 1`] 
             defaultDuration=""
             errors={Array []}
             hideFormGroupError={true}
-            hintId="product-carnet-expiry-hint"
+            hintId="product-carnet-expiry-hint-1"
             quantityId="product-details-carnet-expiry-quantity-1"
             quantityName="carnetExpiryDurationInput1"
             unitId="product-details-carnet-expiry-unit-1"
@@ -710,7 +838,7 @@ exports[`product row renders the right amount of rows for a period carnet 1`] = 
           hideErrorBar={true}
         >
           <label
-            className="govuk-label"
+            className="govuk-label "
             htmlFor="multiple-product-name-0"
           >
             <span
@@ -725,7 +853,7 @@ exports[`product row renders the right amount of rows for a period carnet 1`] = 
             </span>
           </label>
           <span
-            className="govuk-hint"
+            className="govuk-hint "
             id="product-name-hint-0"
           >
             50 characters max
@@ -739,7 +867,7 @@ exports[`product row renders the right amount of rows for a period carnet 1`] = 
             hideText={true}
           >
             <input
-              aria-describedby="product-name-hint-0"
+              aria-labelledby="product-name-hint-0"
               className="govuk-input govuk-input--width-40 govuk-product-name-input__inner__input"
               defaultValue=""
               id="multiple-product-name-0"
@@ -763,7 +891,7 @@ exports[`product row renders the right amount of rows for a period carnet 1`] = 
           hideErrorBar={true}
         >
           <label
-            className="govuk-label"
+            className="govuk-label "
             htmlFor="multiple-product-price-0"
           >
             <span
@@ -778,7 +906,7 @@ exports[`product row renders the right amount of rows for a period carnet 1`] = 
             </span>
           </label>
           <span
-            className="govuk-hint"
+            className="govuk-hint "
             id="product-price-hint-0"
           >
             e.g. 2.99
@@ -802,7 +930,7 @@ exports[`product row renders the right amount of rows for a period carnet 1`] = 
                 hideText={true}
               >
                 <input
-                  aria-describedby="product-price-hint-0"
+                  aria-labelledby="product-price-hint-0"
                   className="govuk-input govuk-input--width-4 govuk-currency-input__inner__input"
                   data-non-numeric={true}
                   defaultValue=""
@@ -828,15 +956,14 @@ exports[`product row renders the right amount of rows for a period carnet 1`] = 
           errors={Array []}
           hideErrorBar={true}
         >
-          <label
-            className="govuk-label"
-            htmlFor="product-details-period-duration"
+          <p
+            className="govuk-label "
           >
             Period duration
-          </label>
+          </p>
           <span
-            className="govuk-hint"
-            id="product-period-duration-hint"
+            className="govuk-hint "
+            id="product-period-duration-hint-0"
           >
             For example, 3 days
           </span>
@@ -845,7 +972,7 @@ exports[`product row renders the right amount of rows for a period carnet 1`] = 
             defaultDuration=""
             errors={Array []}
             hideFormGroupError={true}
-            hintId="product-period-duration-hint"
+            hintId="product-period-duration-hint-0"
             quantityId="product-details-period-duration-quantity-0"
             quantityName="multipleProductDurationInput0"
             school={true}
@@ -914,15 +1041,14 @@ exports[`product row renders the right amount of rows for a period carnet 1`] = 
           errors={Array []}
           hideErrorBar={true}
         >
-          <label
+          <p
             className="govuk-label"
-            htmlFor="product-details-carnet-expiry"
           >
             Carnet expiry
-          </label>
+          </p>
           <span
             className="govuk-hint"
-            id="product-carnet-expiry-hint"
+            id="product-carnet-expiry-hint-0"
           >
             e.g. 2 months
           </span>
@@ -931,7 +1057,7 @@ exports[`product row renders the right amount of rows for a period carnet 1`] = 
             defaultDuration=""
             errors={Array []}
             hideFormGroupError={true}
-            hintId="product-carnet-expiry-hint"
+            hintId="product-carnet-expiry-hint-0"
             quantityId="product-details-carnet-expiry-quantity-0"
             quantityName="carnetExpiryDurationInput0"
             unitId="product-details-carnet-expiry-unit-0"
@@ -971,7 +1097,7 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
           hideErrorBar={true}
         >
           <label
-            className="govuk-label"
+            className="govuk-label "
             htmlFor="multiple-product-name-0"
           >
             <span
@@ -986,7 +1112,7 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
             </span>
           </label>
           <span
-            className="govuk-hint"
+            className="govuk-hint "
             id="product-name-hint-0"
           >
             50 characters max
@@ -1000,7 +1126,7 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
             hideText={true}
           >
             <input
-              aria-describedby="product-name-hint-0"
+              aria-labelledby="product-name-hint-0"
               className="govuk-input govuk-input--width-40 govuk-product-name-input__inner__input"
               defaultValue=""
               id="multiple-product-name-0"
@@ -1024,7 +1150,7 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
           hideErrorBar={true}
         >
           <label
-            className="govuk-label"
+            className="govuk-label "
             htmlFor="multiple-product-price-0"
           >
             <span
@@ -1039,7 +1165,7 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
             </span>
           </label>
           <span
-            className="govuk-hint"
+            className="govuk-hint "
             id="product-price-hint-0"
           >
             e.g. 2.99
@@ -1063,7 +1189,7 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
                 hideText={true}
               >
                 <input
-                  aria-describedby="product-price-hint-0"
+                  aria-labelledby="product-price-hint-0"
                   className="govuk-input govuk-input--width-4 govuk-currency-input__inner__input"
                   data-non-numeric={true}
                   defaultValue=""
@@ -1089,15 +1215,14 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
           errors={Array []}
           hideErrorBar={true}
         >
-          <label
-            className="govuk-label"
-            htmlFor="product-details-period-duration"
+          <p
+            className="govuk-label "
           >
             Period duration
-          </label>
+          </p>
           <span
-            className="govuk-hint"
-            id="product-period-duration-hint"
+            className="govuk-hint "
+            id="product-period-duration-hint-0"
           >
             For example, 3 days
           </span>
@@ -1106,7 +1231,7 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
             defaultDuration=""
             errors={Array []}
             hideFormGroupError={true}
-            hintId="product-period-duration-hint"
+            hintId="product-period-duration-hint-0"
             quantityId="product-details-period-duration-quantity-0"
             quantityName="multipleProductDurationInput0"
             school={false}
@@ -1141,6 +1266,28 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
           errors={Array []}
           hideErrorBar={true}
         >
+          <label
+            className="govuk-label govuk-visually-hidden"
+            htmlFor="multiple-product-name-1"
+          >
+            <span
+              className="govuk-visually-hidden"
+            >
+              Product Name - Product 2
+            </span>
+            <span
+              aria-hidden={true}
+            >
+              Product name
+            </span>
+          </label>
+          <span
+            className="govuk-hint govuk-visually-hidden"
+            id="product-name-hint-1"
+          >
+            50 characters max
+          </span>
+           
           <FormElementWrapper
             addFormGroupError={false}
             errorClass="govuk-input--error"
@@ -1149,7 +1296,7 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
             hideText={true}
           >
             <input
-              aria-describedby="product-name-hint-1"
+              aria-labelledby="product-name-hint-1"
               className="govuk-input govuk-input--width-40 govuk-product-name-input__inner__input"
               defaultValue=""
               id="multiple-product-name-1"
@@ -1172,6 +1319,27 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
           errors={Array []}
           hideErrorBar={true}
         >
+          <label
+            className="govuk-label govuk-visually-hidden"
+            htmlFor="multiple-product-price-1"
+          >
+            <span
+              className="govuk-visually-hidden"
+            >
+              Product Price, in pounds - Product 2
+            </span>
+            <span
+              aria-hidden={true}
+            >
+              Price
+            </span>
+          </label>
+          <span
+            className="govuk-hint govuk-visually-hidden"
+            id="product-price-hint-1"
+          >
+            e.g. 2.99
+          </span>
           <div
             className="govuk-currency-input"
           >
@@ -1191,7 +1359,7 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
                 hideText={true}
               >
                 <input
-                  aria-describedby="product-price-hint-1"
+                  aria-labelledby="product-price-hint-1"
                   className="govuk-input govuk-input--width-4 govuk-currency-input__inner__input"
                   data-non-numeric={true}
                   defaultValue=""
@@ -1217,12 +1385,23 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
           errors={Array []}
           hideErrorBar={true}
         >
+          <p
+            className="govuk-label govuk-visually-hidden"
+          >
+            Period duration
+          </p>
+          <span
+            className="govuk-hint govuk-visually-hidden"
+            id="product-period-duration-hint-1"
+          >
+            For example, 3 days
+          </span>
           <ExpirySelector
             carnet={false}
             defaultDuration=""
             errors={Array []}
             hideFormGroupError={true}
-            hintId="product-period-duration-hint"
+            hintId="product-period-duration-hint-1"
             quantityId="product-details-period-duration-quantity-1"
             quantityName="multipleProductDurationInput1"
             school={false}
@@ -1257,6 +1436,28 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
           errors={Array []}
           hideErrorBar={true}
         >
+          <label
+            className="govuk-label govuk-visually-hidden"
+            htmlFor="multiple-product-name-2"
+          >
+            <span
+              className="govuk-visually-hidden"
+            >
+              Product Name - Product 3
+            </span>
+            <span
+              aria-hidden={true}
+            >
+              Product name
+            </span>
+          </label>
+          <span
+            className="govuk-hint govuk-visually-hidden"
+            id="product-name-hint-2"
+          >
+            50 characters max
+          </span>
+           
           <FormElementWrapper
             addFormGroupError={false}
             errorClass="govuk-input--error"
@@ -1265,7 +1466,7 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
             hideText={true}
           >
             <input
-              aria-describedby="product-name-hint-2"
+              aria-labelledby="product-name-hint-2"
               className="govuk-input govuk-input--width-40 govuk-product-name-input__inner__input"
               defaultValue=""
               id="multiple-product-name-2"
@@ -1288,6 +1489,27 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
           errors={Array []}
           hideErrorBar={true}
         >
+          <label
+            className="govuk-label govuk-visually-hidden"
+            htmlFor="multiple-product-price-2"
+          >
+            <span
+              className="govuk-visually-hidden"
+            >
+              Product Price, in pounds - Product 3
+            </span>
+            <span
+              aria-hidden={true}
+            >
+              Price
+            </span>
+          </label>
+          <span
+            className="govuk-hint govuk-visually-hidden"
+            id="product-price-hint-2"
+          >
+            e.g. 2.99
+          </span>
           <div
             className="govuk-currency-input"
           >
@@ -1307,7 +1529,7 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
                 hideText={true}
               >
                 <input
-                  aria-describedby="product-price-hint-2"
+                  aria-labelledby="product-price-hint-2"
                   className="govuk-input govuk-input--width-4 govuk-currency-input__inner__input"
                   data-non-numeric={true}
                   defaultValue=""
@@ -1333,12 +1555,23 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
           errors={Array []}
           hideErrorBar={true}
         >
+          <p
+            className="govuk-label govuk-visually-hidden"
+          >
+            Period duration
+          </p>
+          <span
+            className="govuk-hint govuk-visually-hidden"
+            id="product-period-duration-hint-2"
+          >
+            For example, 3 days
+          </span>
           <ExpirySelector
             carnet={false}
             defaultDuration=""
             errors={Array []}
             hideFormGroupError={true}
-            hintId="product-period-duration-hint"
+            hintId="product-period-duration-hint-2"
             quantityId="product-details-period-duration-quantity-2"
             quantityName="multipleProductDurationInput2"
             school={false}
@@ -1373,6 +1606,28 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
           errors={Array []}
           hideErrorBar={true}
         >
+          <label
+            className="govuk-label govuk-visually-hidden"
+            htmlFor="multiple-product-name-3"
+          >
+            <span
+              className="govuk-visually-hidden"
+            >
+              Product Name - Product 4
+            </span>
+            <span
+              aria-hidden={true}
+            >
+              Product name
+            </span>
+          </label>
+          <span
+            className="govuk-hint govuk-visually-hidden"
+            id="product-name-hint-3"
+          >
+            50 characters max
+          </span>
+           
           <FormElementWrapper
             addFormGroupError={false}
             errorClass="govuk-input--error"
@@ -1381,7 +1636,7 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
             hideText={true}
           >
             <input
-              aria-describedby="product-name-hint-3"
+              aria-labelledby="product-name-hint-3"
               className="govuk-input govuk-input--width-40 govuk-product-name-input__inner__input"
               defaultValue=""
               id="multiple-product-name-3"
@@ -1404,6 +1659,27 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
           errors={Array []}
           hideErrorBar={true}
         >
+          <label
+            className="govuk-label govuk-visually-hidden"
+            htmlFor="multiple-product-price-3"
+          >
+            <span
+              className="govuk-visually-hidden"
+            >
+              Product Price, in pounds - Product 4
+            </span>
+            <span
+              aria-hidden={true}
+            >
+              Price
+            </span>
+          </label>
+          <span
+            className="govuk-hint govuk-visually-hidden"
+            id="product-price-hint-3"
+          >
+            e.g. 2.99
+          </span>
           <div
             className="govuk-currency-input"
           >
@@ -1423,7 +1699,7 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
                 hideText={true}
               >
                 <input
-                  aria-describedby="product-price-hint-3"
+                  aria-labelledby="product-price-hint-3"
                   className="govuk-input govuk-input--width-4 govuk-currency-input__inner__input"
                   data-non-numeric={true}
                   defaultValue=""
@@ -1449,12 +1725,23 @@ exports[`product row renders the right amount of rows for a period ticket 1`] = 
           errors={Array []}
           hideErrorBar={true}
         >
+          <p
+            className="govuk-label govuk-visually-hidden"
+          >
+            Period duration
+          </p>
+          <span
+            className="govuk-hint govuk-visually-hidden"
+            id="product-period-duration-hint-3"
+          >
+            For example, 3 days
+          </span>
           <ExpirySelector
             carnet={false}
             defaultDuration=""
             errors={Array []}
             hideFormGroupError={true}
-            hintId="product-period-duration-hint"
+            hintId="product-period-duration-hint-3"
             quantityId="product-details-period-duration-quantity-3"
             quantityName="multipleProductDurationInput3"
             school={false}

--- a/repos/fdbt-site/tests/pages/__snapshots__/feedback.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/feedback.test.tsx.snap
@@ -59,6 +59,7 @@ exports[`pages feedback should render correctly after feedback has been successf
           How did you hear about our service?
         </legend>
         <textarea
+          aria-labelledby="hear-about-service-header"
           className="govuk-textarea"
           id="hear-about-service-question"
           name="hearAboutServiceQuestion"
@@ -78,6 +79,7 @@ exports[`pages feedback should render correctly after feedback has been successf
           Please let us know any feedback or suggestions for improvements you may have
         </legend>
         <textarea
+          aria-labelledby="general-feedback-header"
           className="govuk-textarea"
           id="general-feedback-question"
           name="generalFeedbackQuestion"
@@ -262,6 +264,7 @@ exports[`pages feedback should render correctly after the user tries to submit n
           How did you hear about our service?
         </legend>
         <textarea
+          aria-labelledby="hear-about-service-header"
           className="govuk-textarea"
           id="hear-about-service-question"
           name="hearAboutServiceQuestion"
@@ -281,6 +284,7 @@ exports[`pages feedback should render correctly after the user tries to submit n
           Please let us know any feedback or suggestions for improvements you may have
         </legend>
         <textarea
+          aria-labelledby="general-feedback-header"
           className="govuk-textarea"
           id="general-feedback-question"
           name="generalFeedbackQuestion"
@@ -441,6 +445,7 @@ exports[`pages feedback should render correctly when the page is first visited 1
           How did you hear about our service?
         </legend>
         <textarea
+          aria-labelledby="hear-about-service-header"
           className="govuk-textarea"
           id="hear-about-service-question"
           name="hearAboutServiceQuestion"
@@ -460,6 +465,7 @@ exports[`pages feedback should render correctly when the page is first visited 1
           Please let us know any feedback or suggestions for improvements you may have
         </legend>
         <textarea
+          aria-labelledby="general-feedback-header"
           className="govuk-textarea"
           id="general-feedback-question"
           name="generalFeedbackQuestion"

--- a/repos/fdbt-site/tests/pages/__snapshots__/manageFareDayEnd.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/manageFareDayEnd.test.tsx.snap
@@ -56,24 +56,20 @@ exports[`pages manage passenger types should render correctly 1`] = `
             }
             errors={Array []}
           >
-            <fieldset
-              className="govuk-fieldset"
+            <FormElementWrapper
+              errorClass="govuk-input--error"
+              errorId="fare-day-end-input"
+              errors={Array []}
             >
-              <FormElementWrapper
-                errorClass="govuk-input--error"
-                errorId="fare-day-end-input"
-                errors={Array []}
-              >
-                <input
-                  aria-describedby="fare-day-text"
-                  className="govuk-input govuk-input--width-5 govuk-!-margin-right-4"
-                  defaultValue="1234"
-                  id="fare-day-end-input"
-                  name="fareDayEnd"
-                  type="text"
-                />
-              </FormElementWrapper>
-            </fieldset>
+              <input
+                aria-labelledby="fare-day-text"
+                className="govuk-input govuk-input--width-5 govuk-!-margin-right-4"
+                defaultValue="1234"
+                id="fare-day-end-input"
+                name="fareDayEnd"
+                type="text"
+              />
+            </FormElementWrapper>
           </FormGroupWrapper>
           <input
             className="govuk-button"
@@ -154,31 +150,27 @@ exports[`pages manage passenger types should render error state if error 1`] = `
               ]
             }
           >
-            <fieldset
-              className="govuk-fieldset"
+            <FormElementWrapper
+              errorClass="govuk-input--error"
+              errorId="fare-day-end-input"
+              errors={
+                Array [
+                  Object {
+                    "errorMessage": "An error happened!",
+                    "id": "fare-day-end-input",
+                  },
+                ]
+              }
             >
-              <FormElementWrapper
-                errorClass="govuk-input--error"
-                errorId="fare-day-end-input"
-                errors={
-                  Array [
-                    Object {
-                      "errorMessage": "An error happened!",
-                      "id": "fare-day-end-input",
-                    },
-                  ]
-                }
-              >
-                <input
-                  aria-describedby="fare-day-text"
-                  className="govuk-input govuk-input--width-5 govuk-!-margin-right-4"
-                  defaultValue="Not a time"
-                  id="fare-day-end-input"
-                  name="fareDayEnd"
-                  type="text"
-                />
-              </FormElementWrapper>
-            </fieldset>
+              <input
+                aria-labelledby="fare-day-text"
+                className="govuk-input govuk-input--width-5 govuk-!-margin-right-4"
+                defaultValue="Not a time"
+                id="fare-day-end-input"
+                name="fareDayEnd"
+                type="text"
+              />
+            </FormElementWrapper>
           </FormGroupWrapper>
           <input
             className="govuk-button"
@@ -248,24 +240,20 @@ exports[`pages manage passenger types should render popup if saved 1`] = `
             }
             errors={Array []}
           >
-            <fieldset
-              className="govuk-fieldset"
+            <FormElementWrapper
+              errorClass="govuk-input--error"
+              errorId="fare-day-end-input"
+              errors={Array []}
             >
-              <FormElementWrapper
-                errorClass="govuk-input--error"
-                errorId="fare-day-end-input"
-                errors={Array []}
-              >
-                <input
-                  aria-describedby="fare-day-text"
-                  className="govuk-input govuk-input--width-5 govuk-!-margin-right-4"
-                  defaultValue="1254"
-                  id="fare-day-end-input"
-                  name="fareDayEnd"
-                  type="text"
-                />
-              </FormElementWrapper>
-            </fieldset>
+              <input
+                aria-labelledby="fare-day-text"
+                className="govuk-input govuk-input--width-5 govuk-!-margin-right-4"
+                defaultValue="1254"
+                id="fare-day-end-input"
+                name="fareDayEnd"
+                type="text"
+              />
+            </FormElementWrapper>
           </FormGroupWrapper>
           <input
             className="govuk-button"

--- a/repos/fdbt-site/tests/pages/__snapshots__/managePassengerTypes.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/managePassengerTypes.test.tsx.snap
@@ -319,12 +319,13 @@ exports[`pages manage passenger types should render correctly 1`] = `
       <div
         className="govuk-form-group"
       >
-        <div
+        <label
           className="govuk-hint"
+          htmlFor="ageRangeMin"
           id="age-range-min"
         >
           Minimum age (if applicable)
-        </div>
+        </label>
         <FormElementWrapper
           errorClass="govuk-input--error"
           errorId="age-range-min"
@@ -332,6 +333,7 @@ exports[`pages manage passenger types should render correctly 1`] = `
         >
           <input
             className="govuk-input govuk-input--width-5"
+            id="ageRangeMin"
             name="ageRangeMin"
             type="text"
           />
@@ -340,12 +342,13 @@ exports[`pages manage passenger types should render correctly 1`] = `
       <div
         className="govuk-form-group"
       >
-        <div
+        <label
           className="govuk-hint"
+          htmlFor="ageRangeMax"
           id="age-range-max"
         >
           Maximum age (if applicable)
-        </div>
+        </label>
         <FormElementWrapper
           errorClass="govuk-input--error"
           errorId="age-range-max"
@@ -353,6 +356,7 @@ exports[`pages manage passenger types should render correctly 1`] = `
         >
           <input
             className="govuk-input govuk-input--width-5"
+            id="ageRangeMax"
             name="ageRangeMax"
             type="text"
           />
@@ -811,12 +815,13 @@ exports[`pages manage passenger types should render correctly in edit mode 1`] =
       <div
         className="govuk-form-group"
       >
-        <div
+        <label
           className="govuk-hint"
+          htmlFor="ageRangeMin"
           id="age-range-min"
         >
           Minimum age (if applicable)
-        </div>
+        </label>
         <FormElementWrapper
           errorClass="govuk-input--error"
           errorId="age-range-min"
@@ -824,6 +829,7 @@ exports[`pages manage passenger types should render correctly in edit mode 1`] =
         >
           <input
             className="govuk-input govuk-input--width-5"
+            id="ageRangeMin"
             name="ageRangeMin"
             type="text"
           />
@@ -832,12 +838,13 @@ exports[`pages manage passenger types should render correctly in edit mode 1`] =
       <div
         className="govuk-form-group"
       >
-        <div
+        <label
           className="govuk-hint"
+          htmlFor="ageRangeMax"
           id="age-range-max"
         >
           Maximum age (if applicable)
-        </div>
+        </label>
         <FormElementWrapper
           errorClass="govuk-input--error"
           errorId="age-range-max"
@@ -845,6 +852,7 @@ exports[`pages manage passenger types should render correctly in edit mode 1`] =
         >
           <input
             className="govuk-input govuk-input--width-5"
+            id="ageRangeMax"
             name="ageRangeMax"
             type="text"
           />
@@ -1319,12 +1327,13 @@ exports[`pages manage passenger types should render error state on name form gro
       <div
         className="govuk-form-group"
       >
-        <div
+        <label
           className="govuk-hint"
+          htmlFor="ageRangeMin"
           id="age-range-min"
         >
           Minimum age (if applicable)
-        </div>
+        </label>
         <FormElementWrapper
           errorClass="govuk-input--error"
           errorId="age-range-min"
@@ -1340,6 +1349,7 @@ exports[`pages manage passenger types should render error state on name form gro
           <input
             className="govuk-input govuk-input--width-5"
             defaultValue="4"
+            id="ageRangeMin"
             name="ageRangeMin"
             type="text"
           />
@@ -1348,12 +1358,13 @@ exports[`pages manage passenger types should render error state on name form gro
       <div
         className="govuk-form-group"
       >
-        <div
+        <label
           className="govuk-hint"
+          htmlFor="ageRangeMax"
           id="age-range-max"
         >
           Maximum age (if applicable)
-        </div>
+        </label>
         <FormElementWrapper
           errorClass="govuk-input--error"
           errorId="age-range-max"
@@ -1369,6 +1380,7 @@ exports[`pages manage passenger types should render error state on name form gro
           <input
             className="govuk-input govuk-input--width-5"
             defaultValue="15"
+            id="ageRangeMax"
             name="ageRangeMax"
             type="text"
           />
@@ -1850,12 +1862,13 @@ exports[`pages manage passenger types should render error state on passenger typ
       <div
         className="govuk-form-group"
       >
-        <div
+        <label
           className="govuk-hint"
+          htmlFor="ageRangeMin"
           id="age-range-min"
         >
           Minimum age (if applicable)
-        </div>
+        </label>
         <FormElementWrapper
           errorClass="govuk-input--error"
           errorId="age-range-min"
@@ -1871,6 +1884,7 @@ exports[`pages manage passenger types should render error state on passenger typ
           <input
             className="govuk-input govuk-input--width-5"
             defaultValue="15"
+            id="ageRangeMin"
             name="ageRangeMin"
             type="text"
           />
@@ -1879,12 +1893,13 @@ exports[`pages manage passenger types should render error state on passenger typ
       <div
         className="govuk-form-group"
       >
-        <div
+        <label
           className="govuk-hint"
+          htmlFor="ageRangeMax"
           id="age-range-max"
         >
           Maximum age (if applicable)
-        </div>
+        </label>
         <FormElementWrapper
           errorClass="govuk-input--error"
           errorId="age-range-max"
@@ -1900,6 +1915,7 @@ exports[`pages manage passenger types should render error state on passenger typ
           <input
             className="govuk-input govuk-input--width-5"
             defaultValue="65"
+            id="ageRangeMax"
             name="ageRangeMax"
             type="text"
           />
@@ -2360,12 +2376,13 @@ exports[`pages manage passenger types should render update passenger type button
       <div
         className="govuk-form-group"
       >
-        <div
+        <label
           className="govuk-hint"
+          htmlFor="ageRangeMin"
           id="age-range-min"
         >
           Minimum age (if applicable)
-        </div>
+        </label>
         <FormElementWrapper
           errorClass="govuk-input--error"
           errorId="age-range-min"
@@ -2374,6 +2391,7 @@ exports[`pages manage passenger types should render update passenger type button
           <input
             className="govuk-input govuk-input--width-5"
             defaultValue="4"
+            id="ageRangeMin"
             name="ageRangeMin"
             type="text"
           />
@@ -2382,12 +2400,13 @@ exports[`pages manage passenger types should render update passenger type button
       <div
         className="govuk-form-group"
       >
-        <div
+        <label
           className="govuk-hint"
+          htmlFor="ageRangeMax"
           id="age-range-max"
         >
           Maximum age (if applicable)
-        </div>
+        </label>
         <FormElementWrapper
           errorClass="govuk-input--error"
           errorId="age-range-max"
@@ -2396,6 +2415,7 @@ exports[`pages manage passenger types should render update passenger type button
           <input
             className="govuk-input govuk-input--width-5"
             defaultValue="15"
+            id="ageRangeMax"
             name="ageRangeMax"
             type="text"
           />

--- a/repos/fdbt-site/tests/pages/__snapshots__/searchOperators.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/searchOperators.test.tsx.snap
@@ -23,7 +23,6 @@ exports[`pages searchOperator should render a selection error when the user trie
           className="govuk-form-group "
         >
           <fieldset
-            aria-describedby="operator-search"
             className="govuk-fieldset"
           >
             <legend
@@ -149,7 +148,6 @@ exports[`pages searchOperator should render a selection error when the user trie
             className="govuk-form-group "
           >
             <fieldset
-              aria-describedby="selected-operators"
               className="govuk-fieldset"
             >
               <legend
@@ -163,6 +161,7 @@ exports[`pages searchOperator should render a selection error when the user trie
                 </h3>
               </legend>
               <input
+                aria-labelledby="operator-group-name-heading"
                 className="govuk-input "
                 defaultValue=""
                 id="operator-group-name"
@@ -254,7 +253,6 @@ exports[`pages searchOperator should render a selection error when the user trie
           className="govuk-form-group "
         >
           <fieldset
-            aria-describedby="operator-search"
             className="govuk-fieldset"
           >
             <legend
@@ -341,7 +339,6 @@ exports[`pages searchOperator should render a selection error when the user trie
             className="govuk-form-group "
           >
             <fieldset
-              aria-describedby="selected-operators"
               className="govuk-fieldset"
             >
               <legend
@@ -355,6 +352,7 @@ exports[`pages searchOperator should render a selection error when the user trie
                 </h3>
               </legend>
               <input
+                aria-labelledby="operator-group-name-heading"
                 className="govuk-input "
                 defaultValue=""
                 id="operator-group-name"
@@ -550,7 +548,6 @@ exports[`pages searchOperator should render an input error when the user makes a
           className="govuk-form-group govuk-form-group--error"
         >
           <fieldset
-            aria-describedby="operator-search"
             className="govuk-fieldset"
           >
             <legend
@@ -621,7 +618,6 @@ exports[`pages searchOperator should render an input error when the user makes a
             className="govuk-form-group "
           >
             <fieldset
-              aria-describedby="selected-operators"
               className="govuk-fieldset"
             >
               <legend
@@ -635,6 +631,7 @@ exports[`pages searchOperator should render an input error when the user makes a
                 </h3>
               </legend>
               <input
+                aria-labelledby="operator-group-name-heading"
                 className="govuk-input "
                 defaultValue=""
                 id="operator-group-name"
@@ -726,7 +723,6 @@ exports[`pages searchOperator should render just the search input when the user 
           className="govuk-form-group "
         >
           <fieldset
-            aria-describedby="operator-search"
             className="govuk-fieldset"
           >
             <legend
@@ -786,7 +782,6 @@ exports[`pages searchOperator should render just the search input when the user 
             className="govuk-form-group "
           >
             <fieldset
-              aria-describedby="selected-operators"
               className="govuk-fieldset"
             >
               <legend
@@ -800,6 +795,7 @@ exports[`pages searchOperator should render just the search input when the user 
                 </h3>
               </legend>
               <input
+                aria-labelledby="operator-group-name-heading"
                 className="govuk-input "
                 defaultValue=""
                 id="operator-group-name"
@@ -897,7 +893,6 @@ exports[`pages searchOperator should render the page in edit mode 1`] = `
           className="govuk-form-group "
         >
           <fieldset
-            aria-describedby="operator-search"
             className="govuk-fieldset"
           >
             <legend
@@ -1049,7 +1044,6 @@ exports[`pages searchOperator should render the page in edit mode 1`] = `
             className="govuk-form-group "
           >
             <fieldset
-              aria-describedby="selected-operators"
               className="govuk-fieldset"
             >
               <legend
@@ -1063,6 +1057,7 @@ exports[`pages searchOperator should render the page in edit mode 1`] = `
                 </h3>
               </legend>
               <input
+                aria-labelledby="operator-group-name-heading"
                 className="govuk-input "
                 defaultValue="OperatorG Group"
                 id="operator-group-name"
@@ -1252,7 +1247,6 @@ exports[`pages searchOperator should render the search input and a list of selec
           className="govuk-form-group "
         >
           <fieldset
-            aria-describedby="operator-search"
             className="govuk-fieldset"
           >
             <legend
@@ -1339,7 +1333,6 @@ exports[`pages searchOperator should render the search input and a list of selec
             className="govuk-form-group "
           >
             <fieldset
-              aria-describedby="selected-operators"
               className="govuk-fieldset"
             >
               <legend
@@ -1353,6 +1346,7 @@ exports[`pages searchOperator should render the search input and a list of selec
                 </h3>
               </legend>
               <input
+                aria-labelledby="operator-group-name-heading"
                 className="govuk-input "
                 defaultValue=""
                 id="operator-group-name"
@@ -1541,7 +1535,6 @@ exports[`pages searchOperator should render the search input and search results 
           className="govuk-form-group "
         >
           <fieldset
-            aria-describedby="operator-search"
             className="govuk-fieldset"
           >
             <legend
@@ -1667,7 +1660,6 @@ exports[`pages searchOperator should render the search input and search results 
             className="govuk-form-group "
           >
             <fieldset
-              aria-describedby="selected-operators"
               className="govuk-fieldset"
             >
               <legend
@@ -1681,6 +1673,7 @@ exports[`pages searchOperator should render the search input and search results 
                 </h3>
               </legend>
               <input
+                aria-labelledby="operator-group-name-heading"
                 className="govuk-input "
                 defaultValue=""
                 id="operator-group-name"
@@ -1772,7 +1765,6 @@ exports[`pages searchOperator should render the search input, search results and
           className="govuk-form-group "
         >
           <fieldset
-            aria-describedby="operator-search"
             className="govuk-fieldset"
           >
             <legend
@@ -1925,7 +1917,6 @@ exports[`pages searchOperator should render the search input, search results and
             className="govuk-form-group "
           >
             <fieldset
-              aria-describedby="selected-operators"
               className="govuk-fieldset"
             >
               <legend
@@ -1939,6 +1930,7 @@ exports[`pages searchOperator should render the search input, search results and
                 </h3>
               </legend>
               <input
+                aria-labelledby="operator-group-name-heading"
                 className="govuk-input "
                 defaultValue=""
                 id="operator-group-name"


### PR DESCRIPTION
## Description

EXPECTED
[1.1.1 Non-text Content (Level A)](https://webaim.org/standards/wcag/checklist#sc1.1.1)

[1.3.1 Info and Relationships (Level A)](https://webaim.org/standards/wcag/checklist#sc1.3.1)

[2.4.6 Headings and Labels (Level AA)](https://webaim.org/standards/wcag/checklist#sc2.4.6)

[3.3.2 Labels or Instructions (Level A)](https://webaim.org/standards/wcag/checklist#sc3.3.2)

If a text label for a form control is visible, use the <label> element to associate it with its respective form control. If there is no visible label, either provide an associated label, add a descriptive title attribute to the form control, or reference the label(s) using aria-labelledby. Labels are not required for image, submit, reset, button, or hidden form controls.

<input type="text" class="govuk-input govuk-input--width-5" name="ageRangeMin" value="">

ACTUAL: 
OCCURENCE 1 - [Manage Passenger Types - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/managePassengerTypes)
Open image-20240625-104506.png
image-20240625-104506.png


<inputclass="govuk-input govuk-!-width-one-third"id="minimum-passengers-81"name="minimumPassengers81"data-test-id="minimum-passengers"value="1">
OCCURENCE 2 - [Select Time Restrictions - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/selectTimeRestrictions)
Open image-20240625-104720.png
image-20240625-104720.png
YES:



<input type="radio" class="govuk-radios__input" id="valid-days-required" name="timeRestrictionChoice" value="Premade" aria-controls="conditional-time-restriction" aria-expanded="true">
AND

NO:



<input type="radio" class="govuk-radios__input" id="valid-days-not-required" name="timeRestrictionChoice" value="no" data-aria-controls="conditional-time-restriction-2" checked="">
OCCURENCE 3 - [Feedback - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/feedback) // BOTH TEXT BOXES
Open image-20240625-140126.png
image-20240625-140126.png
<textarea class="govuk-textarea" id="general-feedback-question" name="generalFeedbackQuestion" rows="6"></textarea>

and

<textarea class="govuk-textarea" id="hear-about-service-question" name="hearAboutServiceQuestion" rows="3"></textarea>

OCCURENCE 4 - [Multiple Product - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/multipleProducts) // Period Duration text box
Open image-20240625-173938.png
image-20240625-173938.png
<input type="text" class="govuk-input govuk-input--width-3" name="multipleProductDurationInput0" id="product-details-period-duration-quantity-0" aria-describedby="product-period-duration-hint" value="">

OCCURENCE 5 - [Manage Fare Day End - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/manageFareDayEnd)
Open image-20240625-204519.png
image-20240625-204519.png
<input type="text" class="govuk-input govuk-input--width-5 govuk-!-margin-right-4" id="fare-day-end-input" name="fareDayEnd" aria-describedby="fare-day-text" value="">

OCCURENCE 6 - [Search Operators - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/searchOperators)
Open image-20240626-092219.png
image-20240626-092219.png
<fieldset class="govuk-fieldset" aria-describedby="selected-operators">

<legend class="govuk-fieldset__legend--m">

<h3 class="govuk-fieldset__heading" id="operator-group-name-heading">
Enter a name for this group
</h3>

</legend>

<input type="text" id="operator-group-name" class="govuk-input " name="operatorGroupName" value="">

</fieldset>

example:

<label for="firstname">First name:</label> <input type="text" id="firstname">

[Form elements must have labels | Axe Rules | Deque University | Deque Systems](https://dequeuniversity.com/rules/axe/4.9/label?application=AxeEdge)

## Testing instructions

Using wave tool on pages / code review 
