### PR TITLE
CFDS-317 multi-operator external journey (lead operator only)

### DIFF
--- a/fdbt-aws/sql/r.productAdditionalNocs.sql
+++ b/fdbt-aws/sql/r.productAdditionalNocs.sql
@@ -1,0 +1,14 @@
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+
+DROP TABLE IF EXISTS productAdditionalNocs;
+
+CREATE TABLE productAdditionalNocs(
+    `id` int(11) NOT NULL AUTO_INCREMENT,
+    `productId` int(11) NOT NULL,
+    `additionalNocCode` varchar(10) NOT NULL,
+    INDEX idx_additionalNocCode (additionalNocCode),
+    PRIMARY KEY (`id`),
+    CONSTRAINT fk_productAdditionalNocs_products_id FOREIGN KEY (productId) REFERENCES products(id) ON DELETE CASCADE
+) ENGINE = InnoDB CHARACTER SET = utf8;
+
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;

--- a/fdbt-dev/data/productsData/multiOperatorExt/BLAC38f1952d_1738684176462.json
+++ b/fdbt-dev/data/productsData/multiOperatorExt/BLAC38f1952d_1738684176462.json
@@ -1,0 +1,204 @@
+{
+  "nocCode": "BLAC",
+  "type": "multiOperatorExt",
+  "passengerType": {
+    "id": 3
+  },
+  "email": "test@example.com",
+  "uuid": "BLAC38f1952d",
+  "ticketPeriod": {
+    "startDate": "2025-01-01T00:00:00.000Z"
+  },
+  "operatorName": "Test Operator",
+  "products": [
+    {
+      "productName": "MOBE-fare-zone-1",
+      "productPrice": "1.23",
+      "salesOfferPackages": [
+        {
+          "id": 1,
+          "price": "1.23"
+        }
+      ]
+    }
+  ],
+  "zoneName": "Test Town Centre",
+  "stops": [
+    {
+      "stopName": "The Towers",
+      "naptanCode": "CHEPJWM",
+      "atcoCode": "0600MA6001",
+      "localityCode": "N0076467",
+      "localityName": "Macclesfield",
+      "parentLocalityName": "",
+      "indicator": "opp",
+      "street": "Park Street"
+    },
+    {
+      "stopName": "Dog & Partridge",
+      "naptanCode": "wrgdpma",
+      "atcoCode": "069000012480",
+      "localityCode": "E0043040",
+      "localityName": "Paddington",
+      "parentLocalityName": "Warrington",
+      "indicator": "o/s",
+      "street": "New Manchester Road"
+    },
+    {
+      "stopName": "Manchester Rd",
+      "naptanCode": "MANATDWT",
+      "atcoCode": "1800ED24711",
+      "localityCode": "E0028839",
+      "localityName": "Hollinwood",
+      "parentLocalityName": "",
+      "indicator": "Stop A",
+      "street": "MANCHESTER RD"
+    },
+    {
+      "stopName": "Bower Fold",
+      "naptanCode": "MANDGADW",
+      "atcoCode": "1800EH37241",
+      "localityCode": "E0028586",
+      "localityName": "Bower Fold",
+      "parentLocalityName": "Stalybridge",
+      "indicator": null,
+      "street": "Mottram Rd"
+    },
+    {
+      "stopName": "Oak Road",
+      "naptanCode": "MANJTPJW",
+      "atcoCode": "1800SJ47971",
+      "localityCode": "N0075113",
+      "localityName": "Partington",
+      "parentLocalityName": "",
+      "indicator": "nr",
+      "street": "WARBURTON LANE"
+    },
+    {
+      "stopName": "Meadow Close",
+      "naptanCode": "MANPATDT",
+      "atcoCode": "1800WA15551",
+      "localityCode": "E0028979",
+      "localityName": "Little Lever",
+      "parentLocalityName": "",
+      "indicator": "opp",
+      "street": "BOOTH ROAD"
+    },
+    {
+      "stopName": "Church Road",
+      "naptanCode": "lanatgjp",
+      "atcoCode": "25001814",
+      "localityCode": "E0015836",
+      "localityName": "Great Plumpton",
+      "parentLocalityName": "",
+      "indicator": "by",
+      "street": "Church Road"
+    },
+    {
+      "stopName": "Hare and Hounds",
+      "naptanCode": "lanawtwg",
+      "atcoCode": "2500759",
+      "localityCode": "E0015881",
+      "localityName": "Clayton-le-Moors",
+      "parentLocalityName": "",
+      "indicator": "Stop 2",
+      "street": "Whalley Road"
+    },
+    {
+      "stopName": "Skippool Avenue",
+      "naptanCode": "langjpaw",
+      "atcoCode": "2500IMG456",
+      "localityCode": "E0016583",
+      "localityName": "Poulton-le-Fylde",
+      "parentLocalityName": "",
+      "indicator": "opp",
+      "street": "Breck Road"
+    },
+    {
+      "stopName": "Lytham St Annes HTC",
+      "naptanCode": "lanpamtw",
+      "atcoCode": "2500LAA16548",
+      "localityCode": "E0015826",
+      "localityName": "Ansdell",
+      "parentLocalityName": "",
+      "indicator": "by",
+      "street": "Church Road"
+    },
+    {
+      "stopName": "Torsway Avenue",
+      "naptanCode": "blpadadw",
+      "atcoCode": "2590B0008",
+      "localityCode": "E0035280",
+      "localityName": "Kingscote",
+      "parentLocalityName": "Blackpool",
+      "indicator": "by",
+      "street": "Newton Drive"
+    },
+    {
+      "stopName": "Spencer Court",
+      "naptanCode": "blpadwgm",
+      "atcoCode": "2590B0316",
+      "localityCode": "N0079370",
+      "localityName": "Central",
+      "parentLocalityName": "Blackpool",
+      "indicator": "by",
+      "street": "Talbot Road"
+    },
+    {
+      "stopName": "Mesnes Park",
+      "naptanCode": "mergjpjd",
+      "atcoCode": "2800S10110A",
+      "localityCode": "E0029817",
+      "localityName": "Newton le Willows",
+      "parentLocalityName": "",
+      "indicator": "Opposite",
+      "street": "Park Road North"
+    },
+    {
+      "stopName": "Grosvenor Road",
+      "naptanCode": "merdwgmt",
+      "atcoCode": "2800S51045B",
+      "localityCode": "E0052682",
+      "localityName": "Prescot",
+      "parentLocalityName": "",
+      "indicator": "Adjacent",
+      "street": "St Helens Road"
+    },
+    {
+      "stopName": "Campbell Avenue",
+      "naptanCode": "32900357",
+      "atcoCode": "3290YYA00357",
+      "localityCode": "E0043596",
+      "localityName": "Holgate",
+      "parentLocalityName": "York",
+      "indicator": "opp",
+      "street": "Hamilton Drive"
+    },
+    {
+      "stopName": "Main Street St Johns Close",
+      "naptanCode": "45010202",
+      "atcoCode": "450010202",
+      "localityCode": "E0032162",
+      "localityName": "Aberford",
+      "parentLocalityName": "Leeds",
+      "indicator": "at",
+      "street": "Main Street"
+    },
+    {
+      "stopName": "Midgley Road Spring Villas",
+      "naptanCode": "45019529",
+      "atcoCode": "450019529",
+      "localityCode": "E0033244",
+      "localityName": "Mytholmroyd",
+      "parentLocalityName": "Hebden Bridge",
+      "indicator": "at",
+      "street": "Midgley Road"
+    }
+  ],
+  "additionalNocs": [
+    "LNUD",
+    "NWBT"
+  ],
+  "operatorGroupId": 1,
+  "carnet": false
+}

