### PR TITLE
fix: prevent multi-operator internal status from being set wrong

### DIFF
--- a/repos/fdbt-site/src/data/auroradb.ts
+++ b/repos/fdbt-site/src/data/auroradb.ts
@@ -1856,7 +1856,7 @@ export const insertProducts = async (
     dateModified: Date,
     fareType: string,
     lineId: string | undefined,
-    additionalNocs: string[],
+    multiOperatorExtAdditionalNocs: string[],
     startDate: string,
     endDate?: string,
     operatorGroupId?: number,
@@ -1886,8 +1886,8 @@ export const insertProducts = async (
             operatorGroupId || null,
         ]);
 
-        if (additionalNocs.length > 0) {
-            await insertProductAdditionalNocs(productId, additionalNocs);
+        if (multiOperatorExtAdditionalNocs.length > 0) {
+            await insertProductAdditionalNocs(productId, multiOperatorExtAdditionalNocs);
         }
     } catch (error) {
         throw new Error(`Could not insert products into the products table. ${error.stack}`);

--- a/repos/fdbt-site/src/pages/api/csvZoneUpload.ts
+++ b/repos/fdbt-site/src/pages/api/csvZoneUpload.ts
@@ -300,7 +300,10 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                 };
 
                 await putUserDataInProductsBucketWithFilePath(secondaryOperatorFareInfo, additionalNocMatchingJsonLink);
-                await updateProductAdditionalNoc(matchingJsonMetaData.productId, nocCode, stops.length === 0);
+
+                if (ticket.type === 'multiOperatorExt') {
+                    await updateProductAdditionalNoc(matchingJsonMetaData.productId, nocCode, stops.length === 0);
+                }
             } else {
                 const updatedTicket = {
                     ...ticket,

--- a/repos/fdbt-site/src/pages/api/serviceList.ts
+++ b/repos/fdbt-site/src/pages/api/serviceList.ts
@@ -238,11 +238,14 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                 }
 
                 await putUserDataInProductsBucketWithFilePath(secondaryOperatorFareInfo, additionalNocMatchingJsonLink);
-                await updateProductAdditionalNoc(
-                    matchingJsonMetaData.productId,
-                    nocCode,
-                    selectedServices.length === 0,
-                );
+
+                if (ticket.type === 'multiOperatorExt') {
+                    await updateProductAdditionalNoc(
+                        matchingJsonMetaData.productId,
+                        nocCode,
+                        selectedServices.length === 0,
+                    );
+                }
             } else {
                 const updatedTicket = {
                     ...ticket,

--- a/repos/fdbt-site/src/utils/apiUtils/userData.ts
+++ b/repos/fdbt-site/src/utils/apiUtils/userData.ts
@@ -785,7 +785,8 @@ export const insertDataToProductsBucketAndProductsTable = async (
         const dateTime = moment().toDate();
         const { startDate, endDate } = userDataJson.ticketPeriod;
         const lineId = 'lineId' in userDataJson ? userDataJson.lineId : undefined;
-        const additionalNocs = getAdditionalNocsFromTicket(userDataJson);
+        const multiOperatorExtAdditionalNocs =
+            userDataJson.type === 'multiOperatorExt' ? getAdditionalNocsFromTicket(userDataJson) : [];
         const incomplete = userDataJson.type === 'multiOperatorExt';
         const operatorGroupAttribute = getSessionAttribute(ctx.req, REUSE_OPERATOR_GROUP_ATTRIBUTE);
         const operatorGroupId =
@@ -800,7 +801,7 @@ export const insertDataToProductsBucketAndProductsTable = async (
             dateTime,
             userDataJson.type,
             lineId,
-            additionalNocs,
+            multiOperatorExtAdditionalNocs,
             startDate,
             endDate,
             operatorGroupId,


### PR DESCRIPTION
When creating a new multi-operator internal product that is a fare zone, the incomplete status is incorrectly set to true. This is caused by the fact that the `productAdditionalNocs` table is updated with additional nocs, and then incomplete status in the `products` table. The fix is to only update the `productAdditionalNocs` table for multi-operator external products upon product creation so that a multi-operator internal product can only have status incomplete if the product's operator group has a new operator added (after product creation).