### PR TITLE
feat: use operator group ID to ref associated products

### DIFF
--- a/fdbt-aws/sql/n.products.sql
+++ b/fdbt-aws/sql/n.products.sql
@@ -13,8 +13,11 @@ CREATE TABLE products(
     `endDate` datetime NOT NULL,
     `servicesRequiringAttention` varchar(1000),
     `fareTriangleModified` DATETIME DEFAULT NULL,
+    `operatorGroupId` int(11),
     INDEX idx_nocCode (nocCode),
-    PRIMARY KEY (`id`)
+    INDEX idx_operatorGroupId (operatorGroupId),
+    PRIMARY KEY (`id`),
+    CONSTRAINT fk_products_operatorGroup_id FOREIGN KEY (operatorGroupId) REFERENCES operatorGroup(id)
 ) ENGINE = InnoDB CHARACTER SET = utf8;
 
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;

--- a/fdbt-dev/sql/products.sql
+++ b/fdbt-dev/sql/products.sql
@@ -3,17 +3,17 @@ LOCK TABLES `products` WRITE;
 
 TRUNCATE TABLE `products`;
 
-INSERT INTO `products` (nocCode,matchingJsonLink,lineId,dateModified,fareType,startDate,endDate,servicesRequiringAttention,fareTriangleModified)
+INSERT INTO `products` (nocCode,matchingJsonLink,lineId,dateModified,fareType,startDate,endDate,servicesRequiringAttention,fareTriangleModified,operatorGroupId)
 VALUES
-('BLAC', 'BLAC/single/BLAC28ac10f0_1669718716180.json', '4YyoI0', '2022-11-29 10:45:16', 'single', '2020-02-01 00:00:00', '0000-00-00 00:00:00', NULL, NULL),
-('BLAC', 'BLAC/return/BLAC06cacdb0_1669718799461.json', '4YyoI0', '2022-11-29 10:46:40', 'return', '2020-02-01 00:00:00', '0000-00-00 00:00:00', NULL, NULL),
-('BLAC', 'BLAC/flatFare/BLAC510a23b9_1669718842930.json', '', '2022-11-29 10:47:23', 'flatFare', '2020-02-01 00:00:00', '2025-12-01 23:59:59', NULL, NULL),
-('BLAC', 'BLAC/period/BLAC3ac061cd_1669718965369.json', '', '2022-11-29 10:49:25', 'period', '1999-03-01 00:00:00', '0000-00-00 00:00:00', NULL, NULL),
-('BLAC', 'BLAC/flatFare/BLACb3f31902_1669719006084.json', '', '2022-11-29 10:50:06', 'flatFare', '2020-02-01 00:00:00', '0000-00-00 00:00:00', NULL, NULL),
-('BLAC', 'BLAC/multiOperator/BLACdc15ca79_1669719059910.json', '', '2022-11-29 10:51:00', 'multiOperator', '2020-03-12 00:00:00', '0000-00-00 00:00:00', NULL, NULL),
-('BLAC', 'BLAC/multiOperatorExt/BLAC38f1952d_1738684176462.json', '', '2022-11-29 10:51:00', 'multiOperatorExt', '2020-03-12 00:00:00', '0000-00-00 00:00:00', NULL, NULL),
-('BLAC', 'BLAC/multiOperatorExt/BLACc90fe5a8_1738686874177.json', '', '2022-11-29 10:51:00', 'multiOperatorExt', '2020-03-12 00:00:00', '0000-00-00 00:00:00', NULL, NULL),
-('BLAC', 'BLAC/period/BLAC84085f49_1669719096560.json', '', '2022-11-29 10:51:37', 'period', '2020-01-01 00:00:00', '0000-00-00 00:00:00', NULL, NULL);
+('BLAC', 'BLAC/single/BLAC28ac10f0_1669718716180.json', '4YyoI0', '2022-11-29 10:45:16', 'single', '2020-02-01 00:00:00', '0000-00-00 00:00:00', NULL, NULL, NULL),
+('BLAC', 'BLAC/return/BLAC06cacdb0_1669718799461.json', '4YyoI0', '2022-11-29 10:46:40', 'return', '2020-02-01 00:00:00', '0000-00-00 00:00:00', NULL, NULL, NULL),
+('BLAC', 'BLAC/flatFare/BLAC510a23b9_1669718842930.json', '', '2022-11-29 10:47:23', 'flatFare', '2020-02-01 00:00:00', '2025-12-01 23:59:59', NULL, NULL, NULL),
+('BLAC', 'BLAC/period/BLAC3ac061cd_1669718965369.json', '', '2022-11-29 10:49:25', 'period', '1999-03-01 00:00:00', '0000-00-00 00:00:00', NULL, NULL, NULL),
+('BLAC', 'BLAC/flatFare/BLACb3f31902_1669719006084.json', '', '2022-11-29 10:50:06', 'flatFare', '2020-02-01 00:00:00', '0000-00-00 00:00:00', NULL, NULL, NULL),
+('BLAC', 'BLAC/multiOperator/BLACdc15ca79_1669719059910.json', '', '2022-11-29 10:51:00', 'multiOperator', '2020-03-12 00:00:00', '0000-00-00 00:00:00', NULL, NULL, 1),
+('BLAC', 'BLAC/multiOperatorExt/BLAC38f1952d_1738684176462.json', '', '2022-11-29 10:51:00', 'multiOperatorExt', '2020-03-12 00:00:00', '0000-00-00 00:00:00', NULL, NULL, 1),
+('BLAC', 'BLAC/multiOperatorExt/BLACc90fe5a8_1738686874177.json', '', '2022-11-29 10:51:00', 'multiOperatorExt', '2020-03-12 00:00:00', '0000-00-00 00:00:00', NULL, NULL, 1),
+('BLAC', 'BLAC/period/BLAC84085f49_1669719096560.json', '', '2022-11-29 10:51:37', 'period', '2020-01-01 00:00:00', '0000-00-00 00:00:00', NULL, NULL, NULL);
 
 UNLOCK TABLES;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;