--- a/fdbt-dev/data/productsData/multiOperatorExt/BLACc90fe5a8_1738686874177.json
+++ b/fdbt-dev/data/productsData/multiOperatorExt/BLACc90fe5a8_1738686874177.json
@@ -1,0 +1,58 @@
+{
+  "nocCode": "BLAC",
+  "type": "multiOperatorExt",
+  "passengerType": {
+    "id": 3
+  },
+  "email": "test@example.com",
+  "uuid": "BLACc90fe5a8",
+  "ticketPeriod": {
+    "startDate": "2025-01-01T00:00:00.000Z"
+  },
+  "operatorName": "Test Operator",
+  "products": [
+    {
+      "productName": "MOBE-services-1",
+      "productPrice": "1.23",
+      "salesOfferPackages": [
+        {
+          "id": 1,
+          "price": "1.23"
+        }
+      ]
+    }
+  ],
+  "selectedServices": [
+    {
+      "lineName": "1",
+      "lineId": "4YyoI0",
+      "serviceCode": "NW_05_BLAC_1_1",
+      "serviceDescription": "FLEETWOOD - BLACKPOOL via Promenade"
+    },
+    {
+      "lineName": "2",
+      "lineId": "YpQjUw",
+      "serviceCode": "NW_05_BLAC_2_1",
+      "serviceDescription": "POULTON - BLACKPOOL via Victoria Hospital Outpatients"
+    },
+    {
+      "lineName": "2C",
+      "lineId": "vySmfewe0",
+      "serviceCode": "NW_05_BLAC_2C_1",
+      "serviceDescription": "KNOTT END - POULTON - BLACKPOOL"
+    }
+  ],
+  "additionalOperators": [
+    {
+      "nocCode": "LNUD",
+      "selectedServices": []
+    },
+    {
+      "nocCode": "NWBT",
+      "selectedServices": []
+    }
+  ],
+  "termTime": false,
+  "operatorGroupId": 1,
+  "carnet": false
+}

--- a/fdbt-dev/sql/productAdditionalNocs.sql
+++ b/fdbt-dev/sql/productAdditionalNocs.sql
@@ -1,0 +1,14 @@
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+LOCK TABLES `productAdditionalNocs` WRITE;
+
+TRUNCATE TABLE `productAdditionalNocs`;
+
+INSERT INTO `productAdditionalNocs` (productId,additionalNocCode)
+VALUES
+(7, 'LNUD'),
+(7, 'NWBT'),
+(8, 'LNUD'),
+(8, 'NWBT');
+
+UNLOCK TABLES;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;

--- a/fdbt-dev/sql/products.sql
+++ b/fdbt-dev/sql/products.sql
@@ -3,7 +3,7 @@ LOCK TABLES `products` WRITE;
 
 TRUNCATE TABLE `products`;
 
-INSERT INTO `products` (nocCode,matchingJsonLink,lineId,dateModified,fareType,startDate,endDate,servicesRequiringAttention,fareTriangleModified) 
+INSERT INTO `products` (nocCode,matchingJsonLink,lineId,dateModified,fareType,startDate,endDate,servicesRequiringAttention,fareTriangleModified)
 VALUES
 ('BLAC', 'BLAC/single/BLAC28ac10f0_1669718716180.json', '4YyoI0', '2022-11-29 10:45:16', 'single', '2020-02-01 00:00:00', '0000-00-00 00:00:00', NULL, NULL),
 ('BLAC', 'BLAC/return/BLAC06cacdb0_1669718799461.json', '4YyoI0', '2022-11-29 10:46:40', 'return', '2020-02-01 00:00:00', '0000-00-00 00:00:00', NULL, NULL),
@@ -11,6 +11,8 @@ VALUES
 ('BLAC', 'BLAC/period/BLAC3ac061cd_1669718965369.json', '', '2022-11-29 10:49:25', 'period', '1999-03-01 00:00:00', '0000-00-00 00:00:00', NULL, NULL),
 ('BLAC', 'BLAC/flatFare/BLACb3f31902_1669719006084.json', '', '2022-11-29 10:50:06', 'flatFare', '2020-02-01 00:00:00', '0000-00-00 00:00:00', NULL, NULL),
 ('BLAC', 'BLAC/multiOperator/BLACdc15ca79_1669719059910.json', '', '2022-11-29 10:51:00', 'multiOperator', '2020-03-12 00:00:00', '0000-00-00 00:00:00', NULL, NULL),
+('BLAC', 'BLAC/multiOperatorExt/BLAC38f1952d_1738684176462.json', '', '2022-11-29 10:51:00', 'multiOperatorExt', '2020-03-12 00:00:00', '0000-00-00 00:00:00', NULL, NULL),
+('BLAC', 'BLAC/multiOperatorExt/BLACc90fe5a8_1738686874177.json', '', '2022-11-29 10:51:00', 'multiOperatorExt', '2020-03-12 00:00:00', '0000-00-00 00:00:00', NULL, NULL),
 ('BLAC', 'BLAC/period/BLAC84085f49_1669719096560.json', '', '2022-11-29 10:51:37', 'period', '2020-01-01 00:00:00', '0000-00-00 00:00:00', NULL, NULL);
 
 UNLOCK TABLES;

