### PR TITLE
fix: Orphaned form label

### DIFF
--- a/repos/fdbt-site/src/pages/searchOperators.tsx
+++ b/repos/fdbt-site/src/pages/searchOperators.tsx
@@ -289,15 +289,18 @@ export const showSearchResults = (
                                 const { nocCode, name } = operator;
                                 return (
                                     <div className="govuk-checkboxes__item" key={`checkbox-item-${nocCode}`}>
-                                        <span
+                                        <input
+                                            className="govuk-checkboxes__input"
                                             id={`operator-to-add-${index}`}
-                                            // eslint-disable-next-line jsx-a11y/aria-role
-                                            role="input"
-                                            className="govuk-label govuk-checkboxes__label"
+                                            type="checkbox"
                                             onClick={() => addOperator(operator.nocCode, operator.name)}
+                                        />
+                                        <label
+                                            className="govuk-label govuk-checkboxes__label"
+                                            htmlFor={`operator-to-add-${index}`}
                                         >
                                             {name} - {nocCode}
-                                        </span>
+                                        </label>
                                     </div>
                                 );
                             })}

--- a/repos/fdbt-site/src/pages/searchOperators.tsx
+++ b/repos/fdbt-site/src/pages/searchOperators.tsx
@@ -289,16 +289,15 @@ export const showSearchResults = (
                                 const { nocCode, name } = operator;
                                 return (
                                     <div className="govuk-checkboxes__item" key={`checkbox-item-${nocCode}`}>
-                                        <label
+                                        <span
                                             id={`operator-to-add-${index}`}
                                             // eslint-disable-next-line jsx-a11y/aria-role
                                             role="input"
-                                            htmlFor="id"
                                             className="govuk-label govuk-checkboxes__label"
                                             onClick={() => addOperator(operator.nocCode, operator.name)}
                                         >
                                             {name} - {nocCode}
-                                        </label>
+                                        </span>
                                     </div>
                                 );
                             })}

--- a/repos/fdbt-site/tests/pages/__snapshots__/searchOperators.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/searchOperators.test.tsx.snap
@@ -119,12 +119,15 @@ exports[`pages searchOperator should render a selection error when the user trie
                 className="govuk-checkboxes__item"
                 key="checkbox-item-BLAC"
               >
-                <label
-                  className="govuk-label govuk-checkboxes__label"
-                  htmlFor="id"
+                <input
+                  className="govuk-checkboxes__input"
                   id="operator-to-add-0"
                   onClick={[Function]}
-                  role="input"
+                  type="checkbox"
+                />
+                <label
+                  className="govuk-label govuk-checkboxes__label"
+                  htmlFor="operator-to-add-0"
                 >
                   Blackpool
                    - 
@@ -1019,12 +1022,15 @@ exports[`pages searchOperator should render the page in edit mode 1`] = `
                 className="govuk-checkboxes__item"
                 key="checkbox-item-WBTR"
               >
-                <label
-                  className="govuk-label govuk-checkboxes__label"
-                  htmlFor="id"
+                <input
+                  className="govuk-checkboxes__input"
                   id="operator-to-add-0"
                   onClick={[Function]}
-                  role="input"
+                  type="checkbox"
+                />
+                <label
+                  className="govuk-label govuk-checkboxes__label"
+                  htmlFor="operator-to-add-0"
                 >
                   Warrington's Own Buses
                    - 
@@ -1637,12 +1643,15 @@ exports[`pages searchOperator should render the search input and search results 
                 className="govuk-checkboxes__item"
                 key="checkbox-item-BLAC"
               >
-                <label
-                  className="govuk-label govuk-checkboxes__label"
-                  htmlFor="id"
+                <input
+                  className="govuk-checkboxes__input"
                   id="operator-to-add-0"
                   onClick={[Function]}
-                  role="input"
+                  type="checkbox"
+                />
+                <label
+                  className="govuk-label govuk-checkboxes__label"
+                  htmlFor="operator-to-add-0"
                 >
                   Blackpool
                    - 
@@ -1895,12 +1904,15 @@ exports[`pages searchOperator should render the search input, search results and
                 className="govuk-checkboxes__item"
                 key="checkbox-item-WBTR"
               >
-                <label
-                  className="govuk-label govuk-checkboxes__label"
-                  htmlFor="id"
+                <input
+                  className="govuk-checkboxes__input"
                   id="operator-to-add-0"
                   onClick={[Function]}
-                  role="input"
+                  type="checkbox"
+                />
+                <label
+                  className="govuk-label govuk-checkboxes__label"
+                  htmlFor="operator-to-add-0"
                 >
                   Warrington's Own Buses
                    - 


### PR DESCRIPTION
## Description

OCCURENCE 1 AND 2 DONE IN OTHER PRS

EXPECTED
example of correct use of form label:

<form>
<label for="name">Your Name:</label>
<input id="name" type="text" placeholder="Enter your Name">
<input type="submit" value="Submit"> 
</form>
ACTUAL
A form label is present, but it is not correctly associated with a form control.

OCCURENCE 1 - [Select Time Restrictions - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/selectTimeRestrictions)
Open image-20240624-100943.png
image-20240624-100943.png


<div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios"><div class="govuk-radios__item">

<input type="radio" class="govuk-radios__input" id="valid-days-required" name="timeRestrictionChoice" value="Premade" aria-controls="conditional-time-restriction" aria-expanded="false">

<label class="govuk-label govuk-radios__label" for="yes-choice">
Yes
</label>

</div>
OCCURENCE 2 - [Multiple Product - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/multipleProducts)
Open image-20240625-172131.png
image-20240625-172131.png


<label class="govuk-label" for="product-details-period-duration">
Period duration
</label>
OCCURENCE 3 - [Search Operators - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/searchOperators?searchOperator=ARR) && [Multiple Operators Service List - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/multiOperatorServiceList)
Open image-20240626-093019.png
image-20240626-093019.png
Open image-20240626-112623.png
image-20240626-112623.png
<label id="operator-to-add-0" role="input" for="id" class="govuk-label govuk-checkboxes__label">
Arriva Wales

<!-- -->

-
<!-- -->

ACYM
</label>

SOLUTION
An incorrectly associated label does not provide functionality or information about the form control to the user. 

 

Possible causes

a <label> element

does not surround a form control and the for attribute is missing/empty

references an element that is not present in the page

references an element that is not an <input>, <select> or <textarea> element

references an <input> element with image, submit, reset, button, or hidden type

## Testing instructions

Use wave tool on page or code review
