### PR TITLE
fix: CFDS - Broken ARIA reference / Time Restrictions

### DIFF
--- a/repos/fdbt-site/src/layout/GlobalSettingReturnHeader.tsx
+++ b/repos/fdbt-site/src/layout/GlobalSettingReturnHeader.tsx
@@ -10,7 +10,7 @@ export const GlobalSettingReturnHeader: FunctionComponent = () => (
         >
             <div className="govuk-notification-banner__header" />
             <div className="govuk-notification-banner__content global-settings-return-banner">
-                <p className="govuk-heading-s govuk-!-margin-0">
+                <p className="govuk-heading-s govuk-!-margin-0" id="govuk-notification-banner-title">
                     Once you&apos;ve made your changes you can return to your fare creation.
                 </p>
                 <a href={`/globalSettingsRedirect`} className="govuk-button govuk-button--secondary">

--- a/repos/fdbt-site/src/pages/reuseOperatorGroup.tsx
+++ b/repos/fdbt-site/src/pages/reuseOperatorGroup.tsx
@@ -36,7 +36,7 @@ const ReuseOperatorGroup = ({
             <>
                 <ErrorSummary errors={errors} />
                 <div className="govuk-form-group ">
-                    <fieldset className="govuk-fieldset" aria-describedby="operator-group-page-heading">
+                    <fieldset className="govuk-fieldset" aria-describedby="reuse-operator-group-page-heading">
                         <legend className="govuk-fieldset__legend govuk-fieldset__legend--l">
                             <h1 className="govuk-fieldset__heading" id="reuse-operator-group-page-heading">
                                 Select an operator group

--- a/repos/fdbt-site/tests/pages/__snapshots__/reuseOperatorGroup.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/reuseOperatorGroup.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`pages reuseOperatorGroup should render coorectly when one operator grou
       className="govuk-form-group "
     >
       <fieldset
-        aria-describedby="operator-group-page-heading"
+        aria-describedby="reuse-operator-group-page-heading"
         className="govuk-fieldset"
       >
         <legend
@@ -119,7 +119,7 @@ exports[`pages reuseOperatorGroup should render correctly 1`] = `
       className="govuk-form-group "
     >
       <fieldset
-        aria-describedby="operator-group-page-heading"
+        aria-describedby="reuse-operator-group-page-heading"
         className="govuk-fieldset"
       >
         <legend
@@ -213,7 +213,7 @@ exports[`pages reuseOperatorGroup should render errors when user does not select
       className="govuk-form-group "
     >
       <fieldset
-        aria-describedby="operator-group-page-heading"
+        aria-describedby="reuse-operator-group-page-heading"
         className="govuk-fieldset"
       >
         <legend


### PR DESCRIPTION
## Description


**Occurrence 2 fixed in CFDS-278**

EXPECTED - [Broken ARIA Reference Explained - Make Your Website Accessible (equalizedigital.com)](https://equalizedigital.com/accessibility-checker/broken-aria-reference/)
example:



<div id="formBillingId">Billing</div>

<div>
    <div id="formNameId">Name</div>
    <input type="text" aria-labelledby="formBillingId formNameId"/>
</div>
<div>
    <div id="formAddressId">Address</div>
    <input type="text" aria-labelledby="formBillingId formAddressId"/>
</div>
ACTUAL
the aria-labelledby="..." seems to not match a listed variable in the code
OCCURENCE 1 - [Time restrictions (dft-cfd.com)](https://preprod.dft-cfd.com/viewTimeRestrictions)



<div class="govuk-notification-banner govuk-grid-row govuk-!-margin-top-5 govuk-!-margin-bottom-0" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
<div class="govuk-notification-banner__header"></div>
<div class="govuk-notification-banner__content global-settings-return-banner">
<p class="govuk-heading-s govuk-!-margin-0">
Once you've made your changes you can return to your fare creation.
</p>
<a href="/globalSettingsRedirect" class="govuk-button govuk-button--secondary">
Back
</a>
</div>
</div>
OCCURENCE 2 - [Manage Time Restrictions - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/manageTimeRestriction) // THE START TIME AND END TIME OF ALL DAYS ON THIS PAGE. 

Open image-20240624-134835.png
image-20240624-134835.png


<input type="text" class="govuk-input govuk-input--width-5 govuk-!-margin-right-4 false" id="start-time-monday-0" name="startTimemonday" aria-describedby="time-restrictions-hint" value="">
OCCURENCE 3 - [Purchase methods (dft-cfd.com)](https://preprod.dft-cfd.com/viewPurchaseMethods)

Open image-20240625-123354.png
image-20240625-123354.png


<div class="govuk-notification-banner govuk-grid-row govuk-!-margin-top-5 govuk-!-margin-bottom-0" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
<div class="govuk-notification-banner__header"></div>
<div class="govuk-notification-banner__content global-settings-return-banner"><p class="govuk-heading-s govuk-!-margin-0">
Once you've made your changes you can return to your fare creation.
</p>
<a href="/globalSettingsRedirect" class="govuk-button govuk-button--secondary">
Back
</a>
</div>
</div>
OCCURENCE 4 - [Select Operator Group - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/reuseOperatorGroup)

Open image-20240626-110604.png
image-20240626-110604.png
<fieldset class="govuk-fieldset" aria-describedby="operator-group-page-heading">

<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">

<h1 class="govuk-fieldset__heading" id="reuse-operator-group-page-heading">
Select an operator group
</h1>

</legend>

<div class="govuk-warning-text">

<span class="govuk-warning-text__icon govuk-!-margin-top-1" aria-hidden="true">
!
</span>

<strong class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">
Warning
</span>
You can create new operator group in your

<!-- -->

<a class="govuk-link" href="/viewOperatorGroups">
operator settings.
</a><br>
Don't worry you can navigate back to this page when you are finished.
</strong></div></fieldset>

SOLUTION
This usually means that an aria-labeledby or aria-describedby element is present on the page or post but that its reference target does not exist. This means that the element that is being referred to by the specific ARIA attribute you’re using either does not have a proper label or descriptor, or it is not present on the page. Sometimes this is a result of a typo in the code or it is a result of JavaScript or other code hiding the element to which the ARIA attribute is referring.

in this case, check govuk-notification-banner-title is listed as a variable, if not, add or replace with a different variable

Standards and Guidelines
[1.3.1 Info and Relationships (Level A)](https://webaim.org/standards/wcag/checklist#sc1.3.1)

[4.1.2 Name, Role, Value (Level A)](https://webaim.org/standards/wcag/checklist#sc4.1.2)

## Testing instructions

Check using wave tool and code review
