### PR TITLE
fix: do not use uppercase wording for tags

### DIFF
--- a/fdbt-dev/README.md
+++ b/fdbt-dev/README.md
@@ -29,8 +29,8 @@ In order to use the scripts in this repo, the FDBT repos need to be in a particu
 | Var                         | Description                                                                                                                          |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | PATH_TO_ROOT                | The absolute path to the root of the [repo structure](#repo-structure)                                                               |
-| COGNITO_USER_POOL_ID        | In the AWS console, using the cfd-test role, Cognito -> Manage User Pools -> fdbt-user-pool-test -> **Pool Id**                      |
-| COGNITO_USER_POOL_CLIENT_ID | In the AWS console, using the cfd-test role, Cognito -> Manage User Pools -> fdbt-user-pool-test -> App clients -> **App client id** |
+| COGNITO_USER_POOL_ID        | In the AWS console, using the aws-tfn-test role, Cognito -> Manage User Pools -> fdbt-user-pool-test -> **Pool Id**                      |
+| COGNITO_USER_POOL_CLIENT_ID | In the AWS console, using the aws-tfn-test role, Cognito -> Manage User Pools -> fdbt-user-pool-test -> App clients -> **App client id** |
 
 Set the above env vars in your .zshrc or .bashrc:
 

--- a/repos/fdbt-site/README.md
+++ b/repos/fdbt-site/README.md
@@ -17,22 +17,20 @@ All assets should be placed into an appropriate folder in `src/assets` and impor
 
 The site runs middleware to require an auth session against AWS Cognito, if you want to disable this for testing purposes you will need to do the following:
 
--   If NODE_ENV is not 'development', you will need to set the environment variable `ALLOW_DISABLE_AUTH` to be `'1'`. If on the development env, you do not need to set this.
--   Hit the homepage with the query string `?disableAuth=true` appended to the URL
--   You should now be able to navigate the site without authenticating
+- If NODE_ENV is not 'development', you will need to set the environment variable `ALLOW_DISABLE_AUTH` to be `'1'`. If on the development env, you do not need to set this.
+- Hit the homepage with the query string `?disableAuth=true` appended to the URL
+  - You can also replace `true` with a known NOC to login with that operator, e.g. `?disableAuth=BLAC`
+- You should now be able to navigate the site without authenticating
 
 ## Running ClamAV virus scanning tool locally
 
 There are two pages on the fdbt site which accept file uploads. Upon file upload, the site will run the ClamAV virus scanning tool (see [https://www.npmjs.com/package/clamscan](https://www.npmjs.com/package/clamscan) for more info) to validate that the uploaded file does no contain any viruses. When running the site locally, the ClamAV virus scanning tool will NOT run by default. If virus scanning is enabled, there are a couple of steps required to get set up and allow the tool to run. The below steps detail how to get ClamAV set up on MacOS:
 
--   The easiest way to get the ClamAV package is by running 'brew install clamav'
--   You will then need to create a 'freshclam.conf' file. This file will allow you to obtain a copy of the ClamAV databases. The file should be added to '/usr/local/etc/clamav/freshclam.conf' and should contain the following:
-    'Database Mirror database.clamav.net'
--   You can then run 'freshclam -v' to download the ClamAV databases.
--   Next, you will need to create a 'clamd.conf' file. This file should be added to '/usr/local/etc/clamav/clamd.conf' and should contain the following:
-    '# /usr/local/var/run/clamav'
--   Finally, you will need to ensure the socket directory exists by running 'mkdir /usr/local/var/run/clamav'.
--   You should now be able to run 'clamdscan' to run the virus scanning tool. Pointing the tool to a file will run the ClamAV virus scanning tool against the file.
+- The easiest way to get the ClamAV package is by running 'brew install clamav'
+- You will then need to create a 'freshclam.conf' file. This file will allow you to obtain a copy of the ClamAV databases. The file should be added to '/usr/local/etc/clamav/freshclam.conf' and should contain the following:'Database Mirror database.clamav.net'
+- You can then run 'freshclam -v' to download the ClamAV databases.
+- Next, you will need to create a 'clamd.conf' file. This file should be added to '/usr/local/etc/clamav/clamd.conf' and should contain the following:'# /usr/local/var/run/clamav'
+- Finally, you will need to ensure the socket directory exists by running 'mkdir /usr/local/var/run/clamav'.
+- You should now be able to run 'clamdscan' to run the virus scanning tool. Pointing the tool to a file will run the ClamAV virus scanning tool against the file.
 
 Once set up, and with the site running locally, the file upload pages can now successfully run the virus scanning tool. The site contains config which will point to the local clamdscan binary that has been set up above.
-

--- a/repos/fdbt-site/src/components/SettingOverview.tsx
+++ b/repos/fdbt-site/src/components/SettingOverview.tsx
@@ -8,7 +8,7 @@ const SettingOverview = ({ href, name, description, count }: SettingsOverview): 
                 <p className="govuk-body-s govuk-!-font-weight-bold">
                     {name}
                     {typeof count === 'number' && <b className="numberCircle">{count}</b>}
-                    {!count ? null : <strong className="govuk-tag customised-tag">CUSTOMISED</strong>}
+                    {!count ? null : <strong className="govuk-tag customised-tag">Customised</strong>}
                 </p>
                 <p className="govuk-body-s">{description}</p>
             </a>

--- a/repos/fdbt-site/src/pages/home.tsx
+++ b/repos/fdbt-site/src/pages/home.tsx
@@ -33,7 +33,7 @@ const Home = ({ csrfToken, showDeleteProductsLink }: HomeProps): ReactElement =>
 
                 <div className="govuk-!-margin-top-7">
                     <h2 className="govuk-heading-s">
-                        <strong className="govuk-tag new-tag">new</strong>
+                        <strong className="govuk-tag new-tag">New</strong>
                         Manage fares
                     </h2>
                     <p className="govuk-body">View and manage all of your products and services in one place.</p>

--- a/repos/fdbt-site/src/pages/products/exports.tsx
+++ b/repos/fdbt-site/src/pages/products/exports.tsx
@@ -23,7 +23,7 @@ const getTag = (exportDetails: Export): ReactElement => {
     if (exportDetails.netexCount === 0) {
         return (
             <strong className="govuk-tag govuk-tag--blue">
-                {`LOADING PRODUCTS (${exportDetails.numberOfFilesExpected})`}
+                {`Loading products (${exportDetails.numberOfFilesExpected})`}
             </strong>
         );
     }
@@ -31,25 +31,25 @@ const getTag = (exportDetails: Export): ReactElement => {
     if (exportDetails.netexCount === exportDetails.numberOfFilesExpected) {
         if (exportDetails.signedUrl) {
             return (
-                <strong className="govuk-tag govuk-tag--green">{`EXPORT COMPLETE ${exportDetails.netexCount} / ${exportDetails.numberOfFilesExpected}`}</strong>
+                <strong className="govuk-tag govuk-tag--green">{`Export complete ${exportDetails.netexCount} / ${exportDetails.numberOfFilesExpected}`}</strong>
             );
         }
         return (
-            <strong className="govuk-tag govuk-tag--blue">{`EXPORT ZIPPING ${exportDetails.netexCount} / ${exportDetails.numberOfFilesExpected}`}</strong>
+            <strong className="govuk-tag govuk-tag--blue">{`Export zipping ${exportDetails.netexCount} / ${exportDetails.numberOfFilesExpected}`}</strong>
         );
     }
 
     if (exportDetails.exportFailed) {
         const numberOfFilesMissing = exportDetails.numberOfFilesExpected - exportDetails.netexCount;
         return (
-            <strong className="govuk-tag govuk-tag--red">{`EXPORT FAILED - ${numberOfFilesMissing} ${
+            <strong className="govuk-tag govuk-tag--red">{`Export failed - ${numberOfFilesMissing} ${
                 numberOfFilesMissing > 0 ? 'files' : 'file'
             } failed`}</strong>
         );
     }
 
     return (
-        <strong className="govuk-tag govuk-tag--blue">{`IN PROGRESS ${exportDetails.netexCount} / ${exportDetails.numberOfFilesExpected}`}</strong>
+        <strong className="govuk-tag govuk-tag--blue">{`In progress ${exportDetails.netexCount} / ${exportDetails.numberOfFilesExpected}`}</strong>
     );
 };
 

--- a/repos/fdbt-site/src/pages/products/pointToPointProducts.tsx
+++ b/repos/fdbt-site/src/pages/products/pointToPointProducts.tsx
@@ -148,7 +148,7 @@ const PointToPointProductsTable = (
                                       {getTag(product.startDate, product.endDate, true)}
                                       {product.requiresAttention ? (
                                           <strong className="govuk-tag govuk-tag--yellow dft-table-tag">
-                                              NEEDS ATTENTION
+                                              Needs attention
                                           </strong>
                                       ) : null}
                                   </td>

--- a/repos/fdbt-site/src/pages/products/productDetails.tsx
+++ b/repos/fdbt-site/src/pages/products/productDetails.tsx
@@ -117,7 +117,7 @@ const ProductDetails = ({
             <div id="product-status" className="govuk-hint">
                 Product status: {getTag(startDate, endDate, false)}
                 {requiresAttention && (
-                    <strong className="govuk-tag govuk-tag--yellow govuk-!-margin-left-2">NEEDS ATTENTION</strong>
+                    <strong className="govuk-tag govuk-tag--yellow govuk-!-margin-left-2">Needs attention</strong>
                 )}
             </div>
 

--- a/repos/fdbt-site/src/pages/products/services.tsx
+++ b/repos/fdbt-site/src/pages/products/services.tsx
@@ -85,7 +85,7 @@ const ServicesTable = (services: MyFaresServiceWithProductCount[]): ReactElement
                         <td className="govuk-table__cell dft-text-align-centre">
                             {getTag(service.startDate, service.endDate, true)}
                             {service.requiresAttention === true ? (
-                                <strong className="govuk-tag govuk-tag--yellow dft-table-tag">NEEDS ATTENTION</strong>
+                                <strong className="govuk-tag govuk-tag--yellow dft-table-tag">Needs attention</strong>
                             ) : null}
                         </td>
                     </tr>

--- a/repos/fdbt-site/tests/pages/__snapshots__/home.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/home.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`pages home page should render correctly 1`] = `
           <strong
             className="govuk-tag new-tag"
           >
-            new
+            New
           </strong>
           Manage fares
         </h2>
@@ -179,7 +179,7 @@ exports[`pages home page should render correctly for prod environment 1`] = `
           <strong
             className="govuk-tag new-tag"
           >
-            new
+            New
           </strong>
           Manage fares
         </h2>

--- a/repos/fdbt-site/tests/pages/products/__snapshots__/pointToPointProducts.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/products/__snapshots__/pointToPointProducts.test.tsx.snap
@@ -425,7 +425,7 @@ exports[`myfares pages pointToPointProducts should render correctly when product
                 <strong
                   className="govuk-tag govuk-tag--yellow dft-table-tag"
                 >
-                  NEEDS ATTENTION
+                  Needs attention
                 </strong>
               </td>
               <td

--- a/repos/fdbt-site/tests/pages/products/__snapshots__/productDetails.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/products/__snapshots__/productDetails.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`myfares pages productDetails should render correctly 1`] = `
     <strong
       className="govuk-tag govuk-tag--yellow govuk-!-margin-left-2"
     >
-      NEEDS ATTENTION
+      Needs attention
     </strong>
   </div>
   <dl
@@ -378,7 +378,7 @@ exports[`myfares pages productDetails should render correctly for a copied produ
     <strong
       className="govuk-tag govuk-tag--yellow govuk-!-margin-left-2"
     >
-      NEEDS ATTENTION
+      Needs attention
     </strong>
   </div>
   <dl
@@ -692,7 +692,7 @@ exports[`myfares pages productDetails should render correctly for a fare triangl
     <strong
       className="govuk-tag govuk-tag--yellow govuk-!-margin-left-2"
     >
-      NEEDS ATTENTION
+      Needs attention
     </strong>
   </div>
   <dl
@@ -1003,7 +1003,7 @@ exports[`myfares pages productDetails should render correctly while the cannot g
     <strong
       className="govuk-tag govuk-tag--yellow govuk-!-margin-left-2"
     >
-      NEEDS ATTENTION
+      Needs attention
     </strong>
   </div>
   <dl

--- a/repos/fdbt-site/tests/pages/products/__snapshots__/services.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/products/__snapshots__/services.test.tsx.snap
@@ -464,7 +464,7 @@ exports[`myfares pages services should render correctly when services require at
                 <strong
                   className="govuk-tag govuk-tag--yellow dft-table-tag"
                 >
-                  NEEDS ATTENTION
+                  Needs attention
                 </strong>
               </td>
             </tr>


### PR DESCRIPTION
## Description

The GDS guidelines mention that uppercase text is harder to read. Since Gov UK tag examples use normal case, the tag casing has been updated.

## Testing instructions

Check tag casing in the following pages:
- home page when logged in
- services list
- select exports

