### PR TITLE
fix: Multiple form labels

### DIFF
--- a/repos/fdbt-site/src/pages/manageTimeRestriction.tsx
+++ b/repos/fdbt-site/src/pages/manageTimeRestriction.tsx
@@ -296,7 +296,7 @@ const ManageTimeRestriction = ({
                                                     className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                                                     id={`conditional-input-${index}`}
                                                 >
-                                                    <fieldset className="govuk-fieldset flex-container time-restrictions-table">
+                                                    <div className="flex-container time-restrictions-table">
                                                         <div
                                                             className={`govuk-form-group ${
                                                                 errors.some((error) =>
@@ -306,7 +306,7 @@ const ManageTimeRestriction = ({
                                                         >
                                                             {timeRestrictionRows}
                                                         </div>
-                                                    </fieldset>
+                                                    </div>
                                                     <div className="flex-container govuk-!-margin-bottom-4">
                                                         <button
                                                             id={`add-another-button-${day.id}`}

--- a/repos/fdbt-site/src/pages/manageTimeRestriction.tsx
+++ b/repos/fdbt-site/src/pages/manageTimeRestriction.tsx
@@ -171,7 +171,6 @@ const ManageTimeRestriction = ({
                                     }`}
                                     id={`start-time-${day}-${i}`}
                                     name={`startTime${day}`}
-                                    aria-describedby="time-restrictions-hint"
                                     type="text"
                                     defaultValue={findCorrectDefaultValue(startTimeInputs, day, i)}
                                 />
@@ -189,14 +188,13 @@ const ManageTimeRestriction = ({
                                     disabled={lastRow && useFareDayEnd}
                                     id={`end-time-${day}-${i}`}
                                     name={`endTime${day}`}
-                                    aria-describedby="time-restrictions-hint"
                                     type="text"
                                     ref={lastRow ? endTimeRef : undefined}
                                     defaultValue={findCorrectDefaultValue(endTimeInputs, day, i, fareDayEnd)}
                                 />
                             </>
                         </div>
-                        {lastRow && (
+                        {lastRow ? (
                             <>
                                 <span className="govuk-label item">OR </span>
 
@@ -205,7 +203,7 @@ const ManageTimeRestriction = ({
                                         className="govuk-checkboxes__input"
                                         name={`fareDayEnd${day}`}
                                         type="checkbox"
-                                        id="use-fare-day-end"
+                                        id={`use-fare-day-end-${day}-${i}`}
                                         onChange={(e) => {
                                             setUseFareDayEnd(e.currentTarget.checked);
                                             if (endTimeRef.current) {
@@ -215,12 +213,15 @@ const ManageTimeRestriction = ({
                                         }}
                                         checked={useFareDayEnd}
                                     />
-                                    <label className="govuk-label govuk-checkboxes__label" htmlFor="use-fare-day-end">
+                                    <label
+                                        className="govuk-label govuk-checkboxes__label"
+                                        htmlFor={`use-fare-day-end-${day}-${i}`}
+                                    >
                                         Use fare day end
                                     </label>
                                 </div>
                             </>
-                        )}
+                        ) : null}
                     </div>
                 </div>,
             );

--- a/repos/fdbt-site/tests/pages/__snapshots__/manageTimeRestriction.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/manageTimeRestriction.test.tsx.snap
@@ -89,8 +89,8 @@ exports[`pages manage time restriction should render correctly 1`] = `
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-0"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -116,7 +116,6 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-monday-0"
@@ -138,7 +137,6 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -158,14 +156,14 @@ exports[`pages manage time restriction should render correctly 1`] = `
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-monday-0"
                             name="fareDayEndmonday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-monday-0"
                           >
                             Use fare day end
                           </label>
@@ -173,7 +171,7 @@ exports[`pages manage time restriction should render correctly 1`] = `
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -215,8 +213,8 @@ exports[`pages manage time restriction should render correctly 1`] = `
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-1"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -242,7 +240,6 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-tuesday-0"
@@ -264,7 +261,6 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -284,14 +280,14 @@ exports[`pages manage time restriction should render correctly 1`] = `
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-tuesday-0"
                             name="fareDayEndtuesday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-tuesday-0"
                           >
                             Use fare day end
                           </label>
@@ -299,7 +295,7 @@ exports[`pages manage time restriction should render correctly 1`] = `
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -341,8 +337,8 @@ exports[`pages manage time restriction should render correctly 1`] = `
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-2"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -368,7 +364,6 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-wednesday-0"
@@ -390,7 +385,6 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -410,14 +404,14 @@ exports[`pages manage time restriction should render correctly 1`] = `
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-wednesday-0"
                             name="fareDayEndwednesday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-wednesday-0"
                           >
                             Use fare day end
                           </label>
@@ -425,7 +419,7 @@ exports[`pages manage time restriction should render correctly 1`] = `
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -467,8 +461,8 @@ exports[`pages manage time restriction should render correctly 1`] = `
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-3"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -494,7 +488,6 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-thursday-0"
@@ -516,7 +509,6 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -536,14 +528,14 @@ exports[`pages manage time restriction should render correctly 1`] = `
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-thursday-0"
                             name="fareDayEndthursday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-thursday-0"
                           >
                             Use fare day end
                           </label>
@@ -551,7 +543,7 @@ exports[`pages manage time restriction should render correctly 1`] = `
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -593,8 +585,8 @@ exports[`pages manage time restriction should render correctly 1`] = `
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-4"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -620,7 +612,6 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-friday-0"
@@ -642,7 +633,6 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -662,14 +652,14 @@ exports[`pages manage time restriction should render correctly 1`] = `
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-friday-0"
                             name="fareDayEndfriday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-friday-0"
                           >
                             Use fare day end
                           </label>
@@ -677,7 +667,7 @@ exports[`pages manage time restriction should render correctly 1`] = `
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -719,8 +709,8 @@ exports[`pages manage time restriction should render correctly 1`] = `
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-5"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -746,7 +736,6 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-saturday-0"
@@ -768,7 +757,6 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -788,14 +776,14 @@ exports[`pages manage time restriction should render correctly 1`] = `
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-saturday-0"
                             name="fareDayEndsaturday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-saturday-0"
                           >
                             Use fare day end
                           </label>
@@ -803,7 +791,7 @@ exports[`pages manage time restriction should render correctly 1`] = `
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -845,8 +833,8 @@ exports[`pages manage time restriction should render correctly 1`] = `
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-6"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -872,7 +860,6 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-sunday-0"
@@ -894,7 +881,6 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -914,14 +900,14 @@ exports[`pages manage time restriction should render correctly 1`] = `
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-sunday-0"
                             name="fareDayEndsunday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-sunday-0"
                           >
                             Use fare day end
                           </label>
@@ -929,7 +915,7 @@ exports[`pages manage time restriction should render correctly 1`] = `
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -971,8 +957,8 @@ exports[`pages manage time restriction should render correctly 1`] = `
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-7"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -998,7 +984,6 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-bankHoliday-0"
@@ -1020,7 +1005,6 @@ exports[`pages manage time restriction should render correctly 1`] = `
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -1040,14 +1024,14 @@ exports[`pages manage time restriction should render correctly 1`] = `
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-bankHoliday-0"
                             name="fareDayEndbankHoliday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-bankHoliday-0"
                           >
                             Use fare day end
                           </label>
@@ -1055,7 +1039,7 @@ exports[`pages manage time restriction should render correctly 1`] = `
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -1215,8 +1199,8 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-0"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -1242,7 +1226,6 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue="2200"
                             id="start-time-monday-0"
@@ -1264,7 +1247,6 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue="2300"
                             disabled={false}
@@ -1284,14 +1266,14 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-monday-0"
                             name="fareDayEndmonday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-monday-0"
                           >
                             Use fare day end
                           </label>
@@ -1299,7 +1281,7 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -1341,8 +1323,8 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-1"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -1368,7 +1350,6 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue="0100"
                             id="start-time-tuesday-0"
@@ -1390,7 +1371,6 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue="2400"
                             disabled={false}
@@ -1410,14 +1390,14 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-tuesday-0"
                             name="fareDayEndtuesday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-tuesday-0"
                           >
                             Use fare day end
                           </label>
@@ -1425,7 +1405,7 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -1467,8 +1447,8 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-2"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -1494,7 +1474,6 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue="1200"
                             id="start-time-wednesday-0"
@@ -1516,7 +1495,6 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue="1200"
                             disabled={false}
@@ -1536,14 +1514,14 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-wednesday-0"
                             name="fareDayEndwednesday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-wednesday-0"
                           >
                             Use fare day end
                           </label>
@@ -1551,7 +1529,7 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -1593,8 +1571,8 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-3"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -1620,7 +1598,6 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue="-1"
                             id="start-time-thursday-0"
@@ -1642,7 +1619,6 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -1662,14 +1638,14 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-thursday-0"
                             name="fareDayEndthursday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-thursday-0"
                           >
                             Use fare day end
                           </label>
@@ -1677,7 +1653,7 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -1719,8 +1695,8 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-4"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -1746,7 +1722,6 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-friday-0"
@@ -1768,7 +1743,6 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -1788,14 +1762,14 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-friday-0"
                             name="fareDayEndfriday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-friday-0"
                           >
                             Use fare day end
                           </label>
@@ -1803,7 +1777,7 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -1845,8 +1819,8 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-5"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -1872,7 +1846,6 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-saturday-0"
@@ -1894,7 +1867,6 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -1914,14 +1886,14 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-saturday-0"
                             name="fareDayEndsaturday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-saturday-0"
                           >
                             Use fare day end
                           </label>
@@ -1929,7 +1901,7 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -1971,8 +1943,8 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-6"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -1998,7 +1970,6 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-sunday-0"
@@ -2020,7 +1991,6 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -2040,14 +2010,14 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-sunday-0"
                             name="fareDayEndsunday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-sunday-0"
                           >
                             Use fare day end
                           </label>
@@ -2055,7 +2025,7 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -2097,8 +2067,8 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-7"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -2124,7 +2094,6 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-bankHoliday-0"
@@ -2146,7 +2115,6 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -2166,14 +2134,14 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-bankHoliday-0"
                             name="fareDayEndbankHoliday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-bankHoliday-0"
                           >
                             Use fare day end
                           </label>
@@ -2181,7 +2149,7 @@ exports[`pages manage time restriction should render correctly in edit mode 1`] 
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -2419,8 +2387,8 @@ exports[`pages manage time restriction should render error state on day restrict
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-0"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group govuk-form-group--error"
@@ -2451,7 +2419,6 @@ exports[`pages manage time restriction should render error state on day restrict
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 govuk-input--error"
                             defaultValue=""
                             id="start-time-monday-0"
@@ -2473,7 +2440,6 @@ exports[`pages manage time restriction should render error state on day restrict
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue="2300"
                             disabled={false}
@@ -2493,14 +2459,14 @@ exports[`pages manage time restriction should render error state on day restrict
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-monday-0"
                             name="fareDayEndmonday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-monday-0"
                           >
                             Use fare day end
                           </label>
@@ -2508,7 +2474,7 @@ exports[`pages manage time restriction should render error state on day restrict
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -2550,8 +2516,8 @@ exports[`pages manage time restriction should render error state on day restrict
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-1"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group govuk-form-group--error"
@@ -2582,7 +2548,6 @@ exports[`pages manage time restriction should render error state on day restrict
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue="0100"
                             id="start-time-tuesday-0"
@@ -2604,7 +2569,6 @@ exports[`pages manage time restriction should render error state on day restrict
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-input--error"
                             defaultValue="2400"
                             disabled={false}
@@ -2624,14 +2588,14 @@ exports[`pages manage time restriction should render error state on day restrict
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-tuesday-0"
                             name="fareDayEndtuesday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-tuesday-0"
                           >
                             Use fare day end
                           </label>
@@ -2639,7 +2603,7 @@ exports[`pages manage time restriction should render error state on day restrict
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -2681,8 +2645,8 @@ exports[`pages manage time restriction should render error state on day restrict
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-2"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group govuk-form-group--error"
@@ -2713,7 +2677,6 @@ exports[`pages manage time restriction should render error state on day restrict
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 govuk-input--error"
                             defaultValue="1200"
                             id="start-time-wednesday-0"
@@ -2735,7 +2698,6 @@ exports[`pages manage time restriction should render error state on day restrict
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue="1200"
                             disabled={false}
@@ -2755,14 +2717,14 @@ exports[`pages manage time restriction should render error state on day restrict
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-wednesday-0"
                             name="fareDayEndwednesday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-wednesday-0"
                           >
                             Use fare day end
                           </label>
@@ -2770,7 +2732,7 @@ exports[`pages manage time restriction should render error state on day restrict
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -2812,8 +2774,8 @@ exports[`pages manage time restriction should render error state on day restrict
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-3"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group govuk-form-group--error"
@@ -2844,7 +2806,6 @@ exports[`pages manage time restriction should render error state on day restrict
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 govuk-input--error"
                             defaultValue="-1"
                             id="start-time-thursday-0"
@@ -2866,7 +2827,6 @@ exports[`pages manage time restriction should render error state on day restrict
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -2886,14 +2846,14 @@ exports[`pages manage time restriction should render error state on day restrict
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-thursday-0"
                             name="fareDayEndthursday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-thursday-0"
                           >
                             Use fare day end
                           </label>
@@ -2901,7 +2861,7 @@ exports[`pages manage time restriction should render error state on day restrict
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -2943,8 +2903,8 @@ exports[`pages manage time restriction should render error state on day restrict
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-4"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -2970,7 +2930,6 @@ exports[`pages manage time restriction should render error state on day restrict
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-friday-0"
@@ -2992,7 +2951,6 @@ exports[`pages manage time restriction should render error state on day restrict
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -3012,14 +2970,14 @@ exports[`pages manage time restriction should render error state on day restrict
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-friday-0"
                             name="fareDayEndfriday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-friday-0"
                           >
                             Use fare day end
                           </label>
@@ -3027,7 +2985,7 @@ exports[`pages manage time restriction should render error state on day restrict
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -3069,8 +3027,8 @@ exports[`pages manage time restriction should render error state on day restrict
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-5"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -3096,7 +3054,6 @@ exports[`pages manage time restriction should render error state on day restrict
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-saturday-0"
@@ -3118,7 +3075,6 @@ exports[`pages manage time restriction should render error state on day restrict
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -3138,14 +3094,14 @@ exports[`pages manage time restriction should render error state on day restrict
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-saturday-0"
                             name="fareDayEndsaturday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-saturday-0"
                           >
                             Use fare day end
                           </label>
@@ -3153,7 +3109,7 @@ exports[`pages manage time restriction should render error state on day restrict
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -3195,8 +3151,8 @@ exports[`pages manage time restriction should render error state on day restrict
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-6"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -3222,7 +3178,6 @@ exports[`pages manage time restriction should render error state on day restrict
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-sunday-0"
@@ -3244,7 +3199,6 @@ exports[`pages manage time restriction should render error state on day restrict
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -3264,14 +3218,14 @@ exports[`pages manage time restriction should render error state on day restrict
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-sunday-0"
                             name="fareDayEndsunday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-sunday-0"
                           >
                             Use fare day end
                           </label>
@@ -3279,7 +3233,7 @@ exports[`pages manage time restriction should render error state on day restrict
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -3321,8 +3275,8 @@ exports[`pages manage time restriction should render error state on day restrict
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-7"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -3348,7 +3302,6 @@ exports[`pages manage time restriction should render error state on day restrict
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-bankHoliday-0"
@@ -3370,7 +3323,6 @@ exports[`pages manage time restriction should render error state on day restrict
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -3390,14 +3342,14 @@ exports[`pages manage time restriction should render error state on day restrict
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-bankHoliday-0"
                             name="fareDayEndbankHoliday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-bankHoliday-0"
                           >
                             Use fare day end
                           </label>
@@ -3405,7 +3357,7 @@ exports[`pages manage time restriction should render error state on day restrict
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -3608,8 +3560,8 @@ exports[`pages manage time restriction should render error state on name form gr
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-0"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -3635,7 +3587,6 @@ exports[`pages manage time restriction should render error state on name form gr
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue="1200"
                             id="start-time-monday-0"
@@ -3657,7 +3608,6 @@ exports[`pages manage time restriction should render error state on name form gr
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue="2300"
                             disabled={false}
@@ -3677,14 +3627,14 @@ exports[`pages manage time restriction should render error state on name form gr
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-monday-0"
                             name="fareDayEndmonday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-monday-0"
                           >
                             Use fare day end
                           </label>
@@ -3692,7 +3642,7 @@ exports[`pages manage time restriction should render error state on name form gr
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -3734,8 +3684,8 @@ exports[`pages manage time restriction should render error state on name form gr
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-1"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -3761,7 +3711,6 @@ exports[`pages manage time restriction should render error state on name form gr
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-tuesday-0"
@@ -3783,7 +3732,6 @@ exports[`pages manage time restriction should render error state on name form gr
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -3803,14 +3751,14 @@ exports[`pages manage time restriction should render error state on name form gr
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-tuesday-0"
                             name="fareDayEndtuesday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-tuesday-0"
                           >
                             Use fare day end
                           </label>
@@ -3818,7 +3766,7 @@ exports[`pages manage time restriction should render error state on name form gr
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -3860,8 +3808,8 @@ exports[`pages manage time restriction should render error state on name form gr
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-2"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -3887,7 +3835,6 @@ exports[`pages manage time restriction should render error state on name form gr
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-wednesday-0"
@@ -3909,7 +3856,6 @@ exports[`pages manage time restriction should render error state on name form gr
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -3929,14 +3875,14 @@ exports[`pages manage time restriction should render error state on name form gr
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-wednesday-0"
                             name="fareDayEndwednesday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-wednesday-0"
                           >
                             Use fare day end
                           </label>
@@ -3944,7 +3890,7 @@ exports[`pages manage time restriction should render error state on name form gr
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -3986,8 +3932,8 @@ exports[`pages manage time restriction should render error state on name form gr
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-3"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -4013,7 +3959,6 @@ exports[`pages manage time restriction should render error state on name form gr
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-thursday-0"
@@ -4035,7 +3980,6 @@ exports[`pages manage time restriction should render error state on name form gr
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -4055,14 +3999,14 @@ exports[`pages manage time restriction should render error state on name form gr
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-thursday-0"
                             name="fareDayEndthursday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-thursday-0"
                           >
                             Use fare day end
                           </label>
@@ -4070,7 +4014,7 @@ exports[`pages manage time restriction should render error state on name form gr
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -4112,8 +4056,8 @@ exports[`pages manage time restriction should render error state on name form gr
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-4"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -4139,7 +4083,6 @@ exports[`pages manage time restriction should render error state on name form gr
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-friday-0"
@@ -4161,7 +4104,6 @@ exports[`pages manage time restriction should render error state on name form gr
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -4181,14 +4123,14 @@ exports[`pages manage time restriction should render error state on name form gr
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-friday-0"
                             name="fareDayEndfriday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-friday-0"
                           >
                             Use fare day end
                           </label>
@@ -4196,7 +4138,7 @@ exports[`pages manage time restriction should render error state on name form gr
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -4238,8 +4180,8 @@ exports[`pages manage time restriction should render error state on name form gr
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-5"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -4265,7 +4207,6 @@ exports[`pages manage time restriction should render error state on name form gr
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-saturday-0"
@@ -4287,7 +4228,6 @@ exports[`pages manage time restriction should render error state on name form gr
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -4307,14 +4247,14 @@ exports[`pages manage time restriction should render error state on name form gr
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-saturday-0"
                             name="fareDayEndsaturday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-saturday-0"
                           >
                             Use fare day end
                           </label>
@@ -4322,7 +4262,7 @@ exports[`pages manage time restriction should render error state on name form gr
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -4364,8 +4304,8 @@ exports[`pages manage time restriction should render error state on name form gr
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-6"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -4391,7 +4331,6 @@ exports[`pages manage time restriction should render error state on name form gr
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-sunday-0"
@@ -4413,7 +4352,6 @@ exports[`pages manage time restriction should render error state on name form gr
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -4433,14 +4371,14 @@ exports[`pages manage time restriction should render error state on name form gr
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-sunday-0"
                             name="fareDayEndsunday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-sunday-0"
                           >
                             Use fare day end
                           </label>
@@ -4448,7 +4386,7 @@ exports[`pages manage time restriction should render error state on name form gr
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -4490,8 +4428,8 @@ exports[`pages manage time restriction should render error state on name form gr
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-7"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -4517,7 +4455,6 @@ exports[`pages manage time restriction should render error state on name form gr
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-bankHoliday-0"
@@ -4539,7 +4476,6 @@ exports[`pages manage time restriction should render error state on name form gr
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -4559,14 +4495,14 @@ exports[`pages manage time restriction should render error state on name form gr
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-bankHoliday-0"
                             name="fareDayEndbankHoliday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-bankHoliday-0"
                           >
                             Use fare day end
                           </label>
@@ -4574,7 +4510,7 @@ exports[`pages manage time restriction should render error state on name form gr
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -4756,8 +4692,8 @@ exports[`pages manage time restriction should render error state on time restric
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-0"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -4783,7 +4719,6 @@ exports[`pages manage time restriction should render error state on time restric
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-monday-0"
@@ -4805,7 +4740,6 @@ exports[`pages manage time restriction should render error state on time restric
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -4825,14 +4759,14 @@ exports[`pages manage time restriction should render error state on time restric
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-monday-0"
                             name="fareDayEndmonday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-monday-0"
                           >
                             Use fare day end
                           </label>
@@ -4840,7 +4774,7 @@ exports[`pages manage time restriction should render error state on time restric
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -4882,8 +4816,8 @@ exports[`pages manage time restriction should render error state on time restric
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-1"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -4909,7 +4843,6 @@ exports[`pages manage time restriction should render error state on time restric
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-tuesday-0"
@@ -4931,7 +4864,6 @@ exports[`pages manage time restriction should render error state on time restric
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -4951,14 +4883,14 @@ exports[`pages manage time restriction should render error state on time restric
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-tuesday-0"
                             name="fareDayEndtuesday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-tuesday-0"
                           >
                             Use fare day end
                           </label>
@@ -4966,7 +4898,7 @@ exports[`pages manage time restriction should render error state on time restric
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -5008,8 +4940,8 @@ exports[`pages manage time restriction should render error state on time restric
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-2"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -5035,7 +4967,6 @@ exports[`pages manage time restriction should render error state on time restric
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-wednesday-0"
@@ -5057,7 +4988,6 @@ exports[`pages manage time restriction should render error state on time restric
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -5077,14 +5007,14 @@ exports[`pages manage time restriction should render error state on time restric
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-wednesday-0"
                             name="fareDayEndwednesday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-wednesday-0"
                           >
                             Use fare day end
                           </label>
@@ -5092,7 +5022,7 @@ exports[`pages manage time restriction should render error state on time restric
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -5134,8 +5064,8 @@ exports[`pages manage time restriction should render error state on time restric
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-3"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -5161,7 +5091,6 @@ exports[`pages manage time restriction should render error state on time restric
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-thursday-0"
@@ -5183,7 +5112,6 @@ exports[`pages manage time restriction should render error state on time restric
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -5203,14 +5131,14 @@ exports[`pages manage time restriction should render error state on time restric
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-thursday-0"
                             name="fareDayEndthursday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-thursday-0"
                           >
                             Use fare day end
                           </label>
@@ -5218,7 +5146,7 @@ exports[`pages manage time restriction should render error state on time restric
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -5260,8 +5188,8 @@ exports[`pages manage time restriction should render error state on time restric
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-4"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -5287,7 +5215,6 @@ exports[`pages manage time restriction should render error state on time restric
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-friday-0"
@@ -5309,7 +5236,6 @@ exports[`pages manage time restriction should render error state on time restric
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -5329,14 +5255,14 @@ exports[`pages manage time restriction should render error state on time restric
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-friday-0"
                             name="fareDayEndfriday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-friday-0"
                           >
                             Use fare day end
                           </label>
@@ -5344,7 +5270,7 @@ exports[`pages manage time restriction should render error state on time restric
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -5386,8 +5312,8 @@ exports[`pages manage time restriction should render error state on time restric
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-5"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -5413,7 +5339,6 @@ exports[`pages manage time restriction should render error state on time restric
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-saturday-0"
@@ -5435,7 +5360,6 @@ exports[`pages manage time restriction should render error state on time restric
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -5455,14 +5379,14 @@ exports[`pages manage time restriction should render error state on time restric
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-saturday-0"
                             name="fareDayEndsaturday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-saturday-0"
                           >
                             Use fare day end
                           </label>
@@ -5470,7 +5394,7 @@ exports[`pages manage time restriction should render error state on time restric
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -5512,8 +5436,8 @@ exports[`pages manage time restriction should render error state on time restric
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-6"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -5539,7 +5463,6 @@ exports[`pages manage time restriction should render error state on time restric
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-sunday-0"
@@ -5561,7 +5484,6 @@ exports[`pages manage time restriction should render error state on time restric
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -5581,14 +5503,14 @@ exports[`pages manage time restriction should render error state on time restric
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-sunday-0"
                             name="fareDayEndsunday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-sunday-0"
                           >
                             Use fare day end
                           </label>
@@ -5596,7 +5518,7 @@ exports[`pages manage time restriction should render error state on time restric
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -5638,8 +5560,8 @@ exports[`pages manage time restriction should render error state on time restric
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-7"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -5665,7 +5587,6 @@ exports[`pages manage time restriction should render error state on time restric
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-bankHoliday-0"
@@ -5687,7 +5608,6 @@ exports[`pages manage time restriction should render error state on time restric
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -5707,14 +5627,14 @@ exports[`pages manage time restriction should render error state on time restric
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-bankHoliday-0"
                             name="fareDayEndbankHoliday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-bankHoliday-0"
                           >
                             Use fare day end
                           </label>
@@ -5722,7 +5642,7 @@ exports[`pages manage time restriction should render error state on time restric
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -5967,8 +5887,8 @@ exports[`pages manage time restriction should render with fare day end selection
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-0"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group govuk-form-group--error"
@@ -5999,7 +5919,6 @@ exports[`pages manage time restriction should render with fare day end selection
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 govuk-input--error"
                             defaultValue="1111"
                             id="start-time-monday-0"
@@ -6021,7 +5940,6 @@ exports[`pages manage time restriction should render with fare day end selection
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue="2300"
                             disabled={false}
@@ -6041,14 +5959,14 @@ exports[`pages manage time restriction should render with fare day end selection
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-monday-0"
                             name="fareDayEndmonday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-monday-0"
                           >
                             Use fare day end
                           </label>
@@ -6056,7 +5974,7 @@ exports[`pages manage time restriction should render with fare day end selection
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -6098,8 +6016,8 @@ exports[`pages manage time restriction should render with fare day end selection
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-1"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group govuk-form-group--error"
@@ -6130,7 +6048,6 @@ exports[`pages manage time restriction should render with fare day end selection
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue="0100"
                             id="start-time-tuesday-0"
@@ -6152,7 +6069,6 @@ exports[`pages manage time restriction should render with fare day end selection
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-input--error"
                             defaultValue="1234"
                             disabled={true}
@@ -6172,14 +6088,14 @@ exports[`pages manage time restriction should render with fare day end selection
                           <input
                             checked={true}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-tuesday-0"
                             name="fareDayEndtuesday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-tuesday-0"
                           >
                             Use fare day end
                           </label>
@@ -6187,7 +6103,7 @@ exports[`pages manage time restriction should render with fare day end selection
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -6229,8 +6145,8 @@ exports[`pages manage time restriction should render with fare day end selection
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-2"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group govuk-form-group--error"
@@ -6261,7 +6177,6 @@ exports[`pages manage time restriction should render with fare day end selection
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 govuk-input--error"
                             defaultValue="1200"
                             id="start-time-wednesday-0"
@@ -6283,7 +6198,6 @@ exports[`pages manage time restriction should render with fare day end selection
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue="1300"
                             disabled={false}
@@ -6315,7 +6229,6 @@ exports[`pages manage time restriction should render with fare day end selection
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue="1500"
                             id="start-time-wednesday-1"
@@ -6337,7 +6250,6 @@ exports[`pages manage time restriction should render with fare day end selection
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue="1234"
                             disabled={true}
@@ -6357,14 +6269,14 @@ exports[`pages manage time restriction should render with fare day end selection
                           <input
                             checked={true}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-wednesday-1"
                             name="fareDayEndwednesday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-wednesday-1"
                           >
                             Use fare day end
                           </label>
@@ -6372,7 +6284,7 @@ exports[`pages manage time restriction should render with fare day end selection
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -6422,8 +6334,8 @@ exports[`pages manage time restriction should render with fare day end selection
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-3"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group govuk-form-group--error"
@@ -6454,7 +6366,6 @@ exports[`pages manage time restriction should render with fare day end selection
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 govuk-input--error"
                             defaultValue=""
                             id="start-time-thursday-0"
@@ -6476,7 +6387,6 @@ exports[`pages manage time restriction should render with fare day end selection
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -6496,14 +6406,14 @@ exports[`pages manage time restriction should render with fare day end selection
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-thursday-0"
                             name="fareDayEndthursday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-thursday-0"
                           >
                             Use fare day end
                           </label>
@@ -6511,7 +6421,7 @@ exports[`pages manage time restriction should render with fare day end selection
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -6553,8 +6463,8 @@ exports[`pages manage time restriction should render with fare day end selection
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-4"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -6580,7 +6490,6 @@ exports[`pages manage time restriction should render with fare day end selection
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-friday-0"
@@ -6602,7 +6511,6 @@ exports[`pages manage time restriction should render with fare day end selection
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -6622,14 +6530,14 @@ exports[`pages manage time restriction should render with fare day end selection
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-friday-0"
                             name="fareDayEndfriday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-friday-0"
                           >
                             Use fare day end
                           </label>
@@ -6637,7 +6545,7 @@ exports[`pages manage time restriction should render with fare day end selection
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -6679,8 +6587,8 @@ exports[`pages manage time restriction should render with fare day end selection
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-5"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -6706,7 +6614,6 @@ exports[`pages manage time restriction should render with fare day end selection
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-saturday-0"
@@ -6728,7 +6635,6 @@ exports[`pages manage time restriction should render with fare day end selection
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -6748,14 +6654,14 @@ exports[`pages manage time restriction should render with fare day end selection
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-saturday-0"
                             name="fareDayEndsaturday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-saturday-0"
                           >
                             Use fare day end
                           </label>
@@ -6763,7 +6669,7 @@ exports[`pages manage time restriction should render with fare day end selection
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -6805,8 +6711,8 @@ exports[`pages manage time restriction should render with fare day end selection
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-6"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -6832,7 +6738,6 @@ exports[`pages manage time restriction should render with fare day end selection
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-sunday-0"
@@ -6854,7 +6759,6 @@ exports[`pages manage time restriction should render with fare day end selection
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -6874,14 +6778,14 @@ exports[`pages manage time restriction should render with fare day end selection
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-sunday-0"
                             name="fareDayEndsunday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-sunday-0"
                           >
                             Use fare day end
                           </label>
@@ -6889,7 +6793,7 @@ exports[`pages manage time restriction should render with fare day end selection
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >
@@ -6931,8 +6835,8 @@ exports[`pages manage time restriction should render with fare day end selection
                 className="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                 id="conditional-input-7"
               >
-                <fieldset
-                  className="govuk-fieldset flex-container time-restrictions-table"
+                <div
+                  className="flex-container time-restrictions-table"
                 >
                   <div
                     className="govuk-form-group false"
@@ -6958,7 +6862,6 @@ exports[`pages manage time restriction should render with fare day end selection
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false"
                             defaultValue=""
                             id="start-time-bankHoliday-0"
@@ -6980,7 +6883,6 @@ exports[`pages manage time restriction should render with fare day end selection
                             </span>
                           </label>
                           <input
-                            aria-describedby="time-restrictions-hint"
                             className="govuk-input govuk-input--width-5 false"
                             defaultValue=""
                             disabled={false}
@@ -7000,14 +6902,14 @@ exports[`pages manage time restriction should render with fare day end selection
                           <input
                             checked={false}
                             className="govuk-checkboxes__input"
-                            id="use-fare-day-end"
+                            id="use-fare-day-end-bankHoliday-0"
                             name="fareDayEndbankHoliday"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="govuk-label govuk-checkboxes__label"
-                            htmlFor="use-fare-day-end"
+                            htmlFor="use-fare-day-end-bankHoliday-0"
                           >
                             Use fare day end
                           </label>
@@ -7015,7 +6917,7 @@ exports[`pages manage time restriction should render with fare day end selection
                       </div>
                     </div>
                   </div>
-                </fieldset>
+                </div>
                 <div
                   className="flex-container govuk-!-margin-bottom-4"
                 >


### PR DESCRIPTION
## Description

EXPECTED

A form control should have at most one associated label element. If more than one label element is associated to the control, assistive technology may not read the appropriate label.

ACTUAL

Two or more <label>s are associated to a single <input>

[Manage Time Restrictions - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/manageTimeRestriction)

Open image-20240624-153452.png
image-20240624-153452.png
‘USE FARE DAY END’



<div class="govuk-checkboxes__item item">

<input type="checkbox" class="govuk-checkboxes__input" name="fareDayEndmonday" id="use-fare-day-end">

<label class="govuk-label govuk-checkboxes__label" for="use-fare-day-end">
Use fare day end
</label>

</div>
PROPOSED SOLUTION:

Wrap the input within the label?



<label>
    First Name
<input />
</label>
ELSE, use aria-labelledby

## Testing instructions

wave extension on page or code review