--- a/repos/fdbt-admin/src/utils/helpers.ts
+++ b/repos/fdbt-admin/src/utils/helpers.ts
@@ -97,7 +97,7 @@ export const typesOfProductsCreated = (products: ObjectList): FareTypeCount => {
 };
 
 export const createGraphData = (fareTypeCount: FareTypeCount): GraphData[] => {
-    const fareTypes = ['single', 'return', 'flatFare', 'period', 'multiOperator'];
+    const fareTypes = ['single', 'return', 'flatFare', 'period', 'multiOperator', 'multiOperatorExt'];
     const colours = ['#196f3d', '#a93226', '#1f618d', '#2e4053', '#d35400'];
 
     return fareTypes.map((fareType, index) => {

--- a/repos/fdbt-site/cypress_tests/cypress/support/steps.ts
+++ b/repos/fdbt-site/cypress_tests/cypress/support/steps.ts
@@ -44,6 +44,7 @@ export type FareType =
     | 'return'
     | 'flatFare'
     | 'multiOperator'
+    | 'multiOperatorExt'
     | 'schoolService'
     | 'carnet'
     | 'carnetFlatFare'
@@ -373,7 +374,7 @@ export const completeMyFaresMultiOperatorProductsPages = (): void => {
         clickRandomElementInTable('govuk-table__body', 'product-link');
         getElementById('product-name').should('not.be.empty');
         getElementById('product-status').should('not.be.empty');
-        getElementById('fare-type').should('not.be.empty').should('have.text', 'Multi operator');
+        getElementById('fare-type').should('not.be.empty').should('have.text', 'Multi-operator');
         clickElementByText('Back');
     }
 };

--- a/repos/fdbt-site/src/components/ConfirmationTable.tsx
+++ b/repos/fdbt-site/src/components/ConfirmationTable.tsx
@@ -8,10 +8,10 @@ interface ConfirmationTableProps {
 }
 
 const ConfirmationTable = ({ confirmationElements, header }: ConfirmationTableProps): ReactElement => {
-    const builtElements = confirmationElements.map((element) => {
+    const builtElements = confirmationElements.map((element, index) => {
         const content = isArray(element.content) ? element.content : [element.content];
         return (
-            <React.Fragment key={header}>
+            <React.Fragment key={header + index}>
                 <dl className="govuk-summary-list">
                     <div className="govuk-summary-list__row" key={element.name}>
                         <dt className="govuk-summary-list__key">{element.name}</dt>

--- a/repos/fdbt-site/src/constants/index.ts
+++ b/repos/fdbt-site/src/constants/index.ts
@@ -82,7 +82,15 @@ export const INTERNAL_NOC = 'IWBusCo';
 
 export const CREATED_FILES_NUM_PER_PAGE = 10;
 
-export const validFareTypes = ['single', 'period', 'return', 'flatFare', 'multiOperator', 'schoolService'];
+export const fareTypes: Record<string, string> = {
+    single: 'Single',
+    period: 'Period',
+    return: 'Return',
+    flatFare: 'Flat fare',
+    multiOperator: 'Multi-operator (internal)',
+    multiOperatorExt: 'Multi-operator',
+    schoolService: 'School service',
+};
 
 export const purchaseMethodsValuesMap: { [key: string]: string } = {
     agency: 'Travel Shop',

--- a/repos/fdbt-site/src/interfaces/index.ts
+++ b/repos/fdbt-site/src/interfaces/index.ts
@@ -723,7 +723,7 @@ export interface ProductToDisplay {
     productName: string;
     startDate: string;
     endDate?: string;
-    fareType: 'single' | 'return' | 'period' | 'flatFare' | 'multiOperator';
+    fareType: TicketType;
     schoolTicket: boolean;
     serviceLineId: string | null;
     direction: string | null;

--- a/repos/fdbt-site/src/interfaces/matchingJsonTypes.ts
+++ b/repos/fdbt-site/src/interfaces/matchingJsonTypes.ts
@@ -87,7 +87,14 @@ export interface CapStartInfo {
 
 export type FromDb<T> = T & { id: number };
 
-export type TicketType = 'flatFare' | 'period' | 'multiOperator' | 'schoolService' | 'single' | 'return';
+export type TicketType =
+    | 'flatFare'
+    | 'period'
+    | 'multiOperator'
+    | 'multiOperatorExt'
+    | 'schoolService'
+    | 'single'
+    | 'return';
 
 export type Ticket =
     | PointToPointTicket

--- a/repos/fdbt-site/src/interfaces/matchingJsonTypes.ts
+++ b/repos/fdbt-site/src/interfaces/matchingJsonTypes.ts
@@ -18,7 +18,7 @@ export interface PeriodGeoZoneTicket extends BasePeriodTicket {
     exemptedServices?: SelectedService[];
 }
 
-export interface BasePeriodTicket extends BaseTicket<'period' | 'multiOperator'> {
+export interface BasePeriodTicket extends BaseTicket<'period' | 'multiOperator' | 'multiOperatorExt'> {
     operatorName: string;
     products: ProductDetails[];
     fareDayEnd?: string;

--- a/repos/fdbt-site/src/interfaces/typeGuards.ts
+++ b/repos/fdbt-site/src/interfaces/typeGuards.ts
@@ -29,7 +29,7 @@ import {
     TicketRepresentationAttributeWithErrors,
     WithErrors,
 } from '.';
-import { validFareTypes } from '../constants';
+import { fareTypes } from '../constants';
 import { PassengerType } from './dbTypes';
 import {
     Ticket,
@@ -62,7 +62,7 @@ export const isFareTypeAttributeWithErrors = (
 export const isFareType = (fareType: FareType | FareTypeWithErrors | undefined): fareType is FareType =>
     fareType !== undefined &&
     (fareType as FareType).fareType !== undefined &&
-    validFareTypes.includes((fareType as FareType).fareType);
+    Object.hasOwn(fareTypes, (fareType as FareType).fareType);
 
 export const inputMethodErrorsExist = (
     inputMethodAttribute: InputMethodInfo | ErrorInfo | undefined,

--- a/repos/fdbt-site/src/pages/api/csvZoneUpload.ts
+++ b/repos/fdbt-site/src/pages/api/csvZoneUpload.ts
@@ -261,7 +261,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             updateSessionAttribute(req, FARE_ZONE_ATTRIBUTE, fareZoneName);
             const { fareType } = getSessionAttribute(req, FARE_TYPE_ATTRIBUTE) as FareType;
 
-            if (fareType === 'multiOperator' || isSchemeOperator(req, res)) {
+            if (fareType === 'multiOperator' || fareType === 'multiOperatorExt' || isSchemeOperator(req, res)) {
                 redirectTo(res, '/reuseOperatorGroup');
                 return;
             }

--- a/repos/fdbt-site/src/pages/api/salesConfirmation.ts
+++ b/repos/fdbt-site/src/pages/api/salesConfirmation.ts
@@ -45,7 +45,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             userDataJson = getSingleTicketJson(req, res);
         } else if (fareType === 'return') {
             userDataJson = getReturnTicketJson(req, res);
-        } else if (['period', 'multiOperator', 'flatFare'].includes(fareType)) {
+        } else if (['period', 'multiOperator', 'multiOperatorExt', 'flatFare'].includes(fareType)) {
             switch (ticketType) {
                 case 'geoZone':
                 case 'geoZoneFlatFareMultiOperator':

--- a/repos/fdbt-site/src/pages/api/selectSalesOfferPackage.ts
+++ b/repos/fdbt-site/src/pages/api/selectSalesOfferPackage.ts
@@ -86,7 +86,7 @@ export const getProductsByValues = (
     multipleProductAttribute: MultipleProductAttribute | MultipleProductAttributeWithErrors | undefined,
     pricePerDistanceName: string,
 ): ProductInfo[] => {
-    // for 'period', 'multiOperator', 'flatFare' that have multiple products
+    // for 'period', 'multiOperator', 'multiOperatorExt', 'flatFare' that have multiple products
     if (multipleProductAttribute) {
         return multipleProductAttribute.products;
     }

--- a/repos/fdbt-site/src/pages/api/serviceList.ts
+++ b/repos/fdbt-site/src/pages/api/serviceList.ts
@@ -252,7 +252,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
         const ticketType = (getSessionAttribute(req, TICKET_REPRESENTATION_ATTRIBUTE) as TicketRepresentationAttribute)
             .name;
 
-        if (fareType === 'multiOperator') {
+        if (fareType === 'multiOperator' || fareType === 'multiOperatorExt') {
             redirectTo(res, '/reuseOperatorGroup');
             return;
         }

--- a/repos/fdbt-site/src/pages/fareConfirmation.tsx
+++ b/repos/fdbt-site/src/pages/fareConfirmation.tsx
@@ -23,6 +23,7 @@ import { getCsrfToken, sentenceCaseString, getAndValidateNoc } from '../utils';
 import { getPassengerTypeNameByIdAndNoc } from '../data/auroradb';
 import { PassengerType } from '../interfaces/dbTypes';
 import { CompanionInfo, FullTimeRestriction } from '../interfaces/matchingJsonTypes';
+import { fareTypes } from 'src/constants';
 
 const title = 'Fare Confirmation - Create Fares Data Service';
 const description = 'Fare Confirmation page of the Create Fares Data Service';
@@ -52,7 +53,7 @@ export const buildFareConfirmationElements = (
     const confirmationElements: ConfirmationElement[] = [
         {
             name: 'Fare type',
-            content: carnet ? 'Carnet' : sentenceCaseString(fareType),
+            content: carnet ? 'Carnet' : fareTypes[fareType],
             href: 'fareType',
         },
         {
@@ -65,7 +66,7 @@ export const buildFareConfirmationElements = (
     if (carnet) {
         confirmationElements.splice(1, 0, {
             name: 'Carnet type',
-            content: sentenceCaseString(fareType),
+            content: fareTypes[fareType],
             href: 'carnetFareType',
         });
     }

--- a/repos/fdbt-site/src/pages/fareConfirmation.tsx
+++ b/repos/fdbt-site/src/pages/fareConfirmation.tsx
@@ -23,7 +23,7 @@ import { getCsrfToken, sentenceCaseString, getAndValidateNoc } from '../utils';
 import { getPassengerTypeNameByIdAndNoc } from '../data/auroradb';
 import { PassengerType } from '../interfaces/dbTypes';
 import { CompanionInfo, FullTimeRestriction } from '../interfaces/matchingJsonTypes';
-import { fareTypes } from 'src/constants';
+import { fareTypes } from '../constants';
 
 const title = 'Fare Confirmation - Create Fares Data Service';
 const description = 'Fare Confirmation page of the Create Fares Data Service';

--- a/repos/fdbt-site/src/pages/fareType.tsx
+++ b/repos/fdbt-site/src/pages/fareType.tsx
@@ -91,6 +91,11 @@ const buildRadioProps = (schemeOp: boolean): RadioOption[] => {
             hint: 'A ticket that covers more than one NOC in your organisation',
         },
         {
+            value: 'multiOperatorExt',
+            label: 'Multi-operator',
+            hint: 'A ticket that covers multiple collaborating operators',
+        },
+        {
             value: 'schoolService',
             label: 'Academic term/year ticket',
             hint: 'A ticket available to pupils in full-time education',

--- a/repos/fdbt-site/src/pages/products/multiOperatorProducts.tsx
+++ b/repos/fdbt-site/src/pages/products/multiOperatorProducts.tsx
@@ -8,6 +8,7 @@ import { getTag } from './services';
 import DeleteConfirmationPopup from '../../components/DeleteConfirmationPopup';
 import logger from '../../utils/logger';
 import { MyFaresOtherProduct } from '../../interfaces/dbTypes';
+import { fareTypes } from 'src/constants';
 
 const title = 'Multi-operator products (internal) - Create Fares Data Service';
 const description = 'View and access your multi-operator products (internal) in one place.';
@@ -124,7 +125,7 @@ const MultiOperatorProductsTable = (
                                           {product.productDescription}
                                       </a>
                                   </td>
-                                  <td className="govuk-table__cell">{sentenceCaseString(product.type)}</td>
+                                  <td className="govuk-table__cell">{fareTypes[product.type]}</td>
                                   <td className="govuk-table__cell">{product.duration}</td>
                                   <td className="govuk-table__cell dft-table-wrap-anywhere">
                                       {sentenceCaseString(product.passengerType)}

--- a/repos/fdbt-site/src/pages/products/multiOperatorProducts.tsx
+++ b/repos/fdbt-site/src/pages/products/multiOperatorProducts.tsx
@@ -8,7 +8,7 @@ import { getTag } from './services';
 import DeleteConfirmationPopup from '../../components/DeleteConfirmationPopup';
 import logger from '../../utils/logger';
 import { MyFaresOtherProduct } from '../../interfaces/dbTypes';
-import { fareTypes } from 'src/constants';
+import { fareTypes } from '../../constants';
 
 const title = 'Multi-operator products (internal) - Create Fares Data Service';
 const description = 'View and access your multi-operator products (internal) in one place.';

--- a/repos/fdbt-site/src/pages/products/multiOperatorProductsExternal.tsx
+++ b/repos/fdbt-site/src/pages/products/multiOperatorProductsExternal.tsx
@@ -13,6 +13,7 @@ import { MyFaresOtherProduct } from '../../interfaces/dbTypes';
 import { getGroupPassengerTypeById, getMultiOperatorExternalProducts, getPassengerTypeById } from '../../data/auroradb';
 import { getProductsMatchingJson } from '../../data/s3';
 import DeleteConfirmationPopup from '../../components/DeleteConfirmationPopup';
+import CsrfForm from '../../components/CsrfForm';
 
 const title = 'Multi-operator products - Create Fares Data Service';
 const description = 'View and access your multi-operator products in one place.';
@@ -65,9 +66,12 @@ const MultiOperatorProducts = ({
                     </p>
                 </div>
                 <div className="govuk-grid-column-one-third">
-                    <a href="/fareType" className="govuk-button" data-module="govuk-button">
-                        Create new product
-                    </a>
+                    <CsrfForm action="/api/fareType" method="post" csrfToken={csrfToken}>
+                        <input type="hidden" name="fareType" value="multiOperatorExt" />
+                        <button type="submit" className="govuk-button">
+                            Create new product
+                        </button>
+                    </CsrfForm>
                     {/*TODO: add link to exporter*/}
                     <button type="submit" className="govuk-button govuk-button--secondary">
                         Export all products

--- a/repos/fdbt-site/src/pages/products/multiOperatorProductsExternal.tsx
+++ b/repos/fdbt-site/src/pages/products/multiOperatorProductsExternal.tsx
@@ -65,10 +65,9 @@ const MultiOperatorProducts = ({
                     </p>
                 </div>
                 <div className="govuk-grid-column-one-third">
-                    {/*TODO: add link to multiop external flow*/}
-                    <button type="submit" className="govuk-button">
+                    <a href="/fareType" className="govuk-button" data-module="govuk-button">
                         Create new product
-                    </button>
+                    </a>
                     {/*TODO: add link to exporter*/}
                     <button type="submit" className="govuk-button govuk-button--secondary">
                         Export all products

--- a/repos/fdbt-site/src/pages/products/otherProducts.tsx
+++ b/repos/fdbt-site/src/pages/products/otherProducts.tsx
@@ -9,7 +9,7 @@ import DeleteConfirmationPopup from '../../components/DeleteConfirmationPopup';
 import logger from '../../utils/logger';
 import { MyFaresOtherProduct } from '../../interfaces/dbTypes';
 import { FlatFareByDistanceProduct, Product } from 'src/interfaces/matchingJsonTypes';
-import { fareTypes } from 'src/constants';
+import { fareTypes } from '../../constants';
 
 const title = 'Other products - Create Fares Data Service';
 const description = 'View and access your other products in one place.';
@@ -218,7 +218,9 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
         )
     ).flat();
 
-    const otherProducts = allOtherProducts.filter((product) => product.type !== 'multiOperator');
+    const otherProducts = allOtherProducts.filter(
+        (product) => product.type !== 'multiOperator' && product.type !== 'multiOperatorExt',
+    );
     return { props: { otherProducts, csrfToken: getCsrfToken(ctx) } };
 };
 

--- a/repos/fdbt-site/src/pages/products/otherProducts.tsx
+++ b/repos/fdbt-site/src/pages/products/otherProducts.tsx
@@ -9,6 +9,7 @@ import DeleteConfirmationPopup from '../../components/DeleteConfirmationPopup';
 import logger from '../../utils/logger';
 import { MyFaresOtherProduct } from '../../interfaces/dbTypes';
 import { FlatFareByDistanceProduct, Product } from 'src/interfaces/matchingJsonTypes';
+import { fareTypes } from 'src/constants';
 
 const title = 'Other products - Create Fares Data Service';
 const description = 'View and access your other products in one place.';
@@ -130,7 +131,7 @@ const otherProductsTable = (
                                           {product.productDescription}
                                       </a>
                                   </td>
-                                  <td className="govuk-table__cell">{sentenceCaseString(product.type)}</td>
+                                  <td className="govuk-table__cell">{fareTypes[product.type]}</td>
                                   <td className="govuk-table__cell">{product.duration}</td>
                                   <td className="govuk-table__cell dft-table-wrap-anywhere">
                                       {sentenceCaseString(product.passengerType)}

--- a/repos/fdbt-site/src/pages/products/productDetails.tsx
+++ b/repos/fdbt-site/src/pages/products/productDetails.tsx
@@ -693,6 +693,8 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
         ? `/products/pointToPointProducts?serviceId=${serviceId}`
         : ticket.type === 'multiOperator'
         ? '/products/multiOperatorProducts'
+        : ticket.type === 'multiOperatorExt'
+        ? '/products/multiOperatorProductsExternal'
         : '/products/otherProducts';
 
     const lineId =

--- a/repos/fdbt-site/src/pages/products/productDetails.tsx
+++ b/repos/fdbt-site/src/pages/products/productDetails.tsx
@@ -35,7 +35,7 @@ import ProductNamePopup from '../../components/ProductNamePopup';
 import GenerateReturnPopup from '../../components/GenerateReturnPopup';
 import { Stop, TicketWithIds } from '../../interfaces/matchingJsonTypes';
 import { isGeoZoneTicket } from '../../../src/interfaces/typeGuards';
-import { STAGE } from '../../constants';
+import { fareTypes, STAGE } from '../../constants';
 
 const title = 'Product Details - Create Fares Data Service';
 const description = 'Product Details page of the Create Fares Data Service';
@@ -243,7 +243,7 @@ const createProductDetails = async (
         name: 'Fare type',
         id: 'fare-type',
         content: [
-            `${sentenceCaseString(ticket.type)}${ticket.carnet ? ' (carnet)' : ''}${
+            `${fareTypes[ticket.type]}${ticket.carnet ? ' (carnet)' : ''}${
                 'termTime' in ticket && !!ticket.termTime ? ' (academic)' : ''
             }${'return' in ticket ? ' return' : ''}`,
         ],
@@ -638,8 +638,8 @@ const createProductDetails = async (
         'productName' in product
             ? product.productName
             : isSchoolTicket
-            ? `${passengerTypeName} - ${sentenceCaseString(ticket.type)} (school)`
-            : `${passengerTypeName} - ${sentenceCaseString(ticket.type)}`;
+            ? `${passengerTypeName} - ${fareTypes[ticket.type]} (school)`
+            : `${passengerTypeName} - ${fareTypes[ticket.type]}`;
 
     return {
         productDetailsElements,

--- a/repos/fdbt-site/src/pages/products/selectExports.tsx
+++ b/repos/fdbt-site/src/pages/products/selectExports.tsx
@@ -220,7 +220,7 @@ const SelectExports = ({ productsToDisplay, servicesToDisplay, csrf }: SelectExp
                                             </li>
                                             <li className="govuk-tabs__list-item">
                                                 <a className="govuk-tabs__tab" href="#multi-operator-products">
-                                                    Multi operator products
+                                                    Multi-operator products
                                                 </a>
                                             </li>
                                             <li className="govuk-tabs__list-item">

--- a/repos/fdbt-site/src/pages/ticketConfirmation.tsx
+++ b/repos/fdbt-site/src/pages/ticketConfirmation.tsx
@@ -29,6 +29,7 @@ import {
 } from '../constants/attributes';
 import {
     ConfirmationElement,
+    FareType,
     MultipleOperatorsAttribute,
     MultipleProductAttribute,
     MultiProduct,
@@ -352,6 +353,7 @@ export const buildPeriodOrMultiOpTicketConfirmationElements = (
     ).name;
     const serviceInformation = getSessionAttribute(ctx.req, SERVICE_LIST_ATTRIBUTE) as ServiceListAttribute;
     const multiOpAttribute = getSessionAttribute(ctx.req, MULTIPLE_OPERATOR_ATTRIBUTE) as MultipleOperatorsAttribute;
+    const { fareType } = getSessionAttribute(ctx.req, FARE_TYPE_ATTRIBUTE) as FareType;
     const multiOpServices = getSessionAttribute(ctx.req, MULTIPLE_OPERATORS_SERVICES_ATTRIBUTE) as AdditionalOperator[];
     const fileName = getSessionAttribute(ctx.req, CSV_ZONE_FILE_NAME);
     const exemptedServiceAttribute = getSessionAttribute(
@@ -411,7 +413,7 @@ export const buildPeriodOrMultiOpTicketConfirmationElements = (
         );
     }
 
-    if (multiOpAttribute) {
+    if (multiOpAttribute && fareType === 'multiOperator') {
         const additionalOperators = multiOpAttribute.selectedOperators;
         confirmationElements.push({
             name: 'Additional operators',

--- a/repos/fdbt-site/src/pages/ticketConfirmation.tsx
+++ b/repos/fdbt-site/src/pages/ticketConfirmation.tsx
@@ -525,6 +525,9 @@ export const buildTicketConfirmationElements = (
         case 'multiOperator':
             confirmationElements = buildPeriodOrMultiOpTicketConfirmationElements(ctx);
             break;
+        case 'multiOperatorExt':
+            confirmationElements = buildPeriodOrMultiOpTicketConfirmationElements(ctx);
+            break;
         case 'schoolService':
             confirmationElements = buildSchoolTicketConfirmationElements(ctx);
             break;

--- a/repos/fdbt-site/src/pages/ticketRepresentation.tsx
+++ b/repos/fdbt-site/src/pages/ticketRepresentation.tsx
@@ -12,9 +12,9 @@ import {
 import { ErrorInfo, FareType, NextPageContextWithSession } from '../interfaces';
 import { isTicketRepresentationWithErrors } from '../interfaces/typeGuards';
 import TwoThirdsLayout from '../layout/Layout';
-import { getCsrfToken, isSchemeOperator, sentenceCaseString } from '../utils';
+import { getCsrfToken, isSchemeOperator } from '../utils';
 import { getSessionAttribute } from '../utils/sessions';
-import { STAGE } from '../constants';
+import { fareTypes, STAGE } from '../constants';
 
 const title = 'Ticket Representation - Create Fares Data Service';
 const description = 'Ticket Representation selection page of the Create Fares Data Service';
@@ -30,17 +30,6 @@ interface TicketRepresentationProps {
     showGeoZone: boolean;
     stage?: string;
 }
-
-const getFareTypeDesc = (fareType: TicketType) => {
-    switch (fareType) {
-        case 'multiOperator':
-            return 'multi-operator';
-        case 'flatFare':
-            return 'flat fare';
-        default:
-            return fareType;
-    }
-};
 
 const getFareTypeHint = (fareType: TicketType) => {
     switch (fareType) {
@@ -73,7 +62,6 @@ const TicketRepresentation = ({
     showGeoZone,
     stage,
 }: TicketRepresentationProps): ReactElement => {
-    const fareTypeDesc = getFareTypeDesc(fareType);
     const fareTypeHint = getFareTypeHint(fareType);
 
     return (
@@ -85,7 +73,7 @@ const TicketRepresentation = ({
                         <fieldset className="govuk-fieldset" aria-describedby="ticket-representation-page-heading">
                             <legend className="govuk-fieldset__legend govuk-fieldset__legend--l">
                                 <h1 className="govuk-fieldset__heading" id="ticket-representation-page-heading">
-                                    {`Select a type of ${sentenceCaseString(fareTypeDesc).toLowerCase()} ticket`}
+                                    {`Select a type of ${fareTypes[fareType].toLowerCase()} ticket`}
                                 </h1>
                             </legend>
                             <FormElementWrapper errors={errors} errorId="geo-zone" errorClass="govuk-radios--errors">

--- a/repos/fdbt-site/src/pages/ticketRepresentation.tsx
+++ b/repos/fdbt-site/src/pages/ticketRepresentation.tsx
@@ -173,7 +173,7 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Ti
             showHybrid: fareType === 'period' && !isScheme,
             showPointToPoint: (fareType === 'period' && !isCarnet && !isScheme) || fareType === 'schoolService',
             showFlatFlare: fareType === 'flatFare' && !isScheme && !isCarnet,
-            showMultiOperator: fareType === 'multiOperator',
+            showMultiOperator: fareType === 'multiOperator' || fareType === 'multiOperatorExt',
             showGeoZone: fareType !== 'schoolService',
             stage: STAGE || 'dev',
         },

--- a/repos/fdbt-site/src/utils/apiUtils/index.ts
+++ b/repos/fdbt-site/src/utils/apiUtils/index.ts
@@ -108,6 +108,7 @@ export const redirectOnFareType = (req: NextApiRequestWithSession, res: NextApiR
         switch (fareTypeAttribute.fareType) {
             case 'period':
             case 'multiOperator':
+            case 'multiOperatorExt':
             case 'flatFare':
             case 'schoolService':
                 redirectTo(res, '/ticketRepresentation');

--- a/repos/fdbt-site/src/utils/apiUtils/userData.ts
+++ b/repos/fdbt-site/src/utils/apiUtils/userData.ts
@@ -253,7 +253,7 @@ export const getBaseTicketAttributes = <T extends TicketType>(
 export const getBasePeriodTicketAttributes = (
     req: NextApiRequestWithSession,
     res: NextApiResponse,
-    ticketType: 'period' | 'multiOperator',
+    ticketType: 'period' | 'multiOperator' | 'multiOperatorExt',
 ): WithIds<BasePeriodTicket> => {
     const operatorAttribute = getSessionAttribute(req, OPERATOR_ATTRIBUTE);
     const baseTicketAttributes = getBaseTicketAttributes(req, res, ticketType);
@@ -439,12 +439,17 @@ export const getGeoZoneTicketJson = async (
     const zoneStops: Stop[] = await batchGetStopsByAtcoCode(atcoCodes);
 
     const additionalNocs =
-        basePeriodTicketAttributes.type === 'multiOperator' && multiOpAttribute
+        (basePeriodTicketAttributes.type === 'multiOperator' ||
+            basePeriodTicketAttributes.type === 'multiOperatorExt') &&
+        multiOpAttribute
             ? multiOpAttribute.selectedOperators.map((operator) => operator.nocCode)
             : undefined;
 
     const operatorGroupId =
-        basePeriodTicketAttributes.type === 'multiOperator' && multiOpAttribute && multiOpAttribute.id
+        (basePeriodTicketAttributes.type === 'multiOperator' ||
+            basePeriodTicketAttributes.type === 'multiOperatorExt') &&
+        multiOpAttribute &&
+        multiOpAttribute.id
             ? multiOpAttribute.id
             : undefined;
 
@@ -540,7 +545,7 @@ export const getMultipleServicesTicketJson = (
     }
     const basePeriodTicketAttributes = getBasePeriodTicketAttributes(req, res, 'period');
 
-    if (basePeriodTicketAttributes.type === 'multiOperator') {
+    if (basePeriodTicketAttributes.type === 'multiOperator' || basePeriodTicketAttributes.type === 'multiOperatorExt') {
         const additionalOperators = getSessionAttribute(
             req,
             MULTIPLE_OPERATORS_SERVICES_ATTRIBUTE,

--- a/repos/fdbt-site/tests/pages/__snapshots__/fareType.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/fareType.test.tsx.snap
@@ -77,6 +77,11 @@ exports[`pages fareType should render correctly 1`] = `
                   "value": "multiOperator",
                 },
                 Object {
+                  "hint": "A ticket that covers multiple collaborating operators",
+                  "label": "Multi-operator",
+                  "value": "multiOperatorExt",
+                },
+                Object {
                   "hint": "A ticket available to pupils in full-time education",
                   "label": "Academic term/year ticket",
                   "value": "schoolService",
@@ -275,6 +280,11 @@ exports[`pages fareType should render error messaging when errors are passed to 
                   "hint": "A ticket that covers more than one NOC in your organisation",
                   "label": "Multi-operator (internal)",
                   "value": "multiOperator",
+                },
+                Object {
+                  "hint": "A ticket that covers multiple collaborating operators",
+                  "label": "Multi-operator",
+                  "value": "multiOperatorExt",
                 },
                 Object {
                   "hint": "A ticket available to pupils in full-time education",

--- a/repos/fdbt-site/tests/pages/__snapshots__/multipleOperatorsServiceList.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/multipleOperatorsServiceList.test.tsx.snap
@@ -77,12 +77,15 @@ exports[`pages multipleOperatorsServiceList should render correctly with errors 
             className="govuk-checkboxes__item dft-padding-left"
             key="checkbox-item-0"
           >
+            <input
+              className="govuk-checkboxes__input"
+              id="add-operator-checkbox-0"
+              onClick={[Function]}
+              type="checkbox"
+            />
             <label
               className="govuk-label govuk-checkboxes__label"
               htmlFor="add-operator-checkbox-0"
-              id="service-to-add-0"
-              onClick={[Function]}
-              role="button"
             >
               1 Fleetwood - Blackpool
             </label>
@@ -91,12 +94,15 @@ exports[`pages multipleOperatorsServiceList should render correctly with errors 
             className="govuk-checkboxes__item dft-padding-left"
             key="checkbox-item-1"
           >
+            <input
+              className="govuk-checkboxes__input"
+              id="add-operator-checkbox-1"
+              onClick={[Function]}
+              type="checkbox"
+            />
             <label
               className="govuk-label govuk-checkboxes__label"
               htmlFor="add-operator-checkbox-1"
-              id="service-to-add-1"
-              onClick={[Function]}
-              role="button"
             >
               2 Poulton - Blackpool
             </label>
@@ -124,8 +130,7 @@ exports[`pages multipleOperatorsServiceList should render correctly with errors 
                   scope="col"
                 >
                   0
-                   
-                  added
+                   added
                 </th>
                 <th
                   className="govuk-table__header text-align-right"
@@ -325,12 +330,15 @@ exports[`pages multipleOperatorsServiceList should render the multiOperatorData 
             className="govuk-checkboxes__item dft-padding-left"
             key="checkbox-item-0"
           >
+            <input
+              className="govuk-checkboxes__input"
+              id="add-operator-checkbox-0"
+              onClick={[Function]}
+              type="checkbox"
+            />
             <label
               className="govuk-label govuk-checkboxes__label"
               htmlFor="add-operator-checkbox-0"
-              id="service-to-add-0"
-              onClick={[Function]}
-              role="button"
             >
               1 Fleetwood - Blackpool
             </label>
@@ -339,12 +347,15 @@ exports[`pages multipleOperatorsServiceList should render the multiOperatorData 
             className="govuk-checkboxes__item dft-padding-left"
             key="checkbox-item-1"
           >
+            <input
+              className="govuk-checkboxes__input"
+              id="add-operator-checkbox-1"
+              onClick={[Function]}
+              type="checkbox"
+            />
             <label
               className="govuk-label govuk-checkboxes__label"
               htmlFor="add-operator-checkbox-1"
-              id="service-to-add-1"
-              onClick={[Function]}
-              role="button"
             >
               2 Poulton - Blackpool
             </label>
@@ -372,8 +383,7 @@ exports[`pages multipleOperatorsServiceList should render the multiOperatorData 
                   scope="col"
                 >
                   0
-                   
-                  added
+                   added
                 </th>
                 <th
                   className="govuk-table__header text-align-right"

--- a/repos/fdbt-site/tests/pages/__snapshots__/ticketRepresentation.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/ticketRepresentation.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`pages ticketRepresentation price per distance radio not show when in te
             className="govuk-fieldset__heading"
             id="ticket-representation-page-heading"
           >
-            Select a type of multi operator ticket
+            Select a type of multi-operator (internal) ticket
           </h1>
         </legend>
         <FormElementWrapper
@@ -114,7 +114,7 @@ exports[`pages ticketRepresentation should render correctly when the fare type i
             className="govuk-fieldset__heading"
             id="ticket-representation-page-heading"
           >
-            Select a type of multi operator ticket
+            Select a type of multi-operator (internal) ticket
           </h1>
         </legend>
         <FormElementWrapper

--- a/repos/fdbt-site/tests/pages/products/__snapshots__/multiOperatorProductsExternal.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/products/__snapshots__/multiOperatorProductsExternal.test.tsx.snap
@@ -25,12 +25,13 @@ exports[`multiOperatorProductsExternal page renders correctly 1`] = `
     <div
       className="govuk-grid-column-one-third"
     >
-      <button
+      <a
         className="govuk-button"
-        type="submit"
+        data-module="govuk-button"
+        href="/fareType"
       >
         Create new product
-      </button>
+      </a>
       <button
         className="govuk-button govuk-button--secondary"
         type="submit"

--- a/repos/fdbt-site/tests/pages/products/__snapshots__/multiOperatorProductsExternal.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/products/__snapshots__/multiOperatorProductsExternal.test.tsx.snap
@@ -25,13 +25,23 @@ exports[`multiOperatorProductsExternal page renders correctly 1`] = `
     <div
       className="govuk-grid-column-one-third"
     >
-      <a
-        className="govuk-button"
-        data-module="govuk-button"
-        href="/fareType"
+      <CsrfForm
+        action="/api/fareType"
+        csrfToken=""
+        method="post"
       >
-        Create new product
-      </a>
+        <input
+          name="fareType"
+          type="hidden"
+          value="multiOperatorExt"
+        />
+        <button
+          className="govuk-button"
+          type="submit"
+        >
+          Create new product
+        </button>
+      </CsrfForm>
       <button
         className="govuk-button govuk-button--secondary"
         type="submit"

--- a/repos/fdbt-site/tests/pages/products/__snapshots__/selectExports.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/products/__snapshots__/selectExports.test.tsx.snap
@@ -207,7 +207,7 @@ exports[`selectExports renders fully when the user has products they can export 
                     className="govuk-tabs__tab"
                     href="#multi-operator-products"
                   >
-                    Multi operator products
+                    Multi-operator products
                   </a>
                 </li>
                 <li
@@ -630,7 +630,7 @@ exports[`selectExports renders fully when the user has products they can export,
                     className="govuk-tabs__tab"
                     href="#multi-operator-products"
                   >
-                    Multi operator products
+                    Multi-operator products
                   </a>
                 </li>
                 <li

--- a/repos/fdbt-site/tests/pages/products/productDetails.test.tsx
+++ b/repos/fdbt-site/tests/pages/products/productDetails.test.tsx
@@ -755,7 +755,7 @@ describe('myfares pages', () => {
             });
         });
 
-        it('correctly returns the elements which should be displayed on the page for a Multi Operator GeoZone Ticket with Multiple Products', async () => {
+        it('correctly returns the elements which should be displayed on the page for a Multi-operator GeoZone Ticket with Multiple Products', async () => {
             (getProductsMatchingJson as jest.Mock).mockResolvedValueOnce({
                 ...expectedMultiOperatorGeoZoneTicketWithMultipleProducts,
             });
@@ -768,7 +768,7 @@ describe('myfares pages', () => {
                     startDate: '17/12/2020',
                     endDate: '18/12/2020',
                     productDetailsElements: [
-                        { name: 'Fare type', id: 'fare-type', content: ['Multi operator'] },
+                        { name: 'Fare type', id: 'fare-type', content: ['Multi-operator (internal)'] },
                         { id: 'zone', name: 'Zone', content: ['Green Lane Shops'], editLink: '/csvZoneUpload' },
                         {
                             id: 'stops',

--- a/repos/fdbt-site/tests/pages/ticketConfirmation.test.tsx
+++ b/repos/fdbt-site/tests/pages/ticketConfirmation.test.tsx
@@ -258,6 +258,7 @@ describe('pages', () => {
                             selectedOperators: mockAdditionalOperators,
                         },
                         [SERVICE_LIST_EXEMPTION_ATTRIBUTE]: undefined,
+                        [FARE_TYPE_ATTRIBUTE]: { fareType: 'multiOperator' },
                     },
                 });
                 const confirmationElements = buildPeriodOrMultiOpTicketConfirmationElements(ctx);
@@ -349,6 +350,7 @@ describe('pages', () => {
                             hasBods: true,
                             hasTnds: true,
                         },
+                        [FARE_TYPE_ATTRIBUTE]: { fareType: 'multiOperator' },
                     },
                 });
                 const numberOfElementsDueToProducts = ctx.req.session[MULTIPLE_PRODUCT_ATTRIBUTE].products.length;

--- a/repos/fdbt-types/matchingJsonTypes.ts
+++ b/repos/fdbt-types/matchingJsonTypes.ts
@@ -85,7 +85,7 @@ export interface DistancePricingData {
 
 export type FromDb<T> = T & { id: number };
 
-export type TicketType = 'flatFare' | 'period' | 'multiOperator' | 'schoolService' | 'single' | 'return';
+export type TicketType = 'flatFare' | 'period' | 'multiOperator' | 'multiOperatorExt' | 'schoolService' | 'single' | 'return';
 
 export type Ticket =
     | PointToPointTicket


### PR DESCRIPTION
## Description

Amends the existing create product journey to allow creating multi-operator external products

## Testing instructions

- Test creating a multi-operator external fare zone product and assert the products gets created with status incomplete (since any additional operators won't have filled their part of the product)
- Test creating a multi-operator external services product and assert the products gets created with status incomplete (since any additional operators won't have filled their part of the product)
- Regression test the other product type journeys and assert they still work correctly
