### PR TITLE
feat: Capped purchase methods should only show for caps

### DIFF
--- a/repos/fdbt-site/src/pages/selectPurchaseMethods.tsx
+++ b/repos/fdbt-site/src/pages/selectPurchaseMethods.tsx
@@ -20,7 +20,7 @@ import { getAndValidateNoc, getCsrfToken, sentenceCaseString } from '../utils';
 import { getSessionAttribute } from '../utils/sessions';
 import { removeAllWhiteSpace } from '../utils/apiUtils/validator';
 import { PurchaseMethodCardBody } from './viewPurchaseMethods';
-import { SalesOfferPackage, FromDb, TicketWithIds } from '../interfaces/matchingJsonTypes';
+import { SalesOfferPackage, FromDb } from '../interfaces/matchingJsonTypes';
 import BackButton from '../components/BackButton';
 import { getProductsByValues } from './api/selectSalesOfferPackage';
 

--- a/repos/fdbt-site/src/pages/selectPurchaseMethods.tsx
+++ b/repos/fdbt-site/src/pages/selectPurchaseMethods.tsx
@@ -10,6 +10,7 @@ import {
     MULTIPLE_PRODUCT_ATTRIBUTE,
     SALES_OFFER_PACKAGES_ATTRIBUTE,
     SCHOOL_FARE_TYPE_ATTRIBUTE,
+    CAPS_DEFINITION_ATTRIBUTE,
 } from '../constants/attributes';
 import { getSalesOfferPackagesByNocCode } from '../data/auroradb';
 import { ErrorInfo, NextPageContextWithSession, ProductInfo, ProductWithSalesOfferPackages } from '../interfaces';
@@ -19,7 +20,7 @@ import { getAndValidateNoc, getCsrfToken, sentenceCaseString } from '../utils';
 import { getSessionAttribute } from '../utils/sessions';
 import { removeAllWhiteSpace } from '../utils/apiUtils/validator';
 import { PurchaseMethodCardBody } from './viewPurchaseMethods';
-import { SalesOfferPackage, FromDb } from '../interfaces/matchingJsonTypes';
+import { SalesOfferPackage, FromDb, TicketWithIds } from '../interfaces/matchingJsonTypes';
 import BackButton from '../components/BackButton';
 import { getProductsByValues } from './api/selectSalesOfferPackage';
 
@@ -239,18 +240,20 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
                     .includes(purchaseMethod.id),
             ),
         };
-
+        const isCapped = 'caps' in ticket ? !!(ticket.caps && ticket.caps.length > 0) : false;
         return {
             props: {
                 ...(selectedValue && { selected: selectedValue }),
                 products: [productInfo],
-                purchaseMethodsList: purchaseMethodsList as FromDb<SalesOfferPackage>[],
+                purchaseMethodsList: purchaseMethodsList.filter(
+                    (purchaseMethod) => purchaseMethod.isCapped === isCapped,
+                ),
                 errors,
                 csrfToken,
                 backHref: `/products/productDetails?productId=${matchingJsonMetaData?.productId}${
                     matchingJsonMetaData.serviceId ? `&serviceId=${matchingJsonMetaData?.serviceId}` : ''
                 }`,
-                isCapped: false,
+                isCapped,
             },
         };
     }
@@ -295,8 +298,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
                   )
                   .reduce((result, item) => ({ ...result, [item[0]]: item[1] }), {}));
 
-    const isCapped = false;
-
+    const isCapped = !!getSessionAttribute(ctx.req, CAPS_DEFINITION_ATTRIBUTE);
     return {
         props: {
             ...(selected && { selected: selected }),

--- a/repos/fdbt-site/tests/pages/selectPurchaseMethods.test.tsx
+++ b/repos/fdbt-site/tests/pages/selectPurchaseMethods.test.tsx
@@ -112,7 +112,7 @@ describe('pages', () => {
         errors: [{ errorMessage: 'Choose at least one service from the options', id: 'sales-offer-package-error' }],
         csrfToken: '',
         backHref: '',
-        isCapped: false,
+        isCapped: true,
     };
 
     describe('selectPurchaseMethods', () => {


### PR DESCRIPTION
Story

As a user, I would like to correctly define the purchase methods for individual products that qualify for a cap.

Details

We need to update the regular user journey to only show purchase methods defined in the ‘Capped purchase methods’ feature in the Operator Settings.  

Acceptance Criteria

When I am creating a fare product

Given I have select the ‘Yes’ on the /selectCaps page

When I am on /selectPurchaseMethods page

Then I should only see purchase methods I have defined on ‘Capped purchase methods’ feature on /viewPurchaseMethods page