### PR TITLE
fix: only map over valid products in exporter

### DIFF
--- a/repos/fdbt-site/src/pages/products/selectExports.tsx
+++ b/repos/fdbt-site/src/pages/products/selectExports.tsx
@@ -482,11 +482,15 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     const allServicesWithMatchingLineIds: Record<string, MyFaresService> = {};
 
     const validProducts = nonExpiredProducts.filter((product) => {
+        if (!product.lineId) {
+            return true;
+        }
+
+        // If the product has a line ID but the ID doesn't match any of the services, the product should no longer be surfaced
         const matchingService = allBodsServices.find((service) => service.lineId === product.lineId);
 
         if (matchingService) {
             allServicesWithMatchingLineIds[matchingService.id] = matchingService;
-
             return true;
         }
 


### PR DESCRIPTION
## Description

The select exports page displays a count of all the user's products available for export, however this count includes invalid products that are not available to select. The fix is to omit invalid products from the count.

## Testing instructions

In pre-prod, the FSYO operator contains two invalid products and several valid products. Assert that the count of selected products matches the number of available products to select in the export tool. The count is in an indicator tag in the top-left of the page, e.g. "0 / 5 selected"
