### PR TITLE
feat: amend multi-operator option text on fare type page

### DIFF
--- a/repos/fdbt-site/src/pages/fareType.tsx
+++ b/repos/fdbt-site/src/pages/fareType.tsx
@@ -87,8 +87,8 @@ const buildRadioProps = (schemeOp: boolean): RadioOption[] => {
         },
         {
             value: 'multiOperator',
-            label: 'Multi-operator',
-            hint: 'A ticket that covers more than one operator',
+            label: 'Multi-operator (internal)',
+            hint: 'A ticket that covers more than one NOC in your organisation',
         },
         {
             value: 'schoolService',

--- a/repos/fdbt-site/tests/pages/__snapshots__/fareType.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/fareType.test.tsx.snap
@@ -72,8 +72,8 @@ exports[`pages fareType should render correctly 1`] = `
                   "value": "carnet",
                 },
                 Object {
-                  "hint": "A ticket that covers more than one operator",
-                  "label": "Multi-operator",
+                  "hint": "A ticket that covers more than one NOC in your organisation",
+                  "label": "Multi-operator (internal)",
                   "value": "multiOperator",
                 },
                 Object {
@@ -272,8 +272,8 @@ exports[`pages fareType should render error messaging when errors are passed to 
                   "value": "carnet",
                 },
                 Object {
-                  "hint": "A ticket that covers more than one operator",
-                  "label": "Multi-operator",
+                  "hint": "A ticket that covers more than one NOC in your organisation",
+                  "label": "Multi-operator (internal)",
                   "value": "multiOperator",
                 },
                 Object {


### PR DESCRIPTION
## Description

Amends text for the existing multi-operator option on the select fare type page

## Testing instructions

Assert that the multi-operator option label and supporting text matches the new text on the designs
