### PR TITLE
fix: No HTML alternative provided for PDFs

### DIFF
--- a/repos/fdbt-site/src/components/AccessibilityDetails.tsx
+++ b/repos/fdbt-site/src/components/AccessibilityDetails.tsx
@@ -1,0 +1,20 @@
+import React, { ReactElement } from 'react';
+
+interface ContactProps {
+    supportEmail: string;
+}
+
+const AccessibilityDetails = ({ supportEmail }: ContactProps): ReactElement => (
+    <details className="govuk-details margin-top">
+        <summary className="govuk-details__summary">
+            <span className="govuk-details__summary-text">Request an accessible format.</span>
+        </summary>
+        <div className="govuk-details__text">
+            If you use assistive technology (such as a screen reader) and need a version of this document in a more
+            accessible format, please email <a href={`mailto:${supportEmail}`}>{supportEmail}</a>. Please tell us what
+            format you need. It will help us if you say what assistive technology you use.
+        </div>
+    </details>
+);
+
+export default AccessibilityDetails;

--- a/repos/fdbt-site/src/design/modules/_helpers.scss
+++ b/repos/fdbt-site/src/design/modules/_helpers.scss
@@ -27,3 +27,7 @@
 .dft-text-align-centre {
     text-align: center;
 }
+
+.margin-top {
+    margin-top: 15px;
+}

--- a/repos/fdbt-site/src/pages/contact.tsx
+++ b/repos/fdbt-site/src/pages/contact.tsx
@@ -4,6 +4,7 @@ import { BaseLayout } from '../layout/Layout';
 import FileAttachment from '../components/FileAttachment';
 import ServiceGuide from '../assets/files/Create-Fares-Data-Service-Guide.pdf';
 import ServiceGuideFrontPage from '../assets/images/service-guide-front-page.png';
+import AccessibilityDetails from '../components/AccessibilityDetails';
 
 const title = 'Contact - Create Fares Data Service';
 const description = 'Contact page for the Create Fares Data Service';
@@ -70,6 +71,7 @@ const Contact = ({ supportEmail, supportPhone }: ContactProps): ReactElement => 
                         imageUrl={ServiceGuideFrontPage}
                         size="8KB"
                     />
+                    <AccessibilityDetails supportEmail={supportEmail} />
                 </div>
             </div>
         </BaseLayout>

--- a/repos/fdbt-site/src/pages/csvUpload.tsx
+++ b/repos/fdbt-site/src/pages/csvUpload.tsx
@@ -17,6 +17,8 @@ import FileAttachment from '../components/FileAttachment';
 import guidanceDocImage from '../assets/images/Guidance-doc-front-page.png';
 import csvImage from '../assets/images/csv.png';
 import CsrfForm from '../components/CsrfForm';
+import { SUPPORT_EMAIL_ADDRESS } from '../constants';
+import AccessibilityDetails from '../components/AccessibilityDetails';
 
 const title = 'CSV Upload - Create Fares Data Service';
 const description = 'CSV Upload page of the Create Fares Data Service';