--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -1857,6 +1857,7 @@ export const insertProducts = async (
     additionalNocs: string[],
     startDate: string,
     endDate?: string,
+    operatorGroupId?: number,
 ): Promise<void> => {
     logger.info('', {
         context: 'data.auroradb',
@@ -1868,8 +1869,8 @@ export const insertProducts = async (
 
     try {
         const insertQuery = `INSERT INTO products
-        (nocCode, matchingJsonLink, dateModified, fareType, lineId, startDate, endDate)
-        VALUES (?, ?, ?, ?, ?, ?, ?)`;
+        (nocCode, matchingJsonLink, dateModified, fareType, lineId, startDate, endDate, operatorGroupId)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`;
 
         const { insertId: productId } = await executeQuery<ResultSetHeader>(insertQuery, [
             nocCode,
@@ -1879,6 +1880,7 @@ export const insertProducts = async (
             lineId || '',
             startDate,
             endDate || '',
+            operatorGroupId || null,
         ]);
 
         if (additionalNocs.length > 0) {
@@ -2187,6 +2189,30 @@ export const getMultiOperatorExternalProducts = async (): Promise<MyFaresOtherPr
         }));
     } catch (error) {
         throw new Error(`Could not retrieve multi-operator external products from AuroraDB: ${error.stack}`);
+    }
+};
+
+export const getProductsByOperatorGroupId = async (
+    nocCode: string,
+    operatorGroupId: number,
+): Promise<MyFaresOtherProduct[]> => {
+    logger.info('', {
+        context: 'data.auroradb',
+        message: 'getting products by NOC and operator group ID',
+        nocCode,
+        operatorGroupId,
+    });
+
+    try {
+        const queryInput = `
+            SELECT id, nocCode, matchingJsonLink, fareType
+            FROM products
+            WHERE nocCode = ? AND operatorGroupId = ?
+        `;
+
+        return await executeQuery<MyFaresOtherProduct[]>(queryInput, [nocCode, operatorGroupId]);
+    } catch (error) {
+        throw new Error(`Could not retrieve products by operator group ID from AuroraDB: ${error.stack}`);
     }
 };
 

--- a/repos/fdbt-site/src/pages/api/reuseOperatorGroup.ts
+++ b/repos/fdbt-site/src/pages/api/reuseOperatorGroup.ts
@@ -17,18 +17,18 @@ import { AdditionalOperator } from 'src/interfaces/matchingJsonTypes';
 
 export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
     try {
-        const selectedOperatorGroup = Number(req.body.operatorGroupId);
+        const operatorGroupId = Number(req.body.operatorGroupId);
         const noc = getAndValidateNoc(req, res);
 
-        if (!selectedOperatorGroup) {
-            updateSessionAttribute(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, [
-                { errorMessage: 'Choose an operator group from the options below', id: 'operatorGroup' },
-            ]);
+        if (!operatorGroupId) {
+            updateSessionAttribute(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, {
+                errors: [{ errorMessage: 'Choose an operator group from the options below', id: 'operatorGroup' }],
+            });
             redirectTo(res, '/reuseOperatorGroup');
             return;
         }
 
-        const multipleOperators = await getOperatorGroupByNocAndId(selectedOperatorGroup, noc);
+        const multipleOperators = await getOperatorGroupByNocAndId(operatorGroupId, noc);
 
         const ticket = getSessionAttribute(req, MATCHING_JSON_ATTRIBUTE);
         const matchingJsonMetaData = getSessionAttribute(req, MATCHING_JSON_META_DATA_ATTRIBUTE);
@@ -63,11 +63,11 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                 selectedOperators: multipleOperators.operators,
                 id: multipleOperators.id,
             });
-            updateSessionAttribute(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, []);
+            updateSessionAttribute(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, { operatorGroupId });
         } else {
-            updateSessionAttribute(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, [
-                { errorMessage: 'Select a valid operator group', id: 'operatorGroup' },
-            ]);
+            updateSessionAttribute(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, {
+                errors: [{ errorMessage: 'Select a valid operator group', id: 'operatorGroup' }],
+            });
             redirectTo(res, '/reuseOperatorGroup');
             return;
         }

--- a/repos/fdbt-site/src/pages/api/searchOperators.ts
+++ b/repos/fdbt-site/src/pages/api/searchOperators.ts
@@ -8,7 +8,7 @@ import { removeExcessWhiteSpace } from '../../utils/apiUtils/validator';
 import { searchInputId } from '../searchOperators';
 import {
     getOperatorGroupsByNameAndNoc,
-    getOtherProductsByNoc,
+    getProductsByOperatorGroupId,
     insertOperatorGroup,
     operatorHasBodsServices,
     operatorHasFerryOrTramServices,
@@ -54,8 +54,12 @@ export const isSearchInputValid = (searchText: string): boolean => {
     return searchRegex.test(searchText);
 };
 
-export const updateAssociatedProducts = async (nocCode: string, operatorGroupNocs: string[]): Promise<void> => {
-    const multiOperatorProductsFromDb = await getOtherProductsByNoc(nocCode);
+export const updateAssociatedProducts = async (
+    nocCode: string,
+    operatorGroupId: number,
+    operatorGroupNocs: string[],
+): Promise<void> => {
+    const multiOperatorProductsFromDb = await getProductsByOperatorGroupId(nocCode, operatorGroupId);
 
     for await (const product of multiOperatorProductsFromDb) {
         if (product.fareType === 'multiOperator' || product.fareType === 'multiOperatorExt') {
@@ -191,7 +195,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             if (isInEditMode) {
                 await updateOperatorGroup(id, noc, selectedOperators, refinedGroupName);
                 const operatorGroupNocs = selectedOperators.map((operator) => operator.nocCode);
-                await updateAssociatedProducts(noc, operatorGroupNocs);
+                await updateAssociatedProducts(noc, id, operatorGroupNocs);
             } else {
                 await insertOperatorGroup(noc, selectedOperators, refinedGroupName);
             }

--- a/repos/fdbt-site/src/pages/reuseOperatorGroup.tsx
+++ b/repos/fdbt-site/src/pages/reuseOperatorGroup.tsx
@@ -97,7 +97,8 @@ export const getServerSideProps = async (
     const noc = getAndValidateNoc(ctx);
     const operatorGroups = await getOperatorGroupsByNoc(noc);
 
-    const errors = getSessionAttribute(ctx.req, REUSE_OPERATOR_GROUP_ATTRIBUTE) || [];
+    const operatorGroupAttribute = getSessionAttribute(ctx.req, REUSE_OPERATOR_GROUP_ATTRIBUTE);
+    const errors = operatorGroupAttribute && 'errors' in operatorGroupAttribute ? operatorGroupAttribute.errors : [];
 
     const ticket = getSessionAttribute(ctx.req, MATCHING_JSON_ATTRIBUTE);
     const matchingJsonMetaData = getSessionAttribute(ctx.req, MATCHING_JSON_META_DATA_ATTRIBUTE);

--- a/repos/fdbt-site/src/utils/apiUtils/userData.ts
+++ b/repos/fdbt-site/src/utils/apiUtils/userData.ts
@@ -32,6 +32,7 @@ import {
     STOPS_EXEMPTION_ATTRIBUTE,
     CAPS_DEFINITION_ATTRIBUTE,
     FLAT_FARE_RETURN_ATTRIBUTE,
+    REUSE_OPERATOR_GROUP_ATTRIBUTE,
 } from '../../constants/attributes';
 import {
     batchGetStopsByAtcoCode,
@@ -785,6 +786,11 @@ export const insertDataToProductsBucketAndProductsTable = async (
         const { startDate, endDate } = userDataJson.ticketPeriod;
         const lineId = 'lineId' in userDataJson ? userDataJson.lineId : undefined;
         const additionalNocs = getAdditionalNocsFromTicket(userDataJson);
+        const operatorGroupAttribute = getSessionAttribute(ctx.req, REUSE_OPERATOR_GROUP_ATTRIBUTE);
+        const operatorGroupId =
+            operatorGroupAttribute && 'operatorGroupId' in operatorGroupAttribute
+                ? operatorGroupAttribute.operatorGroupId
+                : undefined;
 
         await insertProducts(
             nocCode,
@@ -795,6 +801,7 @@ export const insertDataToProductsBucketAndProductsTable = async (
             additionalNocs,
             startDate,
             endDate,
+            operatorGroupId,
         );
     }
 

--- a/repos/fdbt-site/src/utils/sessions.ts
+++ b/repos/fdbt-site/src/utils/sessions.ts
@@ -217,7 +217,7 @@ export interface SessionAttributeTypes {
     [OPERATOR_ATTRIBUTE]: OperatorAttribute | WithErrors<OperatorAttribute>;
     [TXC_SOURCE_ATTRIBUTE]: TxcSourceAttribute;
     [MULTI_OP_TXC_SOURCE_ATTRIBUTE]: TxcSourceAttribute;
-    [REUSE_OPERATOR_GROUP_ATTRIBUTE]: ErrorInfo[];
+    [REUSE_OPERATOR_GROUP_ATTRIBUTE]: { operatorGroupId: number } | { errors: ErrorInfo[] };
     [SAVE_OPERATOR_GROUP_ATTRIBUTE]: ErrorInfo[];
     [CARNET_FARE_TYPE_ATTRIBUTE]: boolean;
     [SAVED_PASSENGER_GROUPS_ATTRIBUTE]: GroupPassengerType[];

--- a/repos/fdbt-site/tests/pages/api/reuseOperatorGroup.test.ts
+++ b/repos/fdbt-site/tests/pages/api/reuseOperatorGroup.test.ts
@@ -33,9 +33,9 @@ describe('reuseOperatorGroup', () => {
         });
         await reuseOperatorGroup(req, res);
 
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, [
-            { errorMessage: 'Choose an operator group from the options below', id: 'operatorGroup' },
-        ]);
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, {
+            errors: [{ errorMessage: 'Choose an operator group from the options below', id: 'operatorGroup' }],
+        });
         expect(writeHeadMock).toBeCalledWith(302, { Location: '/reuseOperatorGroup' });
     });
 
@@ -49,9 +49,9 @@ describe('reuseOperatorGroup', () => {
         });
         await reuseOperatorGroup(req, res);
 
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, [
-            { errorMessage: 'Select a valid operator group', id: 'operatorGroup' },
-        ]);
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, {
+            errors: [{ errorMessage: 'Select a valid operator group', id: 'operatorGroup' }],
+        });
         expect(writeHeadMock).toBeCalledWith(302, { Location: '/reuseOperatorGroup' });
     });
 
@@ -71,20 +71,21 @@ describe('reuseOperatorGroup', () => {
                 nocCode: 'BOS',
             },
         ];
+        const operatorGroupId = 1;
 
         getOperatorGroupByNocAndId.mockImplementation().mockResolvedValue({
-            id: 1,
+            id: operatorGroupId,
             name: 'Best Ops',
             operators: testOperators,
         });
         const { req, res } = getMockRequestAndResponse({
-            body: { operatorGroupId: '1' },
+            body: { operatorGroupId },
             mockWriteHeadFn: writeHeadMock,
         });
         await reuseOperatorGroup(req, res);
 
         expect(getOperatorGroupByNocAndId).toBeCalledWith(1, 'TEST');
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, []);
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, { operatorGroupId });
         expect(updateSessionAttributeSpy).toBeCalledWith(req, MULTIPLE_OPERATOR_ATTRIBUTE, {
             selectedOperators: testOperators,
             id: 1,
@@ -108,16 +109,17 @@ describe('reuseOperatorGroup', () => {
                 nocCode: 'BOS',
             },
         ];
+        const operatorGroupId = 1;
 
         getOperatorGroupByNocAndId.mockImplementation().mockResolvedValue({
-            id: 1,
+            id: operatorGroupId,
             name: 'Best Ops',
             operators: testOperators,
         });
         const isSchemeOperatorSpy = jest.spyOn(index, 'isSchemeOperator');
         isSchemeOperatorSpy.mockImplementation(() => true);
         const { req, res } = getMockRequestAndResponse({
-            body: { operatorGroupId: '1' },
+            body: { operatorGroupId },
             session: {
                 [TICKET_REPRESENTATION_ATTRIBUTE]: {
                     name: 'multipleServices',
@@ -130,7 +132,7 @@ describe('reuseOperatorGroup', () => {
         });
         await reuseOperatorGroup(req, res);
 
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, []);
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, { operatorGroupId });
         expect(writeHeadMock).toBeCalledWith(302, { Location: '/multiOperatorServiceList' });
     });
 
@@ -150,16 +152,17 @@ describe('reuseOperatorGroup', () => {
                 nocCode: 'BOS',
             },
         ];
+        const operatorGroupId = 1;
 
         getOperatorGroupByNocAndId.mockImplementation().mockResolvedValue({
-            id: 1,
+            id: operatorGroupId,
             name: 'Best Ops',
             operators: testOperators,
         });
         const isSchemeOperatorSpy = jest.spyOn(index, 'isSchemeOperator');
         isSchemeOperatorSpy.mockImplementation(() => true);
         const { req, res } = getMockRequestAndResponse({
-            body: { operatorGroupId: '1' },
+            body: { operatorGroupId },
             session: {
                 [TICKET_REPRESENTATION_ATTRIBUTE]: {
                     name: 'multipleServicesFlatFareMultiOperator',
@@ -172,7 +175,7 @@ describe('reuseOperatorGroup', () => {
         });
         await reuseOperatorGroup(req, res);
 
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, []);
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, { operatorGroupId });
         expect(writeHeadMock).toBeCalledWith(302, { Location: '/multiOperatorServiceList' });
     });
 

--- a/repos/fdbt-site/tests/pages/api/searchOperators.test.ts
+++ b/repos/fdbt-site/tests/pages/api/searchOperators.test.ts
@@ -62,7 +62,7 @@ describe('searchOperators', () => {
 
     describe('updateAssociatedProducts', () => {
         it('updates each product in the database and matching JSON files (fare zone variation)', async () => {
-            const getOtherProductsByNocMock = jest.spyOn(auroradb, 'getOtherProductsByNoc');
+            const getProductsByOperatorGroupIdMock = jest.spyOn(auroradb, 'getProductsByOperatorGroupId');
             const getProductsMatchingJsonMock = jest.spyOn(s3, 'getProductsMatchingJson');
             const updateProductAdditionalNocsMock = jest.spyOn(auroradb, 'updateProductAdditionalNocs');
             const putUserDataInProductsBucketWithFilePathMock = jest.spyOn(
@@ -71,7 +71,7 @@ describe('searchOperators', () => {
             );
             const deleteMultipleObjectsFromS3Mock = jest.spyOn(s3, 'deleteMultipleObjectsFromS3');
 
-            const multiOperatorProductsFromDb: MyFaresOtherProduct[] = [
+            const productsByOperatorGroupId: MyFaresOtherProduct[] = [
                 {
                     id: 1,
                     nocCode: 'TEST',
@@ -106,7 +106,7 @@ describe('searchOperators', () => {
                 additionalNocs: selectedOperatorNocs,
             };
 
-            getOtherProductsByNocMock.mockResolvedValue(multiOperatorProductsFromDb);
+            getProductsByOperatorGroupIdMock.mockResolvedValue(productsByOperatorGroupId);
             updateProductAdditionalNocsMock.mockResolvedValue(void 0);
             getProductsMatchingJsonMock.mockResolvedValueOnce(
                 expectedMultiOperatorExtGeoZoneTicketWithMultipleProducts,
@@ -116,16 +116,16 @@ describe('searchOperators', () => {
             putUserDataInProductsBucketWithFilePathMock.mockResolvedValue('');
             deleteMultipleObjectsFromS3Mock.mockResolvedValue(void 0);
 
-            await updateAssociatedProducts(multiOperatorProductsFromDb[0].nocCode, selectedOperatorNocs);
+            await updateAssociatedProducts(productsByOperatorGroupId[0].nocCode, 123, selectedOperatorNocs);
 
             expect(getProductsMatchingJsonMock).toHaveBeenCalledTimes(2);
             expect(getProductsMatchingJsonMock).toHaveBeenNthCalledWith(
                 1,
-                multiOperatorProductsFromDb[0].matchingJsonLink,
+                productsByOperatorGroupId[0].matchingJsonLink,
             );
             expect(getProductsMatchingJsonMock).toHaveBeenNthCalledWith(
                 2,
-                multiOperatorProductsFromDb[1].matchingJsonLink,
+                productsByOperatorGroupId[1].matchingJsonLink,
             );
             expect(updateProductAdditionalNocsMock).toHaveBeenCalledTimes(1);
             expect(updateProductAdditionalNocsMock).toHaveBeenCalledWith(1, selectedOperatorNocs);
@@ -133,12 +133,12 @@ describe('searchOperators', () => {
             expect(putUserDataInProductsBucketWithFilePathMock).toHaveBeenNthCalledWith(
                 1,
                 updatedTicketMultiOperatorExt,
-                multiOperatorProductsFromDb[0].matchingJsonLink,
+                productsByOperatorGroupId[0].matchingJsonLink,
             );
             expect(putUserDataInProductsBucketWithFilePathMock).toHaveBeenNthCalledWith(
                 2,
                 updatedTicketMultiOperator,
-                multiOperatorProductsFromDb[1].matchingJsonLink,
+                productsByOperatorGroupId[1].matchingJsonLink,
             );
             expect(deleteMultipleObjectsFromS3Mock).toHaveBeenCalledTimes(1);
             expect(deleteMultipleObjectsFromS3Mock).toHaveBeenCalledWith(
@@ -148,7 +148,7 @@ describe('searchOperators', () => {
         });
 
         it('updates each product in the database and matching JSON files (selected services variation)', async () => {
-            const getOtherProductsByNocMock = jest.spyOn(auroradb, 'getOtherProductsByNoc');
+            const getProductsByOperatorGroupIdMock = jest.spyOn(auroradb, 'getProductsByOperatorGroupId');
             const getProductsMatchingJsonMock = jest.spyOn(s3, 'getProductsMatchingJson');
             const updateProductAdditionalNocsMock = jest.spyOn(auroradb, 'updateProductAdditionalNocs');
             const putUserDataInProductsBucketWithFilePathMock = jest.spyOn(
@@ -157,7 +157,7 @@ describe('searchOperators', () => {
             );
             const deleteMultipleObjectsFromS3Mock = jest.spyOn(s3, 'deleteMultipleObjectsFromS3');
 
-            const multiOperatorProductsFromDb: MyFaresOtherProduct[] = [
+            const productsByOperatorGroupId: MyFaresOtherProduct[] = [
                 {
                     id: 1,
                     nocCode: 'TEST',
@@ -212,7 +212,7 @@ describe('searchOperators', () => {
                 ],
             };
 
-            getOtherProductsByNocMock.mockResolvedValue(multiOperatorProductsFromDb);
+            getProductsByOperatorGroupIdMock.mockResolvedValue(productsByOperatorGroupId);
             updateProductAdditionalNocsMock.mockResolvedValue(void 0);
             getProductsMatchingJsonMock.mockResolvedValueOnce(
                 expectedPeriodMultipleServicesTicketWithMultipleProductsAndMultipleOperatorsExt,
@@ -224,16 +224,16 @@ describe('searchOperators', () => {
             putUserDataInProductsBucketWithFilePathMock.mockResolvedValue('');
             deleteMultipleObjectsFromS3Mock.mockResolvedValue(void 0);
 
-            await updateAssociatedProducts(multiOperatorProductsFromDb[0].nocCode, selectedOperatorNocs);
+            await updateAssociatedProducts(productsByOperatorGroupId[0].nocCode, 123, selectedOperatorNocs);
 
             expect(getProductsMatchingJsonMock).toHaveBeenCalledTimes(2);
             expect(getProductsMatchingJsonMock).toHaveBeenNthCalledWith(
                 1,
-                multiOperatorProductsFromDb[0].matchingJsonLink,
+                productsByOperatorGroupId[0].matchingJsonLink,
             );
             expect(getProductsMatchingJsonMock).toHaveBeenNthCalledWith(
                 2,
-                multiOperatorProductsFromDb[1].matchingJsonLink,
+                productsByOperatorGroupId[1].matchingJsonLink,
             );
             expect(updateProductAdditionalNocsMock).toHaveBeenCalledTimes(1);
             expect(updateProductAdditionalNocsMock).toHaveBeenCalledWith(1, selectedOperatorNocs);
@@ -241,12 +241,12 @@ describe('searchOperators', () => {
             expect(putUserDataInProductsBucketWithFilePathMock).toHaveBeenNthCalledWith(
                 1,
                 updatedTicketMultiOperatorExt,
-                multiOperatorProductsFromDb[0].matchingJsonLink,
+                productsByOperatorGroupId[0].matchingJsonLink,
             );
             expect(putUserDataInProductsBucketWithFilePathMock).toHaveBeenNthCalledWith(
                 2,
                 updatedTicketMultiOperator,
-                multiOperatorProductsFromDb[1].matchingJsonLink,
+                productsByOperatorGroupId[1].matchingJsonLink,
             );
             expect(deleteMultipleObjectsFromS3Mock).toHaveBeenCalledTimes(1);
             expect(deleteMultipleObjectsFromS3Mock).toHaveBeenCalledWith(
@@ -484,7 +484,7 @@ describe('searchOperators', () => {
         jest.spyOn(auroradb, 'operatorHasFerryOrTramServices').mockResolvedValue(false);
         jest.spyOn(auroradb, 'updateOperatorGroup').mockResolvedValue();
         jest.spyOn(auroradb, 'getOperatorGroupsByNameAndNoc').mockResolvedValue(undefined);
-        jest.spyOn(auroradb, 'getOtherProductsByNoc').mockResolvedValue([]);
+        jest.spyOn(auroradb, 'getProductsByOperatorGroupId').mockResolvedValue([]);
 
         const mockSelectedOperators: Operator[] = [
             { nocCode: 'BLACK', name: 'Blackpool Transport' },


### PR DESCRIPTION
## Description

When editing an operator group, updating associated products was broken because the only reference were noc codes which can be shared among multiple operator groups.

This PR introduces a proper operator group ID reference as a foreign key in the products table so that the correct products can be updated.
