### PR TITLE
fix: Caps should not show on review page for carnet types

### DIFF
--- a/repos/fdbt-site/src/pages/products/productDetails.tsx
+++ b/repos/fdbt-site/src/pages/products/productDetails.tsx
@@ -396,7 +396,7 @@ const createProductDetails = async (
 
     const hasCaps = (await getCaps(noc)).length > 0;
 
-    if (isDevOrTest && fareTypeIsAllowedToAddACap(ticket.type) && hasCaps) {
+    if (isDevOrTest && fareTypeIsAllowedToAddACap(ticket.type) && hasCaps && !ticket.carnet) {
         let capContent = 'N/A';
 
         if ('cap' in ticket && ticket.cap) {

--- a/repos/fdbt-site/src/pages/salesConfirmation.tsx
+++ b/repos/fdbt-site/src/pages/salesConfirmation.tsx
@@ -23,7 +23,6 @@ import { ticketFormatsList } from './managePurchaseMethod';
 import { GetServerSidePropsResult } from 'next';
 import { SalesOfferPackage } from '../interfaces/matchingJsonTypes';
 import { getCapByNocAndId, getCaps } from '../../src/data/auroradb';
-import { getIsCarnet } from '../utils/apiUtils';
 
 const title = 'Sales Confirmation - Create Fares Data Service';
 const description = 'Sales Confirmation page of the Create Fares Data Service';

--- a/repos/fdbt-site/tests/pages/products/productDetails.test.tsx
+++ b/repos/fdbt-site/tests/pages/products/productDetails.test.tsx
@@ -556,6 +556,20 @@ describe('myfares pages', () => {
         });
 
         it('correctly returns the elements which should be displayed on the page for a carnet return ticket', async () => {
+            (getCaps as jest.Mock).mockResolvedValue([
+                {
+                    name: 'Day cap',
+                    price: '5',
+                    durationAmount: '1',
+                    durationUnits: 'day',
+                },
+                {
+                    name: 'Week cap',
+                    price: '20',
+                    durationAmount: '1',
+                    durationUnits: 'week',
+                },
+            ]);
             (getProductsMatchingJson as jest.Mock).mockResolvedValueOnce({
                 ...expectedCarnetReturnTicket,
                 returnPeriodValidity: { amount: '3', typeOfDuration: 'month' },

--- a/repos/fdbt-site/tests/pages/salesConfirmation.test.tsx
+++ b/repos/fdbt-site/tests/pages/salesConfirmation.test.tsx
@@ -34,6 +34,7 @@ describe('pages', () => {
                     fareType="single"
                     hasCaps={false}
                     selectedCap={null}
+                    isCarnet={false}
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -116,6 +117,7 @@ describe('pages', () => {
                         durationUnits: ExpiryUnit.HOUR,
                     },
                 },
+                isCarnet: false,
             };
             const actualProps = await getServerSideProps(ctx);
             expect((actualProps as { props: SalesConfirmationProps }).props).toEqual(expectedProps);
@@ -149,6 +151,7 @@ describe('pages', () => {
                 moment().add(100, 'years').toISOString(),
                 'single',
                 true,
+                false,
                 {
                     id: 2,
                     capDetails: {
@@ -237,6 +240,7 @@ describe('pages', () => {
                 now.add(100, 'years').toISOString(),
                 'single',
                 true,
+                false,
                 null,
             );
             expect(result).toStrictEqual([


### PR DESCRIPTION
## Description

Caps should not show on review page for carnet types
Correcting https://github.com/fares-data-build-tool/create-data/pull/920

## Testing instructions

Check review page when making carnet ticket caps should not be present
