### PR TITLE
fix: accessibility bugs - hide warning text, fix orphaned form labels

### DIFF
--- a/repos/fdbt-site/src/pages/selectCapExpiry.tsx
+++ b/repos/fdbt-site/src/pages/selectCapExpiry.tsx
@@ -104,7 +104,7 @@ const CapExpiry = ({ errors = [], fieldset, csrfToken }: CapExpiryProps): ReactE
                     <ErrorSummary errors={errors}>
                         {errors.some((error) => error.id === 'product-end-time') && (
                             <p className="govuk-body-m govuk-!-margin-bottom-0 govuk-!-margin-top-4">
-                                <span className="govuk-warning-text__assistive">Warning</span>
+                                <span className="govuk-visually-hidden">Warning</span>
                                 You can set your fare day end in{' '}
                                 <a className="govuk-link" href="/manageFareDayEnd">
                                     operator settings.

--- a/repos/fdbt-site/src/pages/selectCaps.tsx
+++ b/repos/fdbt-site/src/pages/selectCaps.tsx
@@ -66,7 +66,7 @@ const SelectCaps = ({ csrfToken, errors, capsFromDb, backHref, selectedId }: Sel
                                         data-aria-controls="conditional-caps"
                                         defaultChecked={errors.some((error) => error.id === 'caps') || !!selectedId}
                                     />
-                                    <label className="govuk-label govuk-radios__label" htmlFor="yes-choice">
+                                    <label className="govuk-label govuk-radios__label" htmlFor="caps">
                                         Yes
                                     </label>
                                 </div>
@@ -99,10 +99,9 @@ const SelectCaps = ({ csrfToken, errors, capsFromDb, backHref, selectedId }: Sel
                                         name="capChoice"
                                         type="radio"
                                         value="no"
-                                        data-aria-controls="conditional-caps-2"
                                         defaultChecked={!selectedId && !errors.some((error) => error.id === 'caps')}
                                     />
-                                    <label className="govuk-label govuk-radios__label" htmlFor="no-choice">
+                                    <label className="govuk-label govuk-radios__label" htmlFor="no-caps">
                                         No
                                     </label>
                                 </div>
@@ -134,15 +133,19 @@ const CapsCard = ({ cap, selectedId }: { cap: Cap; selectedId: number | null }):
                     <div className="govuk-radios__item card__selector">
                         <input
                             className="govuk-radios__input"
-                            id={`${cap.capDetails.name}-radio`}
+                            id={`${cap.capDetails.name}-${cap.id}-radio`}
                             name="cap"
                             type="radio"
                             value={cap.id}
                             aria-label={cap.capDetails.name}
                             defaultChecked={selectedId === cap.id}
                         />
-                        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-                        <label className="govuk-label govuk-radios__label" />
+                        <label
+                            className="govuk-label govuk-radios__label"
+                            htmlFor={`${cap.capDetails.name}-${cap.id}-radio`}
+                        >
+                            <span className="govuk-visually-hidden">{`${cap.capDetails.name}`}</span>
+                        </label>
                     </div>
                 </div>
                 <CapCardBody cap={cap} />

--- a/repos/fdbt-site/src/pages/selectPassengerType.tsx
+++ b/repos/fdbt-site/src/pages/selectPassengerType.tsx
@@ -55,7 +55,7 @@ const SelectPassengerType = ({
                                 !
                             </span>
                             <strong className="govuk-warning-text__text">
-                                <span className="govuk-warning-text__assistive">Warning</span>
+                                <span className="govuk-visually-hidden">Warning</span>
                                 You can create new types in your{' '}
                                 <a className="govuk-link" href="/viewPassengerTypes">
                                     operator settings.

--- a/repos/fdbt-site/src/pages/selectPeriodValidity.tsx
+++ b/repos/fdbt-site/src/pages/selectPeriodValidity.tsx
@@ -107,7 +107,7 @@ const PeriodValidity = ({ errors = [], fieldset, csrfToken, backHref }: PeriodVa
                     <ErrorSummary errors={errors}>
                         {errors.some((error) => error.id === 'product-end-time') && (
                             <p className="govuk-body-m govuk-!-margin-bottom-0 govuk-!-margin-top-4">
-                                <span className="govuk-warning-text__assistive">Warning</span>
+                                <span className="govuk-visually-hidden">Warning</span>
                                 You can set your fare day end in{' '}
                                 <a className="govuk-link" href="/manageFareDayEnd">
                                     operator settings.

--- a/repos/fdbt-site/tests/pages/__snapshots__/selectPassengerType.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/selectPassengerType.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`pages selectPassengerType should render correctly with no saved groups 
             className="govuk-warning-text__text"
           >
             <span
-              className="govuk-warning-text__assistive"
+              className="govuk-visually-hidden"
             >
               Warning
             </span>
@@ -124,7 +124,7 @@ exports[`pages selectPassengerType should render correctly with no saved groups 
             className="govuk-warning-text__text"
           >
             <span
-              className="govuk-warning-text__assistive"
+              className="govuk-visually-hidden"
             >
               Warning
             </span>
@@ -269,7 +269,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
             className="govuk-warning-text__text"
           >
             <span
-              className="govuk-warning-text__assistive"
+              className="govuk-visually-hidden"
             >
               Warning
             </span>
@@ -481,7 +481,7 @@ exports[`pages selectPassengerType should render correctly with saved groups and
             className="govuk-warning-text__text"
           >
             <span
-              className="govuk-warning-text__assistive"
+              className="govuk-visually-hidden"
             >
               Warning
             </span>


### PR DESCRIPTION
## Description

During testing for accessibility PRs some bigs were found. The word "warning" was showing on warning text which should be hidden.

Orphaned form labels on the Caps page