@@ -28,6 +30,7 @@ interface CsvUploadProps extends UserDataUploadsProps {
     csvTemplateDisplayName: string;
     csvTemplateSize: string;
     csrfToken: string;
+    supportEmail: string;
 }
 
 const CsvUpload = ({
@@ -38,6 +41,7 @@ const CsvUpload = ({
     csvTemplateDisplayName,
     csvTemplateSize,
     csrfToken,
+    supportEmail,
     ...props
 }: CsvUploadProps): ReactElement => (
     <BaseLayout title={title} description={description} errors={errors}>
@@ -76,6 +80,7 @@ const CsvUpload = ({
                     imageUrl={guidanceDocImage}
                     size={guidanceDocSize}
                 />
+                <AccessibilityDetails supportEmail={supportEmail} />
                 <FileAttachment
                     displayName={csvTemplateDisplayName}
                     attachmentUrl={`${FaresTriangleExampleCsv}`}
@@ -117,6 +122,7 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Cs
             poundsOrPence,
             csrfToken: getCsrfToken(ctx),
             backHref,
+            supportEmail: SUPPORT_EMAIL_ADDRESS || 'test@example.com',
         },
     };
 };

--- a/repos/fdbt-site/src/pages/csvZoneUpload.tsx
+++ b/repos/fdbt-site/src/pages/csvZoneUpload.tsx
@@ -32,6 +32,8 @@ import guidanceDocImage from '../assets/images/Guidance-doc-front-page.png';
 import csvImage from '../assets/images/csv.png';
 import CsrfForm from '../components/CsrfForm';
 import { isServiceListAttributeWithErrors } from '../interfaces/typeGuards';
+import AccessibilityDetails from '../components/AccessibilityDetails';
+import { SUPPORT_EMAIL_ADDRESS } from '../constants';
 
 const title = 'CSV Zone Upload - Create Fares Data Service';
 const description = 'CSV Zone Upload page of the Create Fares Data Service';
@@ -46,6 +48,7 @@ interface CSVZoneUploadProps extends UserDataUploadsProps {
     csvTemplateDisplayName: string;
     csvTemplateSize: string;
     csrfToken: string;
+    supportEmail: string;
 }
 
 const CsvZoneUpload = ({
@@ -59,6 +62,7 @@ const CsvZoneUpload = ({
     csvTemplateDisplayName,
     csvTemplateSize,
     csrfToken,
+    supportEmail,
     ...uploadProps
 }: CSVZoneUploadProps): ReactElement => {
     const seen: string[] = [];
@@ -257,6 +261,7 @@ const CsvZoneUpload = ({
                         imageUrl={guidanceDocImage}
                         size={guidanceDocSize}
                     />
+                    <AccessibilityDetails supportEmail={supportEmail} />
                     <FileAttachment
                         displayName={csvTemplateDisplayName}
                         attachmentUrl={`${FareZoneExampleCsv}`}
@@ -348,6 +353,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
         csrfToken: getCsrfToken(ctx),
         backHref,
         dataSourceAttribute,
+        supportEmail: SUPPORT_EMAIL_ADDRESS || 'test@example.com',
     };
 
     const hasClickedYes = (serviceList: ServicesInfo[]) => {

--- a/repos/fdbt-site/src/pages/inputMethod.tsx
+++ b/repos/fdbt-site/src/pages/inputMethod.tsx
@@ -13,6 +13,8 @@ import { getSessionAttribute, updateSessionAttribute } from '../utils/sessions';
 import { inputMethodErrorsExist } from '../interfaces/typeGuards';
 import { getCsrfToken } from '../utils';
 import FileAttachment from '../components/FileAttachment';
+import AccessibilityDetails from '../components/AccessibilityDetails';
+import { SUPPORT_EMAIL_ADDRESS } from '../constants';
 
 const title = 'Input Method - Create Fares Data Service';
 const description = 'Input Method selection page of the Create Fares Data Service';
@@ -26,6 +28,7 @@ interface InputMethodProps {
     csvTemplateDisplayName: string;
     csvTemplateSize: string;
     csrfToken: string;
+    supportEmail: string;
 }
 
 const InputMethod = ({
@@ -35,6 +38,7 @@ const InputMethod = ({
     guidanceDocSize,
     csvTemplateDisplayName,
     csvTemplateSize,
+    supportEmail,
 }: InputMethodProps): ReactElement => {
     return (
         <BaseLayout title={title} description={description} errors={errors}>
@@ -111,6 +115,7 @@ const InputMethod = ({
                         imageUrl={guidanceDocImage}
                         size={guidanceDocSize}
                     />
+                    <AccessibilityDetails supportEmail={supportEmail} />
                     <FileAttachment
                         displayName={csvTemplateDisplayName}
                         attachmentUrl={`${FaresTriangleExampleCsv}`}
@@ -135,6 +140,7 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: In
             csvTemplateSize: '255B',
             errors: inputMethodInfo && inputMethodErrorsExist(inputMethodInfo) ? [inputMethodInfo] : [],
             csrfToken,
+            supportEmail: SUPPORT_EMAIL_ADDRESS || 'test@example.com',
         },
     };
 };

--- a/repos/fdbt-site/tests/components/AccessibilityDetails.test.tsx
+++ b/repos/fdbt-site/tests/components/AccessibilityDetails.test.tsx
@@ -1,0 +1,10 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import AccessibilityDetails from '../../src/components/AccessibilityDetails';
+
+describe('AccessibilityDetails', () => {
+    it('should render the AccessibilityDetails component', () => {
+        const wrapper = shallow(<AccessibilityDetails supportEmail="test@gmail.com" />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/repos/fdbt-site/tests/components/__snapshots__/AccessibilityDetails.test.tsx.snap
+++ b/repos/fdbt-site/tests/components/__snapshots__/AccessibilityDetails.test.tsx.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AccessibilityDetails should render the AccessibilityDetails component 1`] = `
+<details
+  className="govuk-details margin-top"
+>
+  <summary
+    className="govuk-details__summary"
+  >
+    <span
+      className="govuk-details__summary-text"
+    >
+      Request an accessible format.
+    </span>
+  </summary>
+  <div
+    className="govuk-details__text"
+  >
+    If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email 
+    <a
+      href="mailto:test@gmail.com"
+    >
+      test@gmail.com
+    </a>
+    . Please tell us what format you need. It will help us if you say what assistive technology you use.
+  </div>
+</details>
+`;

--- a/repos/fdbt-site/tests/pages/__snapshots__/contact.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/contact.test.tsx.snap
@@ -114,6 +114,9 @@ exports[`contact should render correctly 1`] = `
         imageUrl={Object {}}
         size="8KB"
       />
+      <AccessibilityDetails
+        supportEmail="mock-support-address@email.co.uk"
+      />
     </div>
   </div>
 </BaseLayout>

--- a/repos/fdbt-site/tests/pages/__snapshots__/csvUpload.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/csvUpload.test.tsx.snap
@@ -69,6 +69,9 @@ exports[`pages csvUpload should render correctly 1`] = `
         imageUrl={Object {}}
         size=""
       />
+      <AccessibilityDetails
+        supportEmail="mock-support-address@email.co.uk"
+      />
       <FileAttachment
         attachmentUrl="[object Object]"
         displayName=""

--- a/repos/fdbt-site/tests/pages/__snapshots__/csvZoneUpload.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/csvZoneUpload.test.tsx.snap
@@ -194,6 +194,9 @@ exports[`pages csvzoneupload should render correctly 1`] = `
         imageUrl={Object {}}
         size=""
       />
+      <AccessibilityDetails
+        supportEmail="mock-support-address@email.co.uk"
+      />
       <FileAttachment
         attachmentUrl="[object Object]"
         displayName=""

--- a/repos/fdbt-site/tests/pages/__snapshots__/inputMethod.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/inputMethod.test.tsx.snap
@@ -116,6 +116,9 @@ exports[`pages inputMethod should render correctly 1`] = `
         imageUrl={Object {}}
         size="1.2MB"
       />
+      <AccessibilityDetails
+        supportEmail="mock-support-address@email.co.uk"
+      />
       <FileAttachment
         attachmentUrl="[object Object]"
         displayName="Download fares triangle CSV template - File Type CSV - File Size 255B"

--- a/repos/fdbt-site/tests/pages/csvUpload.test.tsx
+++ b/repos/fdbt-site/tests/pages/csvUpload.test.tsx
@@ -17,6 +17,7 @@ describe('pages', () => {
                     showPriceOption
                     csrfToken=""
                     backHref=""
+                    supportEmail="mock-support-address@email.co.uk"
                 />,
             );
             expect(tree).toMatchSnapshot();

--- a/repos/fdbt-site/tests/pages/csvZoneUpload.test.tsx
+++ b/repos/fdbt-site/tests/pages/csvZoneUpload.test.tsx
@@ -56,6 +56,7 @@ describe('pages', () => {
                     serviceList={mockServiceList}
                     clickedYes={false}
                     dataSourceAttribute={{ source: 'bods', hasBods: true, hasTnds: false }}
+                    supportEmail="mock-support-address@email.co.uk"
                 />,
             );
             expect(tree).toMatchSnapshot();

--- a/repos/fdbt-site/tests/pages/inputMethod.test.tsx
+++ b/repos/fdbt-site/tests/pages/inputMethod.test.tsx
@@ -13,6 +13,7 @@ describe('pages', () => {
                     guidanceDocSize="1.2MB"
                     csvTemplateDisplayName="Download fares triangle CSV template - File Type CSV - File Size 255B"
                     csvTemplateSize="255B"
+                    supportEmail="mock-support-address@email.co.uk"
                 />,
             );
             expect(tree).toMatchSnapshot();


### PR DESCRIPTION
## Description

Decided to add dropdowns rather than a link to a html page alternatives stored in sharepoint

EXPECTED:

PDFs on other government websites
Turn existing PDFs into HTML to improve accessibility and to reach as many users as possible. You need the source document to create an HTML webpage.

Creating a new document as PDF is a last resort and should be avoided unless there is a specific business need. You should always provide an HTML version too.

E.g.

Open image-20240621-084334.png
image-20240621-084334.png
[Publishing accessible documents - GOV.UK (www.gov.uk)](https://www.gov.uk/guidance/publishing-accessible-documents)

ACTUAL:

Open image-20240621-084407.png
image-20240621-084407.png
Open image-20240624-112944.png
image-20240624-112944.png
INSTANCES:

[Contact - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/contact)

[Input Method - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/inputMethod)

[CSV Upload - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/csvUpload)

[CSV Zone Upload - Create Fares Data Service (dft-cfd.com)](https://preprod.dft-cfd.com/csvZoneUpload)

SOLUTION:

[Publishing accessible documents - GOV.UK (www.gov.uk)](https://www.gov.uk/guidance/publishing-accessible-documents)

## Testing instructions

Open each page and see dropdown
