### PR TITLE
CFDS-315 operator group changes cascading to products

### DIFF
--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -2147,7 +2147,7 @@ export const getOtherProductsByNoc = async (nocCode: string): Promise<MyFaresOth
 
     try {
         const queryInput = `
-            SELECT id, matchingJsonLink, startDate, endDate
+            SELECT id, matchingJsonLink, startDate, endDate, fareType
             FROM products
             WHERE lineId = ''
             AND nocCode = ?
@@ -2165,24 +2165,20 @@ export const getOtherProductsByNoc = async (nocCode: string): Promise<MyFaresOth
     }
 };
 
-export const getMultiOperatorExternalProducts = async (nocCode?: string): Promise<MyFaresOtherProduct[]> => {
+export const getMultiOperatorExternalProducts = async (): Promise<MyFaresOtherProduct[]> => {
     logger.info('', {
         context: 'data.auroradb',
         message: 'getting multi-operator external products',
     });
 
     try {
-        let queryInput = `
+        const queryInput = `
             SELECT id, nocCode, matchingJsonLink, startDate, endDate
             FROM products
             WHERE fareType = 'multiOperatorExt'
         `;
 
-        if (nocCode) {
-            queryInput += ' AND nocCode = ?';
-        }
-
-        const queryResults = await executeQuery<MyFaresOtherProduct[]>(queryInput, nocCode ? [nocCode] : []);
+        const queryResults = await executeQuery<MyFaresOtherProduct[]>(queryInput, []);
 
         return queryResults.map((result) => ({
             ...result,

--- a/repos/fdbt-site/src/pages/api/searchOperators.ts
+++ b/repos/fdbt-site/src/pages/api/searchOperators.ts
@@ -7,12 +7,18 @@ import { getSessionAttribute, updateSessionAttribute } from '../../utils/session
 import { removeExcessWhiteSpace } from '../../utils/apiUtils/validator';
 import { searchInputId } from '../searchOperators';
 import {
+    getMultiOperatorExternalProducts,
     getOperatorGroupsByNameAndNoc,
     insertOperatorGroup,
     operatorHasBodsServices,
     operatorHasFerryOrTramServices,
     updateOperatorGroup,
+    updateProductAdditionalNocs,
 } from '../../data/auroradb';
+import { putUserDataInProductsBucketWithFilePath } from '../../utils/apiUtils/userData';
+import { getAdditionalNocMatchingJsonLink } from '../../utils';
+import { PRODUCTS_DATA_BUCKET_NAME } from '../../constants';
+import { deleteMultipleObjectsFromS3, getProductsMatchingJson } from '../../data/s3';
 
 export const replaceSelectedOperatorsWithUserSelectedOperators = (rawList: string[]): Operator[] => {
     if (rawList.length === 0) {
@@ -25,6 +31,7 @@ export const replaceSelectedOperatorsWithUserSelectedOperators = (rawList: strin
     const updatedList = uniqBy(formattedRawList, 'nocCode');
     return updatedList;
 };
+
 export const getOperatorsWithoutServices = async (selectedOperators: Operator[]): Promise<string[]> => {
     const operatorNamesWithoutServices: string[] = [];
 
@@ -45,6 +52,43 @@ export const getOperatorsWithoutServices = async (selectedOperators: Operator[])
 export const isSearchInputValid = (searchText: string): boolean => {
     const searchRegex = new RegExp(/^[a-zA-Z0-9\-:\s]+$/g);
     return searchRegex.test(searchText);
+};
+
+export const updateAssociatedProducts = async (nocCode: string, operatorGroupNocs: string[]): Promise<void> => {
+    const multiOperatorProductsFromDb = await getMultiOperatorExternalProducts(nocCode);
+
+    for await (const product of multiOperatorProductsFromDb) {
+        const ticket = await getProductsMatchingJson(product.matchingJsonLink);
+
+        if (ticket.type === 'multiOperatorExt') {
+            await updateProductAdditionalNocs(product.id, operatorGroupNocs);
+
+            let removedNocs: string[] = [];
+
+            if ('additionalNocs' in ticket) {
+                removedNocs = ticket.additionalNocs.filter((noc) => !operatorGroupNocs.includes(noc));
+                ticket.additionalNocs = operatorGroupNocs;
+            } else if ('additionalOperators' in ticket) {
+                removedNocs = ticket.additionalOperators
+                    .filter((noc) => !operatorGroupNocs.includes(noc.nocCode))
+                    .map((noc) => noc.nocCode);
+
+                ticket.additionalOperators = operatorGroupNocs.map((nocCode) => ({
+                    nocCode,
+                    selectedServices: [],
+                }));
+            }
+
+            await putUserDataInProductsBucketWithFilePath(ticket, product.matchingJsonLink);
+
+            if (removedNocs.length > 0) {
+                const matchingJsonLinks = removedNocs.map((noc) =>
+                    getAdditionalNocMatchingJsonLink(product.matchingJsonLink, noc),
+                );
+                await deleteMultipleObjectsFromS3(matchingJsonLinks, PRODUCTS_DATA_BUCKET_NAME);
+            }
+        }
+    }
 };
 
 export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
@@ -143,6 +187,8 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
 
             if (isInEditMode) {
                 await updateOperatorGroup(id, noc, selectedOperators, refinedGroupName);
+                const operatorGroupNocs = selectedOperators.map((operator) => operator.nocCode);
+                await updateAssociatedProducts(noc, operatorGroupNocs);
             } else {
                 await insertOperatorGroup(noc, selectedOperators, refinedGroupName);
             }

--- a/repos/fdbt-site/src/pages/products/multiOperatorProductsExternal.tsx
+++ b/repos/fdbt-site/src/pages/products/multiOperatorProductsExternal.tsx
@@ -18,7 +18,7 @@ import CsrfForm from '../../components/CsrfForm';
 const title = 'Multi-operator products - Create Fares Data Service';
 const description = 'View and access your multi-operator products in one place.';
 
-export type MultiOperatorProduct = {
+export type MultiOperatorProductExternal = {
     id: number;
     isIncomplete: boolean;
     productDescription: string;
@@ -29,8 +29,8 @@ export type MultiOperatorProduct = {
 };
 
 export interface MultiOperatorProductsProps {
-    ownedProducts: MultiOperatorProduct[];
-    sharedProducts: MultiOperatorProduct[];
+    ownedProducts: MultiOperatorProductExternal[];
+    sharedProducts: MultiOperatorProductExternal[];
     csrfToken: string;
 }
 
@@ -127,7 +127,7 @@ const MultiOperatorProducts = ({
 };
 
 const MultiOperatorProductsTable = (
-    multiOperatorProducts: MultiOperatorProduct[],
+    multiOperatorProducts: MultiOperatorProductExternal[],
     noProductsMessage: string,
     deleteActionHandler?: (productId: number, name: string) => void,
 ): React.ReactElement => {
@@ -221,8 +221,8 @@ export const getServerSideProps = async (
     const yourNoc = getAndValidateNoc(ctx);
     const multiOperatorProductsFromDb: MyFaresOtherProduct[] = await getMultiOperatorExternalProducts();
 
-    const ownedProducts: MultiOperatorProduct[] = [];
-    const sharedProducts: MultiOperatorProduct[] = [];
+    const ownedProducts: MultiOperatorProductExternal[] = [];
+    const sharedProducts: MultiOperatorProductExternal[] = [];
 
     for (const product of multiOperatorProductsFromDb) {
         const matchingJson = await getProductsMatchingJson(product.matchingJsonLink);

--- a/repos/fdbt-site/src/pages/products/productDetails.tsx
+++ b/repos/fdbt-site/src/pages/products/productDetails.tsx
@@ -817,7 +817,11 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
 
     let isIncomplete = false;
 
-    if (ticket.type === 'multiOperatorExt') {
+    if (ticket.type === 'multiOperator') {
+        if ('additionalOperators' in ticket) {
+            isIncomplete = ticket.additionalOperators.some((operator) => operator.selectedServices.length === 0);
+        }
+    } else if (ticket.type === 'multiOperatorExt') {
         const additionalOperators = 'additionalOperators' in ticket ? ticket.additionalOperators : [];
         const additionalNocs = 'additionalNocs' in ticket ? ticket.additionalNocs : [];
         const isFareZoneType = 'zoneName' in ticket;

--- a/repos/fdbt-site/src/pages/products/selectExports.tsx
+++ b/repos/fdbt-site/src/pages/products/selectExports.tsx
@@ -406,7 +406,7 @@ const SelectExports = ({ productsToDisplay, servicesToDisplay, csrf }: SelectExp
                                             {otherProducts.length > 0 ? (
                                                 <div>
                                                     <h2 className="govuk-heading-m govuk-!-margin-bottom-6">
-                                                        Multioperator products
+                                                        Multi-operator (internal) products
                                                     </h2>
 
                                                     {formattedProducts.multiOperatorProducts.length > 0 ? (
@@ -421,8 +421,8 @@ const SelectExports = ({ productsToDisplay, servicesToDisplay, csrf }: SelectExp
                                                     ) : (
                                                         <p className="govuk-body-m govuk-!-margin-top-5">
                                                             <em>
-                                                                You currently have no multioperator products that can be
-                                                                exported.
+                                                                You currently have no multi-operator products that can
+                                                                be exported.
                                                             </em>
                                                         </p>
                                                     )}

--- a/repos/fdbt-site/src/pages/searchOperators.tsx
+++ b/repos/fdbt-site/src/pages/searchOperators.tsx
@@ -65,7 +65,10 @@ export const showSelectedOperators = (
             const newSelectedOperators = selectedOperators.filter((operator) => operator.nocCode !== nocCode);
             const operatorToRemove = databaseSearchResults.find((operator) => operator.nocCode === nocCode) as Operator;
             setSelectedOperators(newSelectedOperators);
-            setSearchResults(alphabetiseOperatorList([...searchResults, operatorToRemove]));
+
+            if (operatorToRemove) {
+                setSearchResults(alphabetiseOperatorList([...searchResults, operatorToRemove]));
+            }
         }
         if (event) {
             event.preventDefault();

--- a/repos/fdbt-site/src/pages/viewOperatorGroups.tsx
+++ b/repos/fdbt-site/src/pages/viewOperatorGroups.tsx
@@ -72,7 +72,7 @@ const ViewOperatorGroups = ({
                 <div className="govuk-grid-column-three-quarters">
                     <h1 className="govuk-heading-xl">Operator Groups</h1>
                     <p className="govuk-body govuk-!-margin-bottom-8">
-                        Define a group of operators for use in a multioperator product.
+                        Define a group of operators for use in a multi-operator product.
                     </p>
 
                     <div>

--- a/repos/fdbt-site/tests/pages/__snapshots__/viewOperatorGroups.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/__snapshots__/viewOperatorGroups.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`pages view operator groups should render correctly on operator group 1`
       <p
         className="govuk-body govuk-!-margin-bottom-8"
       >
-        Define a group of operators for use in a multioperator product.
+        Define a group of operators for use in a multi-operator product.
       </p>
       <div>
         <div>
@@ -106,7 +106,7 @@ exports[`pages view operator groups should render correctly when no operator gro
       <p
         className="govuk-body govuk-!-margin-bottom-8"
       >
-        Define a group of operators for use in a multioperator product.
+        Define a group of operators for use in a multi-operator product.
       </p>
       <div>
         <NoOperatorGroups />

--- a/repos/fdbt-site/tests/pages/api/searchOperators.test.ts
+++ b/repos/fdbt-site/tests/pages/api/searchOperators.test.ts
@@ -1,12 +1,28 @@
-import { getMockRequestAndResponse } from '../../testData/mockData';
+import {
+    expectedMultiOperatorExtGeoZoneTicketWithMultipleProducts,
+    expectedMultiOperatorGeoZoneTicketWithMultipleProducts,
+    expectedPeriodMultipleServicesTicketWithMultipleProductsAndMultipleOperators,
+    expectedPeriodMultipleServicesTicketWithMultipleProductsAndMultipleOperatorsExt,
+    getMockRequestAndResponse,
+} from '../../testData/mockData';
 import searchOperators, {
     replaceSelectedOperatorsWithUserSelectedOperators,
     isSearchInputValid,
+    updateAssociatedProducts,
 } from '../../../src/pages/api/searchOperators';
 import * as session from '../../../src/utils/sessions';
 import { Operator, MultipleOperatorsAttributeWithErrors } from '../../../src/interfaces';
 import { MULTIPLE_OPERATOR_ATTRIBUTE, TICKET_REPRESENTATION_ATTRIBUTE } from '../../../src/constants/attributes';
 import * as auroradb from '../../../src/data/auroradb';
+import * as s3 from '../../../src/data/s3';
+import * as userDataFunctions from '../../../src/utils/apiUtils/userData';
+import { MyFaresOtherProduct } from '../../../src/interfaces/dbTypes';
+import {
+    MultiOperatorGeoZoneTicket,
+    MultiOperatorMultipleServicesTicket,
+    WithIds,
+} from '../../../src/interfaces/matchingJsonTypes';
+import { PRODUCTS_DATA_BUCKET_NAME } from '../../../src/constants';
 
 describe('searchOperators', () => {
     const updateSessionAttributeSpy = jest.spyOn(session, 'updateSessionAttribute');
@@ -40,6 +56,153 @@ describe('searchOperators', () => {
         ])('should return %s when a search term contains %s characters', (expectedValidity, _case, searchText) => {
             const actualValidity = isSearchInputValid(searchText);
             expect(actualValidity).toBe(expectedValidity);
+        });
+    });
+
+    describe('updateAssociatedProducts', () => {
+        it('updates each product in the database and matching JSON files (multiOperatorExt fare zone)', async () => {
+            const getMultiOperatorExternalProductsMock = jest.spyOn(auroradb, 'getMultiOperatorExternalProducts');
+            const getProductsMatchingJsonMock = jest.spyOn(s3, 'getProductsMatchingJson');
+            const updateProductAdditionalNocsMock = jest.spyOn(auroradb, 'updateProductAdditionalNocs');
+            const putUserDataInProductsBucketWithFilePathMock = jest.spyOn(
+                userDataFunctions,
+                'putUserDataInProductsBucketWithFilePath',
+            );
+            const deleteMultipleObjectsFromS3Mock = jest.spyOn(s3, 'deleteMultipleObjectsFromS3');
+
+            const multiOperatorProductsFromDb: MyFaresOtherProduct[] = [
+                {
+                    id: 1,
+                    nocCode: 'TEST',
+                    fareType: 'multiOperatorExt',
+                    matchingJsonLink: 'TEST_1234.json',
+                    startDate: '2021-01-01',
+                },
+                {
+                    id: 2,
+                    nocCode: 'TEST',
+                    fareType: 'multiOperator',
+                    matchingJsonLink: 'TEST-2',
+                    startDate: '2021-01-01',
+                },
+            ];
+            const selectedOperatorNocs = ['BLAC', 'ABCD'];
+
+            const updatedTicket: WithIds<MultiOperatorGeoZoneTicket> = {
+                ...expectedMultiOperatorExtGeoZoneTicketWithMultipleProducts,
+                additionalNocs: ['BLAC', 'ABCD'],
+            };
+
+            getMultiOperatorExternalProductsMock.mockResolvedValue(multiOperatorProductsFromDb);
+            updateProductAdditionalNocsMock.mockResolvedValue(void 0);
+            getProductsMatchingJsonMock.mockResolvedValueOnce(
+                expectedMultiOperatorExtGeoZoneTicketWithMultipleProducts,
+            );
+            getProductsMatchingJsonMock.mockResolvedValueOnce(expectedMultiOperatorGeoZoneTicketWithMultipleProducts);
+            putUserDataInProductsBucketWithFilePathMock.mockResolvedValue('');
+            deleteMultipleObjectsFromS3Mock.mockResolvedValue(void 0);
+
+            await updateAssociatedProducts(multiOperatorProductsFromDb[0].nocCode, selectedOperatorNocs);
+
+            expect(getProductsMatchingJsonMock).toHaveBeenCalledTimes(2);
+            expect(getProductsMatchingJsonMock).toHaveBeenNthCalledWith(
+                1,
+                multiOperatorProductsFromDb[0].matchingJsonLink,
+            );
+            expect(getProductsMatchingJsonMock).toHaveBeenNthCalledWith(
+                2,
+                multiOperatorProductsFromDb[1].matchingJsonLink,
+            );
+            expect(updateProductAdditionalNocsMock).toHaveBeenCalledTimes(1);
+            expect(updateProductAdditionalNocsMock).toHaveBeenCalledWith(1, selectedOperatorNocs);
+            expect(putUserDataInProductsBucketWithFilePathMock).toHaveBeenCalledTimes(1);
+            expect(putUserDataInProductsBucketWithFilePathMock).toHaveBeenCalledWith(
+                updatedTicket,
+                multiOperatorProductsFromDb[0].matchingJsonLink,
+            );
+            expect(deleteMultipleObjectsFromS3Mock).toHaveBeenCalledTimes(1);
+            expect(deleteMultipleObjectsFromS3Mock).toHaveBeenCalledWith(
+                ['TEST_1234_MCTR.json', 'TEST_1234_WBTR.json'],
+                PRODUCTS_DATA_BUCKET_NAME,
+            );
+        });
+
+        it('updates each product in the database and matching JSON files (multiOperatorExt selected services)', async () => {
+            const getMultiOperatorExternalProductsMock = jest.spyOn(auroradb, 'getMultiOperatorExternalProducts');
+            const getProductsMatchingJsonMock = jest.spyOn(s3, 'getProductsMatchingJson');
+            const updateProductAdditionalNocsMock = jest.spyOn(auroradb, 'updateProductAdditionalNocs');
+            const putUserDataInProductsBucketWithFilePathMock = jest.spyOn(
+                userDataFunctions,
+                'putUserDataInProductsBucketWithFilePath',
+            );
+            const deleteMultipleObjectsFromS3Mock = jest.spyOn(s3, 'deleteMultipleObjectsFromS3');
+
+            const multiOperatorProductsFromDb: MyFaresOtherProduct[] = [
+                {
+                    id: 1,
+                    nocCode: 'TEST',
+                    fareType: 'multiOperatorExt',
+                    matchingJsonLink: 'TEST_1234.json',
+                    startDate: '2021-01-01',
+                },
+                {
+                    id: 2,
+                    nocCode: 'TEST',
+                    fareType: 'multiOperator',
+                    matchingJsonLink: 'TEST-2',
+                    startDate: '2021-01-01',
+                },
+            ];
+            const selectedOperatorNocs = ['BLAC', 'ABCD'];
+
+            const updatedTicket: WithIds<MultiOperatorMultipleServicesTicket> = {
+                ...expectedPeriodMultipleServicesTicketWithMultipleProductsAndMultipleOperatorsExt,
+                additionalOperators: [
+                    {
+                        nocCode: 'BLAC',
+                        selectedServices: [],
+                    },
+                    {
+                        nocCode: 'ABCD',
+                        selectedServices: [],
+                    },
+                ],
+            };
+
+            getMultiOperatorExternalProductsMock.mockResolvedValue(multiOperatorProductsFromDb);
+            updateProductAdditionalNocsMock.mockResolvedValue(void 0);
+            getProductsMatchingJsonMock.mockResolvedValueOnce(
+                expectedPeriodMultipleServicesTicketWithMultipleProductsAndMultipleOperatorsExt,
+            );
+            getProductsMatchingJsonMock.mockResolvedValueOnce(
+                expectedPeriodMultipleServicesTicketWithMultipleProductsAndMultipleOperators,
+            );
+            putUserDataInProductsBucketWithFilePathMock.mockResolvedValue('');
+            deleteMultipleObjectsFromS3Mock.mockResolvedValue(void 0);
+
+            await updateAssociatedProducts(multiOperatorProductsFromDb[0].nocCode, selectedOperatorNocs);
+
+            expect(getProductsMatchingJsonMock).toHaveBeenCalledTimes(2);
+            expect(getProductsMatchingJsonMock).toHaveBeenNthCalledWith(
+                1,
+                multiOperatorProductsFromDb[0].matchingJsonLink,
+            );
+            expect(getProductsMatchingJsonMock).toHaveBeenNthCalledWith(
+                2,
+                multiOperatorProductsFromDb[1].matchingJsonLink,
+            );
+            expect(updateProductAdditionalNocsMock).toHaveBeenCalledTimes(1);
+            expect(updateProductAdditionalNocsMock).toHaveBeenCalledWith(1, selectedOperatorNocs);
+            expect(putUserDataInProductsBucketWithFilePathMock).toHaveBeenCalledTimes(1);
+            expect(putUserDataInProductsBucketWithFilePathMock).toHaveBeenCalledWith(
+                updatedTicket,
+                multiOperatorProductsFromDb[0].matchingJsonLink,
+            );
+            expect(deleteMultipleObjectsFromS3Mock).toHaveBeenCalledTimes(1);
+            expect(deleteMultipleObjectsFromS3Mock).toHaveBeenCalledWith(
+                ['TEST_1234_WBTR.json', 'TEST_1234_TESTSCHEME.json'],
+                PRODUCTS_DATA_BUCKET_NAME,
+            );
         });
     });
 
@@ -271,6 +434,7 @@ describe('searchOperators', () => {
         jest.spyOn(auroradb, 'operatorHasFerryOrTramServices').mockResolvedValue(false);
         jest.spyOn(auroradb, 'updateOperatorGroup').mockResolvedValue();
         jest.spyOn(auroradb, 'getOperatorGroupsByNameAndNoc').mockResolvedValue(undefined);
+        jest.spyOn(auroradb, 'getMultiOperatorExternalProducts').mockResolvedValue([]);
 
         const mockSelectedOperators: Operator[] = [
             { nocCode: 'BLACK', name: 'Blackpool Transport' },

--- a/repos/fdbt-site/tests/pages/multipleProducts.test.tsx
+++ b/repos/fdbt-site/tests/pages/multipleProducts.test.tsx
@@ -133,7 +133,7 @@ describe('pages', () => {
                 const ctx = getMockContext({
                     session: {
                         [FARE_TYPE_ATTRIBUTE]: {
-                            fareType: 'multioperator',
+                            fareType: 'multiOperator',
                         },
                         [NUMBER_OF_PRODUCTS_ATTRIBUTE]: undefined,
                         [TICKET_REPRESENTATION_ATTRIBUTE]: { name: 'multipleServicesFlatFareMultiOperator' },

--- a/repos/fdbt-site/tests/pages/products/__snapshots__/selectExports.test.tsx.snap
+++ b/repos/fdbt-site/tests/pages/products/__snapshots__/selectExports.test.tsx.snap
@@ -449,7 +449,7 @@ exports[`selectExports renders fully when the user has products they can export 
                   <h2
                     className="govuk-heading-m govuk-!-margin-bottom-6"
                   >
-                    Multioperator products
+                    Multi-operator (internal) products
                   </h2>
                   <div
                     className="govuk-checkboxes__item govuk-checkboxes--small govuk-!-margin-top-2 govuk-!-margin-left-4"
@@ -739,7 +739,7 @@ exports[`selectExports renders fully when the user has products they can export,
                   <h2
                     className="govuk-heading-m govuk-!-margin-bottom-6"
                   >
-                    Multioperator products
+                    Multi-operator (internal) products
                   </h2>
                   <div
                     className="govuk-checkboxes__item govuk-checkboxes--small govuk-!-margin-top-2 govuk-!-margin-left-4"

--- a/repos/fdbt-site/tests/pages/products/multiOperatorProducts.test.tsx
+++ b/repos/fdbt-site/tests/pages/products/multiOperatorProducts.test.tsx
@@ -2,14 +2,16 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { getProductsMatchingJson } from '../../../src/data/s3';
 import { getOtherProductsByNoc, getPassengerTypeById } from '../../../src/data/auroradb';
-import { MyFaresOtherFaresProduct } from '../../../src/interfaces';
 import {
     expectedMultiOperatorGeoZoneTicketWithMultipleProducts,
     expectedPeriodGeoZoneTicketWithMultipleProducts,
     expectedPeriodMultipleServicesTicketWithMultipleProducts,
     getMockContext,
 } from '../../testData/mockData';
-import MultiOperatorProducts, { getServerSideProps } from '../../../src/pages/products/multiOperatorProducts';
+import MultiOperatorProducts, {
+    getServerSideProps,
+    MultiOperatorProduct,
+} from '../../../src/pages/products/multiOperatorProducts';
 
 jest.mock('../../../src/data/auroradb');
 jest.mock('../../../src/data/s3');
@@ -59,11 +61,12 @@ jest.mock('../../../src/data/s3');
     },
 });
 
-const testProducts: MyFaresOtherFaresProduct[] = [
+const testProducts: MultiOperatorProduct[] = [
     {
         productDescription: 'First product',
         type: 'flatFare',
         id: 1,
+        isIncomplete: false,
         duration: '1 trip',
         passengerType: 'infant',
         startDate: '11/04/2020',
@@ -73,6 +76,7 @@ const testProducts: MyFaresOtherFaresProduct[] = [
         productDescription: 'The greatest product eveer!',
         type: 'period',
         id: 2,
+        isIncomplete: false,
         duration: '3 days',
         passengerType: 'infant',
         startDate: '11/12/2021',
@@ -82,6 +86,7 @@ const testProducts: MyFaresOtherFaresProduct[] = [
         productDescription: 'The greatest product eveer!',
         type: 'period',
         id: 3,
+        isIncomplete: false,
         duration: '3 days',
         passengerType: 'adult',
         startDate: '11/12/2021',
@@ -115,6 +120,7 @@ describe('myfares pages', () => {
                         {
                             duration: '5 weeks',
                             id: 2,
+                            isIncomplete: false,
                             endDate: '18/12/2020',
                             passengerType: '',
                             productDescription: 'Weekly Ticket',
@@ -125,6 +131,7 @@ describe('myfares pages', () => {
                             duration: '1 year',
                             endDate: '18/12/2020',
                             id: 2,
+                            isIncomplete: false,
                             passengerType: '',
                             productDescription: 'Day Ticket',
                             startDate: '17/12/2020',
@@ -135,6 +142,7 @@ describe('myfares pages', () => {
                             endDate: '18/12/2020',
                             passengerType: '',
                             id: 2,
+                            isIncomplete: false,
                             productDescription: 'Monthly Ticket',
                             startDate: '17/12/2020',
                             type: 'multiOperator',

--- a/repos/fdbt-site/tests/pages/products/multiOperatorProductsExternal.test.tsx
+++ b/repos/fdbt-site/tests/pages/products/multiOperatorProductsExternal.test.tsx
@@ -5,7 +5,7 @@ import { getMultiOperatorExternalProducts, getPassengerTypeById } from '../../..
 import { expectedSchemeOperatorMultiServicesTicket, getMockContext } from '../../testData/mockData';
 import MultiOperatorProducts, {
     getServerSideProps,
-    MultiOperatorProduct,
+    MultiOperatorProductExternal,
 } from '../../../src/pages/products/multiOperatorProductsExternal';
 import * as utils from '../../../src/utils';
 
@@ -59,7 +59,7 @@ jest.mock('../../../src/data/s3');
 });
 
 describe('multiOperatorProductsExternal page', () => {
-    const ownedProducts: MultiOperatorProduct[] = [
+    const ownedProducts: MultiOperatorProductExternal[] = [
         {
             id: 1,
             isIncomplete: false,
@@ -79,7 +79,7 @@ describe('multiOperatorProductsExternal page', () => {
             passengerType: 'My best passenger',
         },
     ];
-    const sharedProducts: MultiOperatorProduct[] = [
+    const sharedProducts: MultiOperatorProductExternal[] = [
         {
             id: 3,
             isIncomplete: true,

--- a/repos/fdbt-site/tests/testData/mockData.ts
+++ b/repos/fdbt-site/tests/testData/mockData.ts
@@ -2580,6 +2580,77 @@ export const expectedMultiOperatorGeoZoneTicketWithMultipleProducts: WithIds<Mul
     operatorGroupId: 1,
 };
 
+export const expectedMultiOperatorExtGeoZoneTicketWithMultipleProducts: WithIds<MultiOperatorGeoZoneTicket> = {
+    operatorName: 'test',
+    type: 'multiOperatorExt',
+    nocCode: 'TEST',
+    uuid: '1e0459b3-082e-4e70-89db-96e8ae173e10',
+    email: 'test@example.com',
+    zoneName: 'Green Lane Shops',
+    stops: zoneStops,
+    passengerType: { id: 9 },
+    timeRestriction: { id: 2 },
+    ticketPeriod: {
+        startDate: '2020-12-17T09:30:46.0Z',
+        endDate: '2020-12-18T09:30:46.0Z',
+    },
+    products: [
+        {
+            productName: 'Weekly Ticket',
+            productPrice: '50',
+            productDuration: '5 weeks',
+            productValidity: '24hr',
+            salesOfferPackages: [
+                {
+                    id: 1,
+                    price: undefined,
+                },
+                {
+                    id: 2,
+                    price: undefined,
+                },
+            ],
+            carnetDetails: undefined,
+        },
+        {
+            productName: 'Day Ticket',
+            productPrice: '2.50',
+            productDuration: '1 year',
+            productValidity: '24hr',
+            salesOfferPackages: [
+                {
+                    id: 1,
+                    price: undefined,
+                },
+                {
+                    id: 2,
+                    price: undefined,
+                },
+            ],
+            carnetDetails: undefined,
+        },
+        {
+            productName: 'Monthly Ticket',
+            productPrice: '200',
+            productDuration: '28 months',
+            productValidity: '24hr',
+            salesOfferPackages: [
+                {
+                    id: 1,
+                    price: undefined,
+                },
+                {
+                    id: 2,
+                    price: undefined,
+                },
+            ],
+            carnetDetails: undefined,
+        },
+    ],
+    additionalNocs: ['MCTR', 'WBTR', 'BLAC'],
+    operatorGroupId: 1,
+};
+
 export const expectedPeriodMultipleServicesTicketWithMultipleProducts: WithIds<PeriodMultipleServicesTicket> = {
     operatorName: 'test',
     type: 'period',


### PR DESCRIPTION
## Description

- editing operator groups now cascade changes into associated products
- for example, removing an operator from an operator group will mean that product no longer appears for that operator
- note that if an operator group is edited to include a new operator, and that group is associated with any multi-operator (internal) products that use selected services, then those products will have a new status "incomplete" until all the additional operator selected services are satisfied. At the moment the exporter will still export these products, however a future changes will filter out incomplete products when selecting products to export.

## Testing instructions

- adding operators to a group
- removing operators to a group
- both at the same time
