### PR TITLE
feat: Remove caps for carnet journeys

### DIFF
--- a/repos/fdbt-site/src/pages/api/ticketConfirmation.ts
+++ b/repos/fdbt-site/src/pages/api/ticketConfirmation.ts
@@ -1,6 +1,12 @@
 import { NextApiResponse } from 'next';
 import { NextApiRequestWithSession } from '../../interfaces/index';
-import { getAndValidateNoc, getFareTypeFromFromAttributes, redirectTo, redirectToError } from '../../utils/apiUtils';
+import {
+    getAndValidateNoc,
+    getFareTypeFromFromAttributes,
+    getIsCarnet,
+    redirectTo,
+    redirectToError,
+} from '../../utils/apiUtils';
 import { getCaps } from '../../../src/data/auroradb';
 import { fareTypeIsAllowedToAddACap } from '../../../src/utils';
 
@@ -9,10 +15,11 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
         const fareTypeAttribute = getFareTypeFromFromAttributes(req);
         const nocCode = getAndValidateNoc(req, res);
         const caps = await getCaps(nocCode);
+        const isCarnet = getIsCarnet(req);
 
         const isDevOrTest = process.env.NODE_ENV === 'development' || process.env.STAGE === 'test';
 
-        if (isDevOrTest && fareTypeIsAllowedToAddACap(fareTypeAttribute) && caps.length > 0) {
+        if (isDevOrTest && fareTypeIsAllowedToAddACap(fareTypeAttribute) && caps.length > 0 && !isCarnet) {
             redirectTo(res, '/selectCaps');
             return;
         }

--- a/repos/fdbt-site/src/utils/apiUtils/index.ts
+++ b/repos/fdbt-site/src/utils/apiUtils/index.ts
@@ -4,7 +4,12 @@ import Cookies from 'cookies';
 import { ServerResponse } from 'http';
 import { decode } from 'jsonwebtoken';
 import { ID_TOKEN_COOKIE, REFRESH_TOKEN_COOKIE, DISABLE_AUTH_COOKIE } from '../../constants';
-import { OPERATOR_ATTRIBUTE, FARE_TYPE_ATTRIBUTE, SCHOOL_FARE_TYPE_ATTRIBUTE } from '../../constants/attributes';
+import {
+    OPERATOR_ATTRIBUTE,
+    FARE_TYPE_ATTRIBUTE,
+    SCHOOL_FARE_TYPE_ATTRIBUTE,
+    CARNET_FARE_TYPE_ATTRIBUTE,
+} from '../../constants/attributes';
 import {
     CognitoIdToken,
     ErrorInfo,
@@ -70,6 +75,12 @@ export const redirectToError = (
 ): void => {
     logger.error(message, { context, error: error.stack });
     redirectTo(res, '/error');
+};
+
+export const getIsCarnet = (req: NextApiRequestWithSession): boolean => {
+    const isCarnet = getSessionAttribute(req, CARNET_FARE_TYPE_ATTRIBUTE);
+
+    return isCarnet || false;
 };
 
 export const getFareTypeFromFromAttributes = (req: NextApiRequestWithSession): string => {

--- a/repos/fdbt-site/tests/pages/api/ticketConfirmation.test.ts
+++ b/repos/fdbt-site/tests/pages/api/ticketConfirmation.test.ts
@@ -9,6 +9,7 @@ describe('ticketConfirmation', () => {
     const writeHeadMock = jest.fn();
     const { req, res } = getMockRequestAndResponse({ body: {}, mockWriteHeadFn: writeHeadMock });
     const getFareTypeSpy = jest.spyOn(index, 'getFareTypeFromFromAttributes');
+    const getIsCarnetSpy = jest.spyOn(index, 'getIsCarnet');
     jest.spyOn(index, 'getAndValidateNoc').mockReturnValue('BLAC');
     jest.mock('../../../src/utils/apiUtils');
     jest.mock('../../../src/data/auroradb');
@@ -55,6 +56,16 @@ describe('ticketConfirmation', () => {
     it('should return 302 redirect to /selectPurchaseMethods when the fareType is single and no cap exists', async () => {
         getFareTypeSpy.mockReturnValue('single');
         getCapsSpy.mockResolvedValueOnce([]);
+        await ticketConfirmation(req, res);
+        expect(writeHeadMock).toBeCalledWith(302, {
+            Location: '/selectPurchaseMethods',
+        });
+    });
+
+    it('should return 302 redirect to /selectPurchaseMethods when product is carnet', async () => {
+        getFareTypeSpy.mockReturnValue('single');
+        getIsCarnetSpy.mockReturnValue(true);
+        getCapsSpy.mockResolvedValueOnce([cap]);
         await ticketConfirmation(req, res);
         expect(writeHeadMock).toBeCalledWith(302, {
             Location: '/selectPurchaseMethods',


### PR DESCRIPTION
## Description

Outcome

User should not be able to add caps to carnet products

Details 

Remove the page /selectCaps from all carnet product user journeys 

## Testing instructions
Create a cap
Go to create product create carnet type you should not see select caps page 
Go to single, return or flat fare generically and make a product after creating a cap you should see select cap
