### PR TITLE
feat: add service changelog

### DIFF
--- a/repos/fdbt-site/server/index.ts
+++ b/repos/fdbt-site/server/index.ts
@@ -37,6 +37,7 @@ const unauthenticatedGetRoutes = [
     '/privacy',
     '/noServices',
     '/robots.txt',
+    '/changelog',
 ];
 
 const unauthenticatedPostRoutes = [

--- a/repos/fdbt-site/src/layout/Footer.tsx
+++ b/repos/fdbt-site/src/layout/Footer.tsx
@@ -37,6 +37,11 @@ const Footer = (): ReactElement => (
                                 Privacy
                             </a>
                         </li>
+                        <li className="govuk-footer__inline-list-item">
+                            <a className="govuk-footer__link" href="/changelog">
+                                Service changelog
+                            </a>
+                        </li>
                     </ul>
                     <p className="govuk-footer__body">
                         Built by the{' '}

--- a/repos/fdbt-site/src/pages/changelog.tsx
+++ b/repos/fdbt-site/src/pages/changelog.tsx
@@ -26,7 +26,7 @@ const Changelog = (): ReactElement => (
         <h2 className="govuk-heading-l">October 2024 (1.86.0)</h2>
         <ul className="govuk-list govuk-list--bullet">
             <li>Remove flag pricing by distance on flat fare journeys</li>
-            <li>Upgrade the GOVV.UK frontend version to v5</li>
+            <li>Upgrade the GOV.UK frontend version to v5</li>
             <li>Change crown logo to His Majesty The King</li>
             <li>Improve accessibility compliance across the site</li>
         </ul>

--- a/repos/fdbt-site/src/pages/changelog.tsx
+++ b/repos/fdbt-site/src/pages/changelog.tsx
@@ -1,0 +1,47 @@
+import React, { ReactElement } from 'react';
+import TwoThirdsLayout from '../layout/Layout';
+
+const title = 'Changelog - Create Fares Data Service';
+const description = 'Changelog page for the Create Fares Data Service';
+
+const Changelog = (): ReactElement => (
+    <TwoThirdsLayout title={title} description={description}>
+        <h1 className="govuk-heading-xl">Service Changelog</h1>
+        <p className="govuk-body">Last updated: 17 December 2024</p>
+        <hr className="govuk-section-break govuk-section-break--xl govuk-section-break--visible" />
+        <h2 className="govuk-heading-l">December 2024 (1.88.0)</h2>
+        <ul className="govuk-list govuk-list--bullet">
+            <li>Add service changelog</li>
+            <li>Add missing caps selection option when creating products</li>
+            <li>Hide expired and invalid products in the exporter tool</li>
+            <li>Use proper casing for GOV.UK tags</li>
+        </ul>
+        <hr className="govuk-section-break govuk-section-break--xl govuk-section-break--visible" />
+        <h2 className="govuk-heading-l">December 2024 (1.87.0)</h2>
+        <ul className="govuk-list govuk-list--bullet">
+            <li>Add fares cap options for ticketing products</li>
+            <li>Improve site password policy</li>
+        </ul>
+        <hr className="govuk-section-break govuk-section-break--xl govuk-section-break--visible" />
+        <h2 className="govuk-heading-l">October 2024 (1.86.0)</h2>
+        <ul className="govuk-list govuk-list--bullet">
+            <li>Remove flag pricing by distance on flat fare journeys</li>
+            <li>Upgrade the GOVV.UK frontend version to v5</li>
+            <li>Change crown logo to His Majesty The King</li>
+            <li>Improve accessibility compliance across the site</li>
+        </ul>
+        <hr className="govuk-section-break govuk-section-break--xl govuk-section-break--visible" />
+        <h2 className="govuk-heading-l">March 2024 (1.85.0)</h2>
+        <ul className="govuk-list govuk-list--bullet">
+            <li>Fix download template & guide links on several pages</li>
+            <li>Prevent unexpected stops appearing in stop lists</li>
+            <li>Use correct fare zone type for some fare frames</li>
+        </ul>
+    </TwoThirdsLayout>
+);
+
+export const getServerSideProps = (): { props: {} } => ({
+    props: {},
+});
+
+export default Changelog;

--- a/repos/fdbt-site/src/pages/index.tsx
+++ b/repos/fdbt-site/src/pages/index.tsx
@@ -1,57 +1,68 @@
 import React, { ReactElement } from 'react';
-import TwoThirdsLayout from '../layout/Layout';
+import { BaseLayout } from '../layout/Layout';
 
 const title = 'Create Fares Data';
 const description = 'Create Fares Data is a service that allows you to generate data in NeTEx format';
 
 const Start = (): ReactElement => (
-    <TwoThirdsLayout title={title} description={description}>
-        <h1 className="govuk-heading-xl">Create fares data</h1>
+    <BaseLayout title={title} description={description}>
+        <div className="govuk-grid-row">
+            <div className="govuk-grid-column-two-thirds">
+                <h1 className="govuk-heading-xl">Create fares data</h1>
 
-        <p className="govuk-body">
-            This service is for creating or accessing NeTEx data for public transport services, excluding rail, in
-            England. The service can be used by:
-        </p>
+                <p className="govuk-body">
+                    This service is for creating or accessing NeTEx data for public transport services, excluding rail,
+                    in England. The service can be used by:
+                </p>
 
-        <ul className="govuk-list govuk-list--bullet">
-            <li>Bus operators running commercial services in England</li>
-            <li>Local transport authorities acting on behalf of bus operators</li>
-            <li>Local transport authorities that operate their own services</li>
-        </ul>
+                <ul className="govuk-list govuk-list--bullet">
+                    <li>Bus operators running commercial services in England</li>
+                    <li>Local transport authorities acting on behalf of bus operators</li>
+                    <li>Local transport authorities that operate their own services</li>
+                </ul>
 
-        <p className="govuk-body">Use this service to:</p>
+                <p className="govuk-body">Use this service to:</p>
 
-        <ul className="govuk-list govuk-list--bullet">
-            <li>Generate fares data in NeTEx format for a new or existing service</li>
-            <li>Download your own fares data</li>
-        </ul>
-        <p className="govuk-body">
-            All service data is taken directly from the Traveline National Data Set and the NaPTAN database. To avoid
-            data discrepancies, ensure that all service data is correct within these datasets before using the service.
-        </p>
+                <ul className="govuk-list govuk-list--bullet">
+                    <li>Generate fares data in NeTEx format for a new or existing service</li>
+                    <li>Download your own fares data</li>
+                </ul>
+                <p className="govuk-body">
+                    All service data is taken directly from the Traveline National Data Set and the NaPTAN database. To
+                    avoid data discrepancies, ensure that all service data is correct within these datasets before using
+                    the service.
+                </p>
 
-        <a
-            href="/home"
-            role="button"
-            draggable="false"
-            className="govuk-button govuk-button--start"
-            data-module="govuk-button"
-            id="start-now-button"
-        >
-            Start now
-            <svg
-                className="govuk-button__start-icon"
-                xmlns="http://www.w3.org/2000/svg"
-                width="17.5"
-                height="19"
-                viewBox="0 0 33 40"
-                role="presentation"
-                focusable="false"
-            >
-                <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-            </svg>
-        </a>
-    </TwoThirdsLayout>
+                <a
+                    href="/home"
+                    role="button"
+                    draggable="false"
+                    className="govuk-button govuk-button--start"
+                    data-module="govuk-button"
+                    id="start-now-button"
+                >
+                    Start now
+                    <svg
+                        className="govuk-button__start-icon"
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="17.5"
+                        height="19"
+                        viewBox="0 0 33 40"
+                        role="presentation"
+                        focusable="false"
+                    >
+                        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+                    </svg>
+                </a>
+            </div>
+            <div className="govuk-grid-column-one-thirds">
+                <h2 className="govuk-heading-m">Public information</h2>
+                <a className="govuk-link govuk-body" href="/changelog">
+                    Service changelog
+                </a>
+            </div>
+        </div>
+    </BaseLayout>
 );
 
 export const getServerSideProps = (): { props: {} } => ({

--- a/repos/fdbt-site/tests/layout/__snapshots__/Footer.test.tsx.snap
+++ b/repos/fdbt-site/tests/layout/__snapshots__/Footer.test.tsx.snap
@@ -82,6 +82,16 @@ exports[`Footer should render correctly 1`] = `
               Privacy
             </a>
           </li>
+          <li
+            className="govuk-footer__inline-list-item"
+          >
+            <a
+              className="govuk-footer__link"
+              href="/changelog"
+            >
+              Service changelog
+            </a>
+          </li>
         </ul>
         <p
           className="govuk-footer__body"

--- a/repos/fdbt-site/tests/pages/__snapshots__/changelog.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/changelog.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`contact should render correctly 1`] = `
       Remove flag pricing by distance on flat fare journeys
     </li>
     <li>
-      Upgrade the GOVV.UK frontend version to v5
+      Upgrade the GOV.UK frontend version to v5
     </li>
     <li>
       Change crown logo to His Majesty The King

--- a/repos/fdbt-site/tests/pages/__snapshots__/changelog.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/changelog.test.tsx.snap
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`contact should render correctly 1`] = `
+<TwoThirdsLayout
+  description="Changelog page for the Create Fares Data Service"
+  title="Changelog - Create Fares Data Service"
+>
+  <h1
+    className="govuk-heading-xl"
+  >
+    Service Changelog
+  </h1>
+  <p
+    className="govuk-body"
+  >
+    Last updated: 17 December 2024
+  </p>
+  <hr
+    className="govuk-section-break govuk-section-break--xl govuk-section-break--visible"
+  />
+  <h2
+    className="govuk-heading-l"
+  >
+    December 2024 (1.88.0)
+  </h2>
+  <ul
+    className="govuk-list govuk-list--bullet"
+  >
+    <li>
+      Add service changelog
+    </li>
+    <li>
+      Add missing caps selection option when creating products
+    </li>
+    <li>
+      Hide expired and invalid products in the exporter tool
+    </li>
+    <li>
+      Use proper casing for GOV.UK tags
+    </li>
+  </ul>
+  <hr
+    className="govuk-section-break govuk-section-break--xl govuk-section-break--visible"
+  />
+  <h2
+    className="govuk-heading-l"
+  >
+    December 2024 (1.87.0)
+  </h2>
+  <ul
+    className="govuk-list govuk-list--bullet"
+  >
+    <li>
+      Add fares cap options for ticketing products
+    </li>
+    <li>
+      Improve site password policy
+    </li>
+  </ul>
+  <hr
+    className="govuk-section-break govuk-section-break--xl govuk-section-break--visible"
+  />
+  <h2
+    className="govuk-heading-l"
+  >
+    October 2024 (1.86.0)
+  </h2>
+  <ul
+    className="govuk-list govuk-list--bullet"
+  >
+    <li>
+      Remove flag pricing by distance on flat fare journeys
+    </li>
+    <li>
+      Upgrade the GOVV.UK frontend version to v5
+    </li>
+    <li>
+      Change crown logo to His Majesty The King
+    </li>
+    <li>
+      Improve accessibility compliance across the site
+    </li>
+  </ul>
+  <hr
+    className="govuk-section-break govuk-section-break--xl govuk-section-break--visible"
+  />
+  <h2
+    className="govuk-heading-l"
+  >
+    March 2024 (1.85.0)
+  </h2>
+  <ul
+    className="govuk-list govuk-list--bullet"
+  >
+    <li>
+      Fix download template & guide links on several pages
+    </li>
+    <li>
+      Prevent unexpected stops appearing in stop lists
+    </li>
+    <li>
+      Use correct fare zone type for some fare frames
+    </li>
+  </ul>
+</TwoThirdsLayout>
+`;

--- a/repos/fdbt-site/tests/pages/__snapshots__/index.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/index.test.tsx.snap
@@ -1,151 +1,197 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`pages operator should render correctly 1`] = `
-<TwoThirdsLayout
+<BaseLayout
   description="Create Fares Data is a service that allows you to generate data in NeTEx format"
   title="Create Fares Data"
 >
-  <h1
-    className="govuk-heading-xl"
+  <div
+    className="govuk-grid-row"
   >
-    Create fares data
-  </h1>
-  <p
-    className="govuk-body"
-  >
-    This service is for creating or accessing NeTEx data for public transport services, excluding rail, in England. The service can be used by:
-  </p>
-  <ul
-    className="govuk-list govuk-list--bullet"
-  >
-    <li>
-      Bus operators running commercial services in England
-    </li>
-    <li>
-      Local transport authorities acting on behalf of bus operators
-    </li>
-    <li>
-      Local transport authorities that operate their own services
-    </li>
-  </ul>
-  <p
-    className="govuk-body"
-  >
-    Use this service to:
-  </p>
-  <ul
-    className="govuk-list govuk-list--bullet"
-  >
-    <li>
-      Generate fares data in NeTEx format for a new or existing service
-    </li>
-    <li>
-      Download your own fares data
-    </li>
-  </ul>
-  <p
-    className="govuk-body"
-  >
-    All service data is taken directly from the Traveline National Data Set and the NaPTAN database. To avoid data discrepancies, ensure that all service data is correct within these datasets before using the service.
-  </p>
-  <a
-    className="govuk-button govuk-button--start"
-    data-module="govuk-button"
-    draggable="false"
-    href="/home"
-    id="start-now-button"
-    role="button"
-  >
-    Start now
-    <svg
-      className="govuk-button__start-icon"
-      focusable="false"
-      height="19"
-      role="presentation"
-      viewBox="0 0 33 40"
-      width="17.5"
-      xmlns="http://www.w3.org/2000/svg"
+    <div
+      className="govuk-grid-column-two-thirds"
     >
-      <path
-        d="M0 0h13l20 20-20 20H0l20-20z"
-        fill="currentColor"
-      />
-    </svg>
-  </a>
-</TwoThirdsLayout>
+      <h1
+        className="govuk-heading-xl"
+      >
+        Create fares data
+      </h1>
+      <p
+        className="govuk-body"
+      >
+        This service is for creating or accessing NeTEx data for public transport services, excluding rail, in England. The service can be used by:
+      </p>
+      <ul
+        className="govuk-list govuk-list--bullet"
+      >
+        <li>
+          Bus operators running commercial services in England
+        </li>
+        <li>
+          Local transport authorities acting on behalf of bus operators
+        </li>
+        <li>
+          Local transport authorities that operate their own services
+        </li>
+      </ul>
+      <p
+        className="govuk-body"
+      >
+        Use this service to:
+      </p>
+      <ul
+        className="govuk-list govuk-list--bullet"
+      >
+        <li>
+          Generate fares data in NeTEx format for a new or existing service
+        </li>
+        <li>
+          Download your own fares data
+        </li>
+      </ul>
+      <p
+        className="govuk-body"
+      >
+        All service data is taken directly from the Traveline National Data Set and the NaPTAN database. To avoid data discrepancies, ensure that all service data is correct within these datasets before using the service.
+      </p>
+      <a
+        className="govuk-button govuk-button--start"
+        data-module="govuk-button"
+        draggable="false"
+        href="/home"
+        id="start-now-button"
+        role="button"
+      >
+        Start now
+        <svg
+          className="govuk-button__start-icon"
+          focusable="false"
+          height="19"
+          role="presentation"
+          viewBox="0 0 33 40"
+          width="17.5"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 0h13l20 20-20 20H0l20-20z"
+            fill="currentColor"
+          />
+        </svg>
+      </a>
+    </div>
+    <div
+      className="govuk-grid-column-one-thirds"
+    >
+      <h2
+        className="govuk-heading-m"
+      >
+        Public information
+      </h2>
+      <a
+        className="govuk-link govuk-body"
+        href="/changelog"
+      >
+        Service changelog
+      </a>
+    </div>
+  </div>
+</BaseLayout>
 `;
 
 exports[`pages operator should render correctly with no multiple operators 1`] = `
-<TwoThirdsLayout
+<BaseLayout
   description="Create Fares Data is a service that allows you to generate data in NeTEx format"
   title="Create Fares Data"
 >
-  <h1
-    className="govuk-heading-xl"
+  <div
+    className="govuk-grid-row"
   >
-    Create fares data
-  </h1>
-  <p
-    className="govuk-body"
-  >
-    This service is for creating or accessing NeTEx data for public transport services, excluding rail, in England. The service can be used by:
-  </p>
-  <ul
-    className="govuk-list govuk-list--bullet"
-  >
-    <li>
-      Bus operators running commercial services in England
-    </li>
-    <li>
-      Local transport authorities acting on behalf of bus operators
-    </li>
-    <li>
-      Local transport authorities that operate their own services
-    </li>
-  </ul>
-  <p
-    className="govuk-body"
-  >
-    Use this service to:
-  </p>
-  <ul
-    className="govuk-list govuk-list--bullet"
-  >
-    <li>
-      Generate fares data in NeTEx format for a new or existing service
-    </li>
-    <li>
-      Download your own fares data
-    </li>
-  </ul>
-  <p
-    className="govuk-body"
-  >
-    All service data is taken directly from the Traveline National Data Set and the NaPTAN database. To avoid data discrepancies, ensure that all service data is correct within these datasets before using the service.
-  </p>
-  <a
-    className="govuk-button govuk-button--start"
-    data-module="govuk-button"
-    draggable="false"
-    href="/home"
-    id="start-now-button"
-    role="button"
-  >
-    Start now
-    <svg
-      className="govuk-button__start-icon"
-      focusable="false"
-      height="19"
-      role="presentation"
-      viewBox="0 0 33 40"
-      width="17.5"
-      xmlns="http://www.w3.org/2000/svg"
+    <div
+      className="govuk-grid-column-two-thirds"
     >
-      <path
-        d="M0 0h13l20 20-20 20H0l20-20z"
-        fill="currentColor"
-      />
-    </svg>
-  </a>
-</TwoThirdsLayout>
+      <h1
+        className="govuk-heading-xl"
+      >
+        Create fares data
+      </h1>
+      <p
+        className="govuk-body"
+      >
+        This service is for creating or accessing NeTEx data for public transport services, excluding rail, in England. The service can be used by:
+      </p>
+      <ul
+        className="govuk-list govuk-list--bullet"
+      >
+        <li>
+          Bus operators running commercial services in England
+        </li>
+        <li>
+          Local transport authorities acting on behalf of bus operators
+        </li>
+        <li>
+          Local transport authorities that operate their own services
+        </li>
+      </ul>
+      <p
+        className="govuk-body"
+      >
+        Use this service to:
+      </p>
+      <ul
+        className="govuk-list govuk-list--bullet"
+      >
+        <li>
+          Generate fares data in NeTEx format for a new or existing service
+        </li>
+        <li>
+          Download your own fares data
+        </li>
+      </ul>
+      <p
+        className="govuk-body"
+      >
+        All service data is taken directly from the Traveline National Data Set and the NaPTAN database. To avoid data discrepancies, ensure that all service data is correct within these datasets before using the service.
+      </p>
+      <a
+        className="govuk-button govuk-button--start"
+        data-module="govuk-button"
+        draggable="false"
+        href="/home"
+        id="start-now-button"
+        role="button"
+      >
+        Start now
+        <svg
+          className="govuk-button__start-icon"
+          focusable="false"
+          height="19"
+          role="presentation"
+          viewBox="0 0 33 40"
+          width="17.5"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 0h13l20 20-20 20H0l20-20z"
+            fill="currentColor"
+          />
+        </svg>
+      </a>
+    </div>
+    <div
+      className="govuk-grid-column-one-thirds"
+    >
+      <h2
+        className="govuk-heading-m"
+      >
+        Public information
+      </h2>
+      <a
+        className="govuk-link govuk-body"
+        href="/changelog"
+      >
+        Service changelog
+      </a>
+    </div>
+  </div>
+</BaseLayout>
 `;

--- a/repos/fdbt-site/tests/pages/changelog.test.tsx
+++ b/repos/fdbt-site/tests/pages/changelog.test.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import Changelog from '../../src/pages/changelog';
+
+describe('contact', () => {
+    it('should render correctly', () => {
+        const tree = shallow(<Changelog />);
+        expect(tree).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
## Description

Add a service changelog to the site

## Testing instructions

- Go to "/changelog" and assert the page exists
- Assert the page has changelog content from 2024 onwards
- Assert the site footer has a "Service changelog" link to the changelog page
- Assert that on the home page under the main body, there is a link to the changelog page