### PR TITLE
fix: revert character set utf8 change for noc queries

### DIFF
--- a/repos/fdbt-reference-data-service/src/uploaders/csv_uploader/db_queries.py
+++ b/repos/fdbt-reference-data-service/src/uploaders/csv_uploader/db_queries.py
@@ -3,7 +3,7 @@ def public_name_query(bucket_name):
         "SET FOREIGN_KEY_CHECKS = 0;",
         "DROP TABLE IF EXISTS nocPublicNameNew;",
         "CREATE TABLE nocPublicNameNew LIKE nocPublicName;",
-        f"LOAD DATA FROM S3 's3-eu-west-2://{bucket_name}/PublicName.csv' REPLACE INTO TABLE nocPublicNameNew CHARACTER SET UTF8 FIELDS TERMINATED BY ',' ENCLOSED BY '\"' ESCAPED BY '' LINES TERMINATED BY '\\n' IGNORE 1 lines ( pubNmId, operatorPublicName, pubNmQual, ttrteEnq, fareEnq, lostPropEnq, disruptEnq, complEnq, twitter, facebook, linkedin, youtube, changeDate, changeAgent, changeComment, ceasedDate, dataOwner, website );",
+        f"LOAD DATA FROM S3 's3-eu-west-2://{bucket_name}/PublicName.csv' REPLACE INTO TABLE nocPublicNameNew FIELDS TERMINATED BY ',' ENCLOSED BY '\"' ESCAPED BY '' LINES TERMINATED BY '\\n' IGNORE 1 lines ( pubNmId, operatorPublicName, pubNmQual, ttrteEnq, fareEnq, lostPropEnq, disruptEnq, complEnq, twitter, facebook, linkedin, youtube, changeDate, changeAgent, changeComment, ceasedDate, dataOwner, website );",
         "SET FOREIGN_KEY_CHECKS = 1;",
     ]
 
@@ -13,7 +13,7 @@ def noc_table_query(bucket_name):
         "SET FOREIGN_KEY_CHECKS = 0;",
         "DROP TABLE IF EXISTS nocTableNew;",
         "CREATE TABLE nocTableNew LIKE nocTable;",
-        f"LOAD DATA FROM S3 's3-eu-west-2://{bucket_name}/NOCTable.csv' REPLACE INTO TABLE nocTableNew CHARACTER SET UTF8 FIELDS TERMINATED BY ',' ENCLOSED BY '\"' ESCAPED BY '' LINES TERMINATED BY '\\n' IGNORE 1 lines ( nocCode, operatorPublicName, vosaPsvLicenseName, opId, pubNmId, nocCdQual, changeDate, changeAgent, changeComment, dateCeased, dataOwner );",
+        f"LOAD DATA FROM S3 's3-eu-west-2://{bucket_name}/NOCTable.csv' REPLACE INTO TABLE nocTableNew FIELDS TERMINATED BY ',' ENCLOSED BY '\"' ESCAPED BY '' LINES TERMINATED BY '\\n' IGNORE 1 lines ( nocCode, operatorPublicName, vosaPsvLicenseName, opId, pubNmId, nocCdQual, changeDate, changeAgent, changeComment, dateCeased, dataOwner );",
         "SET FOREIGN_KEY_CHECKS = 1;",
     ]
 
@@ -23,7 +23,7 @@ def noc_lines_query(bucket_name):
         "SET FOREIGN_KEY_CHECKS = 0;",
         "DROP TABLE IF EXISTS nocLineNew;",
         "CREATE TABLE nocLineNew LIKE nocLine;",
-        f"LOAD DATA FROM S3 's3-eu-west-2://{bucket_name}/NOCLines.csv' REPLACE INTO TABLE nocLineNew CHARACTER SET UTF8 FIELDS TERMINATED BY ',' ENCLOSED BY '\"' ESCAPED BY '' LINES TERMINATED BY '\\n' IGNORE 1 lines ( nocLineNo, nocCode, pubNm, refNm, licence, mode, tlRegOwn, ebsrAgent, lo, sw, wm, wa, yo, nw, ne, sc, se, ea, em, ni, nx, megabus, newBharat, terravision, ncsd, easybus, yorksRt, travelEnq, comment, auditDate, auditEditor, auditComment, duplicate, dateCeased, cessationComment );",
+        f"LOAD DATA FROM S3 's3-eu-west-2://{bucket_name}/NOCLines.csv' REPLACE INTO TABLE nocLineNew FIELDS TERMINATED BY ',' ENCLOSED BY '\"' ESCAPED BY '' LINES TERMINATED BY '\\n' IGNORE 1 lines ( nocLineNo, nocCode, pubNm, refNm, licence, mode, tlRegOwn, ebsrAgent, lo, sw, wm, wa, yo, nw, ne, sc, se, ea, em, ni, nx, megabus, newBharat, terravision, ncsd, easybus, yorksRt, travelEnq, comment, auditDate, auditEditor, auditComment, duplicate, dateCeased, cessationComment );",
         "SET FOREIGN_KEY_CHECKS = 1;",
     ]
 


### PR DESCRIPTION
## Description

Reverting a change where we set character set as UTF-8 when inserting NOC data into DB as it produces an error.

